### PR TITLE
fix memory pressure in cat command with large skip number

### DIFF
--- a/cmd/cat_test.go
+++ b/cmd/cat_test.go
@@ -142,7 +142,7 @@ func Test_CatCmd_Run_good_skip(t *testing.T) {
 
 func Test_CatCmd_Run_good_all_skip(t *testing.T) {
 	cmd := &CatCmd{}
-	cmd.Skip = 12
+	cmd.Skip = 100_002
 	cmd.Limit = 10
 	cmd.PageSize = 10
 	cmd.SampleRatio = 1.0


### PR DESCRIPTION
This is to address https://github.com/hangxie/parquet-tools/issues/219

EDIT memory footprint may vary, depend on schema, I will add a feature to make this parameter tunable at runtime.