### PR TITLE
refactor build facilities

### DIFF
--- a/.circleci/build-bin.sh
+++ b/.circleci/build-bin.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eou pipefail
+
+for TARGET in ${REL_TARGET}; do
+    echo "    ${TARGET}"
+    BINARY=${BUILDDIR}/release/parquet-tools-${VERSION}-${TARGET}
+    rm -f ${BINARY} ${BINARY}.gz ${BINARY}.zip
+    export GOOS=$(echo ${TARGET} | cut -f 1 -d \-)
+    export GOARCH=$(echo ${TARGET} | cut -f 2 -d \-)
+    ${GO} build ${GOFLAGS} -tags "${TAGS}" -ldflags "${LDFLAGS}" -o ${BINARY} ./
+    if [ ${GOOS} == "windows" ]; then
+        (cd $(dirname ${BINARY});
+            BASE_NAME=$(basename ${BINARY});
+            mv ${BASE_NAME} ${BASE_NAME}.exe;
+            zip -qm ${BASE_NAME}.zip ${BASE_NAME}.exe)
+    else
+        gzip ${BINARY}
+    fi
+done

--- a/.circleci/build-deb.sh
+++ b/.circleci/build-deb.sh
@@ -2,8 +2,7 @@
 
 set -eou pipefail
 
-GIT_TAG=$1
-VERSION=$(echo ${GIT_TAG} | cut -f 1 -d \- | tr -d 'a-z')
+DEB_VER=$(echo ${VERSION} | cut -f 1 -d \- | tr -d 'a-z')
 
 PKG_NAME=parquet-tools
 PKG_ARCH=amd64
@@ -17,9 +16,9 @@ docker ps | grep ${DOCKER_NAME} && docker rm -f ${DOCKER_NAME}
 docker run -dit --rm --name ${DOCKER_NAME} ubuntu:20.04
 
 # CCI does not support volume mount, so use docker cp instead
-docker cp ${SOURCE_DIR}/build/release/${PKG_NAME}-${GIT_TAG}-linux-${BIN_ARCH}.gz ${DOCKER_NAME}:/tmp/${PKG_NAME}.gz
+docker cp ${SOURCE_DIR}/build/release/${PKG_NAME}-${VERSION}-linux-${BIN_ARCH}.gz ${DOCKER_NAME}:/tmp/${PKG_NAME}.gz
 docker cp ${SOURCE_DIR}/package/deb ${DOCKER_NAME}:/tmp/
-cat ${SOURCE_DIR}/package/deb/DEBIAN/control | sed "s/^Version:.*/Version: ${VERSION}/" > /tmp/control
+cat ${SOURCE_DIR}/package/deb/DEBIAN/control | sed "s/^Version:.*/Version: ${DEB_VER}/" > /tmp/control
 docker cp /tmp/control ${DOCKER_NAME}:/tmp/deb/DEBIAN/control
 
 # Build deb
@@ -31,7 +30,7 @@ docker exec -t ${DOCKER_NAME} bash -c "
     cd /tmp;
     dpkg-deb --build /tmp/deb;
 "
-docker cp ${DOCKER_NAME}:/tmp/deb.deb ${SOURCE_DIR}/build/release/${PKG_NAME}_${VERSION}_${PKG_ARCH}.deb
+docker cp ${DOCKER_NAME}:/tmp/deb.deb ${SOURCE_DIR}/build/release/${PKG_NAME}_${DEB_VER}_${PKG_ARCH}.deb
 
 # Clean up
 docker ps | grep ${DOCKER_NAME} && docker rm -f ${DOCKER_NAME}

--- a/.circleci/build-img.sh
+++ b/.circleci/build-img.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eou pipefail
+
+docker build . -f package/Dockerfile -t parquet-tools:latest

--- a/.circleci/build-rpm.sh
+++ b/.circleci/build-rpm.sh
@@ -2,8 +2,7 @@
 
 set -eou pipefail
 
-GIT_TAG=$1
-VERSION=$(echo ${GIT_TAG} | cut -f 1 -d \- | tr -d 'a-z')
+RPM_VER=$(echo ${VERSION} | cut -f 1 -d \- | tr -d 'a-z')
 
 PKG_NAME=parquet-tools
 PKG_ARCH=x86_64
@@ -17,10 +16,10 @@ docker ps | grep ${DOCKER_NAME} && docker rm -f ${DOCKER_NAME}
 docker run -dit --rm --name ${DOCKER_NAME} ubuntu:20.04
 
 # CCI does not support volume mount, so use docker cp instead
