### PR TITLE
tweak version default output to meet common sense

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,24 +7,32 @@ import (
 
 // VersionCmd is a kong command for version
 type VersionCmd struct {
-	JSON bool `short:"j" help:"Output in JSON format." default:"false"`
+	JSON      bool `short:"j" help:"Output in JSON format." default:"false"`
+	BuildTime bool `short:"b" help:"Output build time as well." default:"false"`
 }
 
 // Run does actual version job
 func (c *VersionCmd) Run(ctx *Context) error {
-	if c.JSON {
-		v := struct {
-			Version   string
-			BuildTime string
-		}{
-			Version:   ctx.Version,
-			BuildTime: ctx.Build,
+	if !c.JSON {
+		fmt.Println(ctx.Version)
+		if c.BuildTime {
+			fmt.Println(ctx.Build)
 		}
-		buf, _ := json.Marshal(v)
-		fmt.Println(string(buf))
-	} else {
-		fmt.Println("Version:", ctx.Version)
-		fmt.Println("Build Time:", ctx.Build)
+		return nil
 	}
+
+	v := struct {
+		Version   string
+		BuildTime *string `json:",omitempty"`
+	}{
+		Version:   ctx.Version,
+		BuildTime: nil,
+	}
+	if c.BuildTime {
+		v.BuildTime = &ctx.Build
+	}
+	buf, _ := json.Marshal(v)
+	fmt.Println(string(buf))
+
 	return nil
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -13,7 +13,7 @@ func Test_VersionCmd_Run_panic(t *testing.T) {
 	assert.NotPanics(t, func() { assert.Nil(t, cmd.Run(&ctx)) })
 }
 
-func Test_VersionCmd_Run_good(t *testing.T) {
+func Test_VersionCmd_Run_good_plain(t *testing.T) {
 	cmd := &VersionCmd{}
 	ctx := Context{
 		Version: "the-version",
@@ -23,13 +23,46 @@ func Test_VersionCmd_Run_good(t *testing.T) {
 	stdout, stderr := captureStdoutStderr(func() {
 		assert.Nil(t, cmd.Run(&ctx))
 	})
-	assert.Equal(t, stdout, "Version: the-version\nBuild Time: the-build\n")
+	assert.Equal(t, stdout, "the-version\n")
+	assert.Equal(t, stderr, "")
+}
+
+func Test_VersionCmd_Run_good_plain_with_build_time(t *testing.T) {
+	cmd := &VersionCmd{
+		BuildTime: true,
+	}
+	ctx := Context{
+		Version: "the-version",
+		Build:   "the-build",
+	}
+
+	stdout, stderr := captureStdoutStderr(func() {
+		assert.Nil(t, cmd.Run(&ctx))
+	})
+	assert.Equal(t, stdout, "the-version\nthe-build\n")
 	assert.Equal(t, stderr, "")
 }
 
 func Test_VersionCmd_Run_good_json(t *testing.T) {
 	cmd := &VersionCmd{
 		JSON: true,
+	}
+	ctx := Context{
+		Version: "the-version",
+		Build:   "the-build",
+	}
+
+	stdout, stderr := captureStdoutStderr(func() {
+		assert.Nil(t, cmd.Run(&ctx))
+	})
+	assert.Equal(t, stdout, `{"Version":"the-version"}`+"\n")
+	assert.Equal(t, stderr, "")
+}
+
+func Test_VersionCmd_Run_good_json_with_build_time(t *testing.T) {
+	cmd := &VersionCmd{
+		JSON:      true,
+		BuildTime: true,
 	}
 	ctx := Context{
 		Version: "the-version",


### PR DESCRIPTION
Most software output version as simple as:

```
v1.2.3
```