### PR TITLE
show build source with version command

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -116,9 +116,9 @@ You can pull the image from either location:
 
 ```bash
 $ docker run --rm hangxie/parquet-tools version
-v1.20.0
+v1.22.2
 $ podman run --rm ghcr.io/hangxie/parquet-tools version
-v1.20.0
+v1.22.2
 ```
 
 ### Prebuilt Packages
@@ -679,34 +679,35 @@ $ parquet-tools size -q all -j testdata/good.parquet
 
 ### version Command
 
-`version` command provides version, build information, and git hash, it will be quite helpful when you are troubleshooting a problem from this tool itself.
+`version` command provides version, build time, git hash, and source of the executable, it will be quite helpful when you are troubleshooting a problem from this tool itself. Source of the executable can be "source" (or "") which means it was built from source code, or "github" indicates it was from github release (include container images and deb/rpm packages as they share the same build result), or "bottle" if it was from homebrew bottles.
 
 #### Print Version
 
 ```bash
 $ parquet-tools version
-v1.20.0
+v1.22.2
 ```
 
 #### Print All Information
 
 ```bash
-$ parquet-tools version -bg
-v1.20.0
-2023-07-04T23:40:28+00:00
-f171552
+$ parquet-tools version -bgs
+v1.22.2
+2024-09-09T20:36:44+00:00
+0bcba77
+bottle
 ```
 
 #### Print Version and Build Time in JSON Format
 
 ```bash
 $ parquet-tools version --build-time --json
-{"Version":"v1.20.0","BuildTime":"2023-07-04T23:40:28+00:00","GitHash":"f171552"}
+{"Version":"v1.22.2","BuildTime":"2024-09-09T20:36:44+00:00","GitHash":"0bcba77","Source":"bottle"}
 ```
 
 #### Print Version in JSON Format
 
 ```bash
 $ parquet-tools version -j
-{"Version":"v1.20.0"}
+{"Version":"v1.22.2"}
 ```

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,9 +6,17 @@ import (
 )
 
 var (
+	// semantic version
 	version string
-	build   string
+	// build time in ISO-8601 format
+	build string
+	// git hash for this build
 	gitHash string
+	// where the executable came from, can be:
+	// - "source" or "" for build from source
+	// - "github" for from github release
+	// - "bottle" for from homebrew bottles
+	source string
 )
 
 // VersionCmd is a kong command for version
@@ -16,6 +24,7 @@ type VersionCmd struct {
 	JSON      bool `short:"j" help:"Output in JSON format." default:"false"`
 	BuildTime bool `short:"b" help:"Output build time as well." default:"false"`
 	GitHash   bool `short:"g" help:"Output git hash." default:"false"`
+	Source    bool `short:"s" help:"Source of the executable." default:"false"`
 }
 
 // Run does actual version job
@@ -28,6 +37,9 @@ func (c VersionCmd) Run() error {
 		if c.GitHash {
 			fmt.Println(gitHash)
 		}
+		if c.Source {
+			fmt.Println(source)
+		}
 		return nil
 	}
 
@@ -35,16 +47,21 @@ func (c VersionCmd) Run() error {
 		Version   string
 		BuildTime *string `json:",omitempty"`
 		GitHash   *string `json:",omitempty"`
+		Source    *string `json:",omitempty"`
 	}{
 		Version:   version,
 		BuildTime: nil,
 		GitHash:   nil,
+		Source:    nil,
 	}
 	if c.BuildTime {
 		v.BuildTime = &build
 	}
 	if c.GitHash {
 		v.GitHash = &gitHash
+	}
+	if c.Source {
+		v.Source = &source
 	}
 	buf, _ := json.Marshal(v)
 	fmt.Println(string(buf))

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -10,6 +10,7 @@ func setupTest() {
 	version = "the-version"
 	build = "the-build"
 	gitHash = "the-hash"
+	source = "unit-test"
 }
 
 func Test_VersionCmd_Run_good_plain(t *testing.T) {
@@ -72,16 +73,30 @@ func Test_VersionCmd_Run_good_json_with_build_time(t *testing.T) {
 	require.Equal(t, "", stderr)
 }
 
-func Test_VersionCmd_Run_good_json_with_build_time_and_git_hash(t *testing.T) {
+func Test_VersionCmd_Run_good_json_with_source(t *testing.T) {
+	setupTest()
+	cmd := &VersionCmd{}
+	cmd.JSON = true
+	cmd.Source = true
+
+	stdout, stderr := captureStdoutStderr(func() {
+		require.Nil(t, cmd.Run())
+	})
+	require.Equal(t, `{"Version":"the-version","Source":"unit-test"}`+"\n", stdout)
+	require.Equal(t, "", stderr)
+}
+
+func Test_VersionCmd_Run_good_json_with_all_meta(t *testing.T) {
 	setupTest()
 	cmd := &VersionCmd{}
 	cmd.JSON = true
 	cmd.BuildTime = true
 	cmd.GitHash = true
+	cmd.Source = true
 
 	stdout, stderr := captureStdoutStderr(func() {
 		require.Nil(t, cmd.Run())
 	})
-	require.Equal(t, `{"Version":"the-version","BuildTime":"the-build","GitHash":"the-hash"}`+"\n", stdout)
+	require.Equal(t, `{"Version":"the-version","BuildTime":"the-build","GitHash":"the-hash","Source":"unit-test"}`+"\n", stdout)
 	require.Equal(t, "", stderr)
 }

--- a/package/scripts/build-bin.sh
+++ b/package/scripts/build-bin.sh
@@ -8,7 +8,10 @@ for TARGET in ${REL_TARGET}; do
         rm -f ${BINARY} ${BINARY}.gz ${BINARY}.zip
         export GOOS=$(echo ${TARGET} | cut -f 1 -d \-)
         export GOARCH=$(echo ${TARGET} | cut -f 2 -d \-)
-        ${GO} build ${GOFLAGS} -tags "${TAGS}" -ldflags "${LDFLAGS}" -o ${BINARY} ./
+        ${GO} build ${GOFLAGS} \
+            -tags "${TAGS}" \
+            -ldflags "${LDFLAGS} -X ${PKG_PREFIX}/cmd.source=github" \
+            -o ${BINARY} ./
         if [ ${GOOS} == "windows" ]; then
             (cd $(dirname ${BINARY});
                 BASE_NAME=$(basename ${BINARY});

--- a/package/scripts/build-brew.sh
+++ b/package/scripts/build-brew.sh
@@ -21,7 +21,8 @@ for ARCH in arm64 amd64; do
 
     # rebuild just in case we need any special setting for homebrew
     GOOS=darwin GOARCH=${ARCH} \
-        ${GO} build ${GOFLAGS} -tags "${TAGS}" -ldflags "${LDFLAGS}" \
+        ${GO} build ${GOFLAGS} -tags "${TAGS}" \
+        -ldflags "${LDFLAGS} -X ${PKG_PREFIX}/cmd.source=bottle" \
         -o ${BOTTLE_DIR}/bin/parquet-tools ${SOURCE_DIR}
 
     # nice-to-have files


### PR DESCRIPTION
Since we now have more than one source to provide executable, it will be helpful to have source information when troubleshooting.