-git -C ${SOURCE_DIR} archive --format=tar.gz --prefix=${PKG_NAME}-${VERSION}/ -o /tmp/${PKG_NAME}-${VERSION}.tar.gz ${GIT_TAG}
-docker cp /tmp/${PKG_NAME}-${VERSION}.tar.gz ${DOCKER_NAME}:/tmp/
-docker cp ${SOURCE_DIR}/build/release/${PKG_NAME}-${GIT_TAG}-linux-${BIN_ARCH}.gz ${DOCKER_NAME}:/tmp/${PKG_NAME}.gz
-cat ${SOURCE_DIR}/package/rpm/${PKG_NAME}.spec | sed "s/^Version:.*/Version: ${VERSION}/" > /tmp/${PKG_NAME}.spec
+git -C ${SOURCE_DIR} archive --format=tar.gz --prefix=${PKG_NAME}-${RPM_VER}/ -o /tmp/${PKG_NAME}-${RPM_VER}.tar.gz ${VERSION}
+docker cp /tmp/${PKG_NAME}-${RPM_VER}.tar.gz ${DOCKER_NAME}:/tmp/
+docker cp ${SOURCE_DIR}/build/release/${PKG_NAME}-${VERSION}-linux-${BIN_ARCH}.gz ${DOCKER_NAME}:/tmp/${PKG_NAME}.gz
+cat ${SOURCE_DIR}/package/rpm/${PKG_NAME}.spec | sed "s/^Version:.*/Version: ${RPM_VER}/" > /tmp/${PKG_NAME}.spec
 docker cp /tmp/${PKG_NAME}.spec ${DOCKER_NAME}:/tmp/${PKG_NAME}.spec
 
 # Build RPM
@@ -29,11 +28,11 @@ docker exec -t ${DOCKER_NAME} bash -c "
     apt-get update -qq;
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git rpm file binutils;
     mkdir -p ~/rpmbuild/SOURCES;
-    cp /tmp/${PKG_NAME}-${VERSION}.tar.gz ~/rpmbuild/SOURCES/;
+    cp /tmp/${PKG_NAME}-${RPM_VER}.tar.gz ~/rpmbuild/SOURCES/;
     rpmbuild -bb --target ${PKG_ARCH} /tmp/${PKG_NAME}.spec;
-    cp /root/rpmbuild/RPMS/${PKG_ARCH}/${PKG_NAME}-${VERSION}-1.${PKG_ARCH}.rpm /tmp/;
+    cp /root/rpmbuild/RPMS/${PKG_ARCH}/${PKG_NAME}-${RPM_VER}-1.${PKG_ARCH}.rpm /tmp/;
 "
-docker cp ${DOCKER_NAME}:/tmp/${PKG_NAME}-${VERSION}-1.${PKG_ARCH}.rpm ${SOURCE_DIR}/build/release/
+docker cp ${DOCKER_NAME}:/tmp/${PKG_NAME}-${RPM_VER}-1.${PKG_ARCH}.rpm ${SOURCE_DIR}/build/release/
 
 # Clean up
 docker ps | grep ${DOCKER_NAME} && docker rm -f ${DOCKER_NAME}

--- a/.circleci/gen-meta.sh
+++ b/.circleci/gen-meta.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eou pipefail
+
+(cd ${BUILDDIR}/release; \
+    sha512sum parquet-tools* > checksum-sha512.txt; \
+    md5sum parquet-tools* > checksum-md5.txt)
+
+# version file
+echo ${VERSION} > ${BUILDDIR}/VERSION
+PREV_VERSION=$(git tag --sort=-committerdate | head -2 | tail -1)
+
+# changelog file
+echo "Changes since [${PREV_VERSION}](https://github.com/hangxie/parquet-tools/releases/tag/${PREV_VERSION}):" > ${BUILDDIR}/CHANGELOG
+echo >> ${BUILDDIR}/CHANGELOG
+git log --pretty=format:"* %h %s" ${VERSION}...${PREV_VERSION} >> ${BUILDDIR}/CHANGELOG
+echo >> ${BUILDDIR}/CHANGELOG
+
+# license file
+cp LICENSE ${BUILDDIR}/release/LICENSE


### PR DESCRIPTION
Move tedious bash scripts to their dedicated script file to make Makefile cleaner.

This also move all `docker` command out of Makefile so I can use `podman` command to replace `docker` command, the only thing I need to do is to add following lines to `.bash_profile`:

```
function docker() {
    podman "$@"
}
export -f docker
```