### PR TITLE
remove pre-commit hooks for go

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,15 +19,3 @@ repos:
       - id: no-commit-to-branch
       - id: pretty-format-json
         args: [--no-sort-keys]
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
-    hooks:
-      - id: go-fmt
-      - id: go-imports
-      - id: go-cyclo
-        args: [-over=15]
-      - id: no-go-testing
-      - id: golangci-lint
-      - id: go-unit-tests
-      - id: go-build
-      - id: go-mod-tidy


### PR DESCRIPTION
The hook repo is sunsetting (https://github.com/dnephin/pre-commit-golang/issues/98) and most of the checks are done in CircleCI already.