### PR TITLE
make schema logic private (go struct, json schema, csv schema)

### DIFF
--- a/internal/gostruct_test.go
+++ b/internal/gostruct_test.go
@@ -24,7 +24,7 @@ func Test_GoStructNode_String_good(t *testing.T) {
 	schemaRoot := NewSchemaTree(pr)
 	require.NotNil(t, schemaRoot)
 
-	typeStr, err := NewGoStructNode(*schemaRoot).String()
+	typeStr, err := goStructNode{*schemaRoot}.String()
 	require.Nil(t, err)
 
 	expected, _ := os.ReadFile("../testdata/golden/schema-all-types-go.txt")
@@ -49,7 +49,7 @@ func Test_GoStructNode_String_composite_map_key(t *testing.T) {
 	// 1st field is "Key_value", its
 	// 1st field is map's key
 	schemaRoot.Children[1].Children[0].Children[0].ConvertedType = &mapType
-	_, err = NewGoStructNode(*schemaRoot).String()
+	_, err = goStructNode{*schemaRoot}.String()
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "go struct does not support composite type as map key")
 }
@@ -64,7 +64,7 @@ func Test_GoStructNode_String_composite_map_value(t *testing.T) {
 	schemaRoot := NewSchemaTree(pr)
 	require.NotNil(t, schemaRoot)
 
-	_, err = NewGoStructNode(*schemaRoot).String()
+	_, err = goStructNode{*schemaRoot}.String()
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "go struct does not support composite type as map value")
 }
@@ -82,7 +82,7 @@ func Test_GoStructNode_String_invalid_scalar(t *testing.T) {
 	// A bit explanation:
 	// 1st field is "Shoe_brand"
 	schemaRoot.Children[0].Type = nil
-	_, err = NewGoStructNode(*schemaRoot).String()
+	_, err = goStructNode{*schemaRoot}.String()
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "type not set")
 }
@@ -103,7 +103,7 @@ func Test_GoStructNode_String_invalid_list(t *testing.T) {
 	// 1st field is "List", its
 	// 1st field is "Element"
 	schemaRoot.Children[0].Children[0].Children[0].Type = &invalidType
-	_, err = NewGoStructNode(*schemaRoot).String()
+	_, err = goStructNode{*schemaRoot}.String()
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "unknown type: 999")
 }
@@ -124,7 +124,7 @@ func Test_GoStructNode_String_invalid_map_key(t *testing.T) {
 	// 1st field is "Key_value", its
 	// 1st field is map's key
 	schemaRoot.Children[1].Children[0].Children[0].Type = &invalidType
-	_, err = NewGoStructNode(*schemaRoot).String()
+	_, err = goStructNode{*schemaRoot}.String()
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "unknown type: 999")
 }
@@ -144,7 +144,7 @@ func Test_GoStructNode_String_invalid_map_value(t *testing.T) {
 	// 1st field is "Key_value", its
 	// 3nd field is map's value
 	schemaRoot.Children[1].Children[0].Children[1].Type = nil
-	_, err = NewGoStructNode(*schemaRoot).String()
+	_, err = goStructNode{*schemaRoot}.String()
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "type not set")
 }
@@ -159,7 +159,7 @@ func Test_GoStructNode_String_invalid_list_element(t *testing.T) {
 	schemaRoot := NewSchemaTree(pr)
 	require.NotNil(t, schemaRoot)
 
-	_, err = NewGoStructNode(*schemaRoot).String()
+	_, err = goStructNode{*schemaRoot}.String()
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "go struct does not support composite type as list element in field [Parquet_go_root.Lol]")
 }
@@ -171,7 +171,7 @@ func Test_go_struct_list_variant(t *testing.T) {
 	se := SchemaNode{}
 	require.Nil(t, json.Unmarshal(buf, &se))
 
-	schemaRoot := NewGoStructNode(se)
+	schemaRoot := goStructNode{se}
 	actual, err := schemaRoot.String()
 	require.Nil(t, err)
 

--- a/internal/jsonschema.go
+++ b/internal/jsonschema.go
@@ -7,15 +7,11 @@ type JSONSchema struct {
 	Fields []JSONSchema `json:",omitempty"`
 }
 
-type JSONSchemaNode struct {
+type jsonSchemaNode struct {
 	SchemaNode
 }
 
-func NewJSONSchemaNode(s SchemaNode) JSONSchemaNode {
-	return JSONSchemaNode{s}
-}
-
-func (s JSONSchemaNode) Schema() JSONSchema {
+func (s jsonSchemaNode) Schema() JSONSchema {
 	tagMap := s.SchemaNode.getTagMap()
 
 	annotations := []string{}
@@ -34,7 +30,7 @@ func (s JSONSchemaNode) Schema() JSONSchema {
 	}
 
 	for index, child := range s.Children {
-		ret.Fields[index] = NewJSONSchemaNode(*child).Schema()
+		ret.Fields[index] = jsonSchemaNode{*child}.Schema()
 	}
 
 	return ret

--- a/internal/jsonschema_test.go
+++ b/internal/jsonschema_test.go
@@ -18,7 +18,7 @@ func Test_JSONSchemaNode_Schema_good(t *testing.T) {
 	schemaRoot := NewSchemaTree(pr)
 	require.NotNil(t, schemaRoot)
 
-	schema := NewJSONSchemaNode(*schemaRoot).Schema()
+	schema := jsonSchemaNode{*schemaRoot}.Schema()
 	require.Nil(t, err)
 
 	actual, _ := json.MarshalIndent(schema, "", "  ")


### PR DESCRIPTION
Do not expose logic so downstreams (those who use this repo as module) won't be affected by future change.