### PR TITLE
build docker image for arm/v7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,27 +86,22 @@ jobs:
     working_directory: ~/repo
     docker:
       - image: cimg/base:stable
+        environment:
+          PLATFORM: linux/amd64,linux/arm64,linux/arm
     steps:
       - checkout
       - setup_remote_docker:
           version: 19.03.14
       - run:
-          name: Enable buildx
-          command: |
-            ssh remote-docker \<<EOF
-                sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
-                sudo systemctl restart docker
-                sudo docker info
-            EOF
-      - run:
           name: Build and push to docker hub
           command: |
             echo "${DOCKER_HUB_TOKEN}" | docker login -u hangxie --password-stdin
+            export DOCKER_CLI_EXPERIMENTAL=enabled
             docker context create multi-platform
-            docker buildx create multi-platform --use
+            docker buildx create multi-platform --platform ${PLATFORM} --use
             docker buildx build --progress plain \
                 -f package/Dockerfile --push \
-                --platform linux/amd64,linux/arm64 \
+                --platform ${PLATFORM} \
                 -t hangxie/parquet-tools:${CIRCLE_TAG} \
                 -t hangxie/parquet-tools:latest \
                 .

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ tools:  ## Install build tools
 build: deps  ## Build locally for local os/arch creating $(BUILDDIR) in ./
 	@echo "==> Building executable"
 	@mkdir -p $(BUILDDIR)
-	@$(GO) build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $(BUILDDIR) ./
+	@CGO_ENABLED=$(CGO_ENABLED) \
+		$(GO) build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $(BUILDDIR) ./
 
 clean:  ## Clean up the build dirs
 	@echo "==> Cleaning up build dirs"

--- a/USAGE.md
+++ b/USAGE.md
@@ -87,7 +87,7 @@ Docker image is hosted on [Docker Hub](https://hub.docker.com/r/hangxie/parquet-
 docker pull hangxie/parquet-tools
 ```
 
-I do have image for amd64 and arm64, more architectures will come soon, I am not ready to release `latest` tag yet, but should be ready soon.
+Current this project builds docker image for amd64, arm64, and arm/v7.
 
 ### Prebuilt Packages
 


### PR DESCRIPTION
It seems missing CGO_ENAGLED flag in build step caused arm/v7 to look for gcc and other stuffs.