### PR TITLE
remove URI from ReadOption and WriteOption

### DIFF
--- a/cmd/cat.go
+++ b/cmd/cat.go
@@ -29,6 +29,7 @@ type CatCmd struct {
 	SampleRatio  float32 `short:"s" help:"Sample ratio (0.0-1.0)." default:"1.0"`
 	Format       string  `short:"f" help:"output format (json/jsonl/csv/tsv)" enum:"json,jsonl,csv,tsv" default:"json"`
 	NoHeader     bool    `help:"(CSV/TSV only) do not output field name as header" default:"false"`
+	URI          string  `arg:"" predictor:"file" help:"URI of Parquet file."`
 }
 
 // here are performance numbers for different SkipPageSize:
@@ -76,7 +77,7 @@ func (c CatCmd) Run() error {
 		return fmt.Errorf("unknown format: %s", c.Format)
 	}
 
-	fileReader, err := internal.NewParquetFileReader(c.ReadOption)
+	fileReader, err := internal.NewParquetFileReader(c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -19,6 +19,7 @@ type ImportCmd struct {
 	Format     string `help:"Source file formats (csv/json/jsonl)." short:"f" enum:"csv,json,jsonl" default:"csv"`
 	Schema     string `required:"" short:"m" predictor:"file" help:"Schema file name."`
 	SkipHeader bool   `help:"Skip first line of CSV files" default:"false"`
+	URI        string `arg:"" predictor:"file" help:"URI of Parquet file."`
 }
 
 // Run does actual import job
@@ -54,7 +55,7 @@ func (c ImportCmd) importCSV() error {
 	defer csvFile.Close()
 	csvReader := csv.NewReader(csvFile)
 
-	parquetWriter, err := internal.NewCSVWriter(c.WriteOption, schema)
+	parquetWriter, err := internal.NewCSVWriter(c.URI, c.WriteOption, schema)
 	if err != nil {
 		return fmt.Errorf("failed to create CSV writer: %s", err.Error())
 	}
@@ -104,7 +105,7 @@ func (c ImportCmd) importJSON() error {
 		return fmt.Errorf("invalid JSON string: %s", string(jsonData))
 	}
 
-	parquetWriter, err := internal.NewJSONWriter(c.WriteOption, string(schemaData))
+	parquetWriter, err := internal.NewJSONWriter(c.URI, c.WriteOption, string(schemaData))
 	if err != nil {
 		return fmt.Errorf("failed to create JSON writer: %s", err.Error())
 	}
@@ -142,7 +143,7 @@ func (c ImportCmd) importJSONL() error {
 	scanner := bufio.NewScanner(jsonlFile)
 	scanner.Split(bufio.ScanLines)
 
-	parquetWriter, err := internal.NewJSONWriter(c.WriteOption, string(schemaData))
+	parquetWriter, err := internal.NewJSONWriter(c.URI, c.WriteOption, string(schemaData))
 	if err != nil {
 		return fmt.Errorf("failed to create JSON writer: %s", err.Error())
 	}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -158,7 +158,7 @@ func Test_ImportCmd_importCSV_good(t *testing.T) {
 	err := cmd.importCSV()
 	require.Nil(t, err)
 
-	reader, err := internal.NewParquetFileReader(internal.ReadOption{CommonOption: cmd.WriteOption.CommonOption})
+	reader, err := internal.NewParquetFileReader(cmd.URI, internal.ReadOption{})
 	require.Nil(t, err)
 	require.Equal(t, reader.GetNumRows(), int64(7))
 }

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -17,7 +17,8 @@ import (
 // MetaCmd is a kong command for meta
 type MetaCmd struct {
 	internal.ReadOption
-	Base64 bool `name:"base64" short:"b" help:"Encode min/max value." default:"false"`
+	Base64 bool   `name:"base64" short:"b" help:"Encode min/max value." default:"false"`
+	URI    string `arg:"" predictor:"file" help:"URI of Parquet file."`
 }
 
 type columnMeta struct {
@@ -48,7 +49,7 @@ type parquetMeta struct {
 
 // Run does actual meta job
 func (c MetaCmd) Run() error {
-	reader, err := internal.NewParquetFileReader(c.ReadOption)
+	reader, err := internal.NewParquetFileReader(c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}

--- a/cmd/rowcount.go
+++ b/cmd/rowcount.go
@@ -9,11 +9,12 @@ import (
 // RowCountCmd is a kong command for rowcount
 type RowCountCmd struct {
 	internal.ReadOption
+	URI string `arg:"" predictor:"file" help:"URI of Parquet file."`
 }
 
 // Run does actual rowcount job
 func (c RowCountCmd) Run() error {
-	reader, err := internal.NewParquetFileReader(c.ReadOption)
+	reader, err := internal.NewParquetFileReader(c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -18,11 +18,12 @@ var (
 type SchemaCmd struct {
 	internal.ReadOption
 	Format string `short:"f" help:"Schema format (raw/json/go/csv)." enum:"raw,json,go,csv" default:"json"`
+	URI    string `arg:"" predictor:"file" help:"URI of Parquet file."`
 }
 
 // Run does actual schema job
 func (c SchemaCmd) Run() error {
-	reader, err := internal.NewParquetFileReader(c.ReadOption)
+	reader, err := internal.NewParquetFileReader(c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}

--- a/cmd/size.go
+++ b/cmd/size.go
@@ -19,11 +19,12 @@ type SizeCmd struct {
 	internal.ReadOption
 	Query string `short:"q" help:"Size to query (raw/uncompressed/footer/all)." enum:"raw,uncompressed,footer,all" default:"raw"`
 	JSON  bool   `short:"j" help:"Output in JSON format." default:"false"`
+	URI   string `arg:"" predictor:"file" help:"URI of Parquet file."`
 }
 
 // Run does actual size job
 func (c SizeCmd) Run() error {
-	reader, err := internal.NewParquetFileReader(c.ReadOption)
+	reader, err := internal.NewParquetFileReader(c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}

--- a/internal/gostruct_test.go
+++ b/internal/gostruct_test.go
@@ -14,8 +14,8 @@ import (
 
 func Test_GoStructNode_String_good(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/all-types.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/all-types.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer func() {
 		_ = pr.PFile.Close()
@@ -35,8 +35,8 @@ func Test_GoStructNode_String_good(t *testing.T) {
 
 func Test_GoStructNode_String_composite_map_key(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/map-value-map.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/map-value-map.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -56,8 +56,8 @@ func Test_GoStructNode_String_composite_map_key(t *testing.T) {
 
 func Test_GoStructNode_String_composite_map_value(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/map-composite-value.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/map-composite-value.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -71,8 +71,8 @@ func Test_GoStructNode_String_composite_map_value(t *testing.T) {
 
 func Test_GoStructNode_String_invalid_scalar(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/good.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/good.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -89,8 +89,8 @@ func Test_GoStructNode_String_invalid_scalar(t *testing.T) {
 
 func Test_GoStructNode_String_invalid_list(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/reinterpret-list.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/reinterpret-list.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -110,8 +110,8 @@ func Test_GoStructNode_String_invalid_list(t *testing.T) {
 
 func Test_GoStructNode_String_invalid_map_key(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/reinterpret-map-key.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/reinterpret-map-key.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -131,8 +131,8 @@ func Test_GoStructNode_String_invalid_map_key(t *testing.T) {
 
 func Test_GoStructNode_String_invalid_map_value(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/reinterpret-map-key.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/reinterpret-map-key.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -151,8 +151,8 @@ func Test_GoStructNode_String_invalid_map_value(t *testing.T) {
 
 func Test_GoStructNode_String_invalid_list_element(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/list-of-list.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/list-of-list.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 

--- a/internal/io_test.go
+++ b/internal/io_test.go
@@ -169,40 +169,40 @@ func Test_parseURI_good(t *testing.T) {
 
 func Test_NewParquetFileReader_invalid_uri(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "://uri"
-	_, err := NewParquetFileReader(option)
+	uri := "://uri"
+	_, err := NewParquetFileReader(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "unable to parse file location")
 }
 
 func Test_NewParquetFileReader_invalid_uri_scheme(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "invalid-scheme://something"
-	_, err := NewParquetFileReader(option)
+	uri := "invalid-scheme://something"
+	_, err := NewParquetFileReader(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "unknown location scheme")
 }
 
 func Test_NewParquetFileReader_local_non_existent_file(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "file/does/not/exist"
-	_, err := NewParquetFileReader(option)
+	uri := "file/does/not/exist"
+	_, err := NewParquetFileReader(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "no such file or directory")
 }
 
 func Test_NewParquetFileReader_local_not_parquet(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/not-a-parquet-file"
-	_, err := NewParquetFileReader(option)
+	uri := "../testdata/not-a-parquet-file"
+	_, err := NewParquetFileReader(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "invalid argument")
 }
 
 func Test_NewParquetFileReader_local_good(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/good.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/good.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	require.NotNil(t, pr)
 	pr.PFile.Close()
@@ -214,8 +214,8 @@ func Test_NewParquetFileReader_s3_good(t *testing.T) {
 	os.Unsetenv("AWS_PROFILE")
 
 	option := ReadOption{Anonymous: true}
-	option.URI = "s3://daylight-openstreetmap/parquet/osm_features/release=v1.46/type=way/20240506_151445_00143_nanmw_fb5fe2f1-fec8-494f-8c2e-0feb15cedff0"
-	_, err := NewParquetFileReader(option)
+	uri := "s3://daylight-openstreetmap/parquet/osm_features/release=v1.46/type=way/20240506_151445_00143_nanmw_fb5fe2f1-fec8-494f-8c2e-0feb15cedff0"
+	_, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 }
 
@@ -225,8 +225,8 @@ func Test_NewParquetFileReader_s3_non_existent_versioned(t *testing.T) {
 	os.Unsetenv("AWS_PROFILE")
 
 	option := ReadOption{ObjectVersion: "random-version-id", Anonymous: true}
-	option.URI = "s3://daylight-openstreetmap/parquet/osm_features/release=v1.46/type=way/20240506_151445_00143_nanmw_fb5fe2f1-fec8-494f-8c2e-0feb15cedff0"
-	_, err := NewParquetFileReader(option)
+	uri := "s3://daylight-openstreetmap/parquet/osm_features/release=v1.46/type=way/20240506_151445_00143_nanmw_fb5fe2f1-fec8-494f-8c2e-0feb15cedff0"
+	_, err := NewParquetFileReader(uri, option)
 	require.NotNil(t, err)
 	// refer to https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
 	// the sample data bucket does not have version enabled so it will return HTTP/400
@@ -238,8 +238,8 @@ func Test_NewParquetFileReader_gcs_no_permission(t *testing.T) {
 	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null")
 
 	option := ReadOption{}
-	option.URI = "gs://cloud-samples-data/bigquery/us-states/us-states.parquet"
-	_, err := NewParquetFileReader(option)
+	uri := "gs://cloud-samples-data/bigquery/us-states/us-states.parquet"
+	_, err := NewParquetFileReader(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "failed to open GCS object")
 }
@@ -254,40 +254,40 @@ func Test_NewParquetFileReader_azblob_no_permission(t *testing.T) {
 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", base64.StdEncoding.EncodeToString(randBytes))
 
 	option := ReadOption{}
-	option.URI = "wasbs://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet"
-	_, err = NewParquetFileReader(option)
+	uri := "wasbs://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet"
+	_, err = NewParquetFileReader(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "failed to open Azure blob object")
 }
 
 func Test_NewFileWriter_invalid_uri(t *testing.T) {
 	option := WriteOption{}
-	option.URI = "://uri"
-	_, err := NewParquetFileWriter(option)
+	uri := "://uri"
+	_, err := NewParquetFileWriter(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "unable to parse file location")
 }
 
 func Test_NewFileWriter_invalid_uri_scheme(t *testing.T) {
 	option := WriteOption{}
-	option.URI = "invalid-scheme://something"
-	_, err := NewParquetFileWriter(option)
+	uri := "invalid-scheme://something"
+	_, err := NewParquetFileWriter(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "unknown location scheme")
 }
 
 func Test_NewFileWriter_local_not_a_file(t *testing.T) {
 	option := WriteOption{}
-	option.URI = "../testdata/"
-	_, err := NewParquetFileWriter(option)
+	uri := "../testdata/"
+	_, err := NewParquetFileWriter(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "is a directory")
 }
 
 func Test_NewFileWriter_local_good(t *testing.T) {
 	option := WriteOption{}
-	option.URI = os.TempDir() + "/file-writer.parquet"
-	fw, err := NewParquetFileWriter(option)
+	uri := os.TempDir() + "/file-writer.parquet"
+	fw, err := NewParquetFileWriter(uri, option)
 	require.Nil(t, err)
 	require.NotNil(t, fw)
 	defer fw.Close()
@@ -296,8 +296,8 @@ func Test_NewFileWriter_local_good(t *testing.T) {
 func Test_NewFileWriter_s3_non_existent_bucket(t *testing.T) {
 	option := WriteOption{}
 	intVal, _ := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
-	option.URI = fmt.Sprintf("s3://bucket-does-not-exist-%d", intVal.Int64())
-	_, err := NewParquetFileWriter(option)
+	uri := fmt.Sprintf("s3://bucket-does-not-exist-%d", intVal.Int64())
+	_, err := NewParquetFileWriter(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "unable to find region of bucket [bucket-does-not-exist-")
 }
@@ -309,8 +309,8 @@ func Test_NewFileWriter_s3_good(t *testing.T) {
 
 	// parquet writer does not actually write to destination immediately
 	option := WriteOption{}
-	option.URI = "s3://daylight-openstreetmap/parquet/osm_features/release=v1.46/type=way/20240506_151445_00143_nanmw_fb5fe2f1-fec8-494f-8c2e-0feb15cedff0"
-	fw, err := NewParquetFileWriter(option)
+	uri := "s3://daylight-openstreetmap/parquet/osm_features/release=v1.46/type=way/20240506_151445_00143_nanmw_fb5fe2f1-fec8-494f-8c2e-0feb15cedff0"
+	fw, err := NewParquetFileWriter(uri, option)
 	require.Nil(t, err)
 	require.NotNil(t, fw)
 	defer fw.Close()
@@ -322,8 +322,8 @@ func Test_NewFileWriter_gcs_no_permission(t *testing.T) {
 
 	// parquet writer does not actually write to destination immediately
 	option := WriteOption{}
-	option.URI = "gs://cloud-samples-data/bigquery/us-states/us-states.parquet"
-	_, err := NewParquetFileWriter(option)
+	uri := "gs://cloud-samples-data/bigquery/us-states/us-states.parquet"
+	_, err := NewParquetFileWriter(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "failed to open GCS object")
 }
@@ -338,13 +338,13 @@ func Test_NewFileWriter_azblob_invalid_url(t *testing.T) {
 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", base64.StdEncoding.EncodeToString(randBytes))
 
 	option := WriteOption{}
-	option.URI = "wasbs://bad/url"
-	_, err = NewParquetFileWriter(option)
+	uri := "wasbs://bad/url"
+	_, err = NewParquetFileWriter(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "azure blob URI format:")
 
-	option.URI = "wasbs://storageaccount.blob.core.windows.net//aa"
-	_, err = NewParquetFileWriter(option)
+	uri = "wasbs://storageaccount.blob.core.windows.net//aa"
+	_, err = NewParquetFileWriter(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "azure blob URI format:")
 }
@@ -359,37 +359,37 @@ func Test_NewFileWriter_azblob_good(t *testing.T) {
 	os.Setenv("AZURE_STORAGE_ACCESS_KEY", base64.StdEncoding.EncodeToString(randBytes))
 
 	option := WriteOption{}
-	option.URI = "wasbs://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/lfs/foobar.parquet"
+	uri := "wasbs://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/lfs/foobar.parquet"
 
 	// permission will be checked at close/flush time
-	_, err = NewParquetFileWriter(option)
+	_, err = NewParquetFileWriter(uri, option)
 	require.Nil(t, err)
 }
 
 func Test_NewFileWriter_http_not_supported(t *testing.T) {
 	option := WriteOption{}
-	option.URI = "https://domain.tld/path/to/file"
-	_, err := NewParquetFileWriter(option)
+	uri := "https://domain.tld/path/to/file"
+	_, err := NewParquetFileWriter(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "writing to https endpoint is not currently supported")
 }
 
 func Test_NewCSVWriter_invalid_uri(t *testing.T) {
 	option := WriteOption{}
-	option.URI = "://uri"
-	_, err := NewCSVWriter(option, []string{"name=Id, type=INT64"})
+	uri := "://uri"
+	_, err := NewCSVWriter(uri, option, []string{"name=Id, type=INT64"})
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "unable to parse file location")
 }
 
 func Test_NewCSVWriter_invalid_schema(t *testing.T) {
 	option := WriteOption{}
-	option.URI = os.TempDir() + "/csv-writer.parquet"
-	_, err := NewCSVWriter(option, []string{"invalid schema"})
+	uri := os.TempDir() + "/csv-writer.parquet"
+	_, err := NewCSVWriter(uri, option, []string{"invalid schema"})
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "expect 'key=value'")
 
-	_, err = NewCSVWriter(option, []string{"name=Id"})
+	_, err = NewCSVWriter(uri, option, []string{"name=Id"})
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "not a valid Type string")
 }
@@ -397,8 +397,8 @@ func Test_NewCSVWriter_invalid_schema(t *testing.T) {
 func Test_NewCSVWriter_good(t *testing.T) {
 	option := WriteOption{}
 	option.Compression = "LZ4_RAW"
-	option.URI = os.TempDir() + "/csv-writer.parquet"
-	pw, err := NewCSVWriter(option, []string{"name=Id, type=INT64"})
+	uri := os.TempDir() + "/csv-writer.parquet"
+	pw, err := NewCSVWriter(uri, option, []string{"name=Id, type=INT64"})
 	require.Nil(t, err)
 	require.NotNil(t, pw)
 	defer pw.PFile.Close()
@@ -406,20 +406,20 @@ func Test_NewCSVWriter_good(t *testing.T) {
 
 func Test_NewJSONWriter_invalid_uri(t *testing.T) {
 	option := WriteOption{}
-	option.URI = "://uri"
-	_, err := NewJSONWriter(option, "")
+	uri := "://uri"
+	_, err := NewJSONWriter(uri, option, "")
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "unable to parse file location")
 }
 
 func Test_NewJSONWriter_invalid_schema(t *testing.T) {
 	option := WriteOption{}
-	option.URI = os.TempDir() + "/json-writer.parquet"
-	_, err := NewJSONWriter(option, "invalid schema")
+	uri := os.TempDir() + "/json-writer.parquet"
+	_, err := NewJSONWriter(uri, option, "invalid schema")
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "error in unmarshalling json schema string:")
 
-	_, err = NewJSONWriter(option, `{"Tag":"name=parquet-go-root","Fields":[{"Tag":"name=id, type=FOOBAR"}]}`)
+	_, err = NewJSONWriter(uri, option, `{"Tag":"name=parquet-go-root","Fields":[{"Tag":"name=id, type=FOOBAR"}]}`)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "type FOOBAR: not a valid Type string")
 }
@@ -427,8 +427,8 @@ func Test_NewJSONWriter_invalid_schema(t *testing.T) {
 func Test_NewJSONWriter_good(t *testing.T) {
 	option := WriteOption{}
 	option.Compression = "ZSTD"
-	option.URI = os.TempDir() + "/json-writer.parquet"
-	pw, err := NewJSONWriter(option, `{"Tag":"name=parquet-go-root","Fields":[{"Tag":"name=id, type=INT64"}]}`)
+	uri := os.TempDir() + "/json-writer.parquet"
+	pw, err := NewJSONWriter(uri, option, `{"Tag":"name=parquet-go-root","Fields":[{"Tag":"name=id, type=INT64"}]}`)
 	require.Nil(t, err)
 	require.NotNil(t, pw)
 	defer pw.PFile.Close()
@@ -436,22 +436,22 @@ func Test_NewJSONWriter_good(t *testing.T) {
 
 func Test_NewParquetFileReader_http_bad_url(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "https://no-such-host.tld/"
+	uri := "https://no-such-host.tld/"
 	option.HTTPMultipleConnection = true
 	option.HTTPIgnoreTLSError = true
 	option.HTTPExtraHeaders = map[string]string{"key": "value"}
-	_, err := NewParquetFileReader(option)
+	_, err := NewParquetFileReader(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "no such host")
 }
 
 func Test_NewParquetFileReader_http_no_range_support(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "https://www.google.com/"
+	uri := "https://www.google.com/"
 	option.HTTPMultipleConnection = false
 	option.HTTPIgnoreTLSError = true
 	option.HTTPExtraHeaders = map[string]string{"key": "value"}
-	_, err := NewParquetFileReader(option)
+	_, err := NewParquetFileReader(uri, option)
 
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "does not support range")
@@ -459,26 +459,26 @@ func Test_NewParquetFileReader_http_no_range_support(t *testing.T) {
 
 func Test_NewParquetFileReader_http_good(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-01.parquet"
+	uri := "https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-01.parquet"
 	option.HTTPMultipleConnection = true
 	option.HTTPIgnoreTLSError = false
 	option.HTTPExtraHeaders = map[string]string{"key": "value"}
-	_, err := NewParquetFileReader(option)
+	_, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 }
 
 func Test_NewParquetFileReader_hdfs_bad(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "hdfs://localhost:1/temp/good.parquet"
-	_, err := NewParquetFileReader(option)
+	uri := "hdfs://localhost:1/temp/good.parquet"
+	_, err := NewParquetFileReader(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "connection refused")
 }
 
 func Test_newParquetFileWriter_hdfs_bad(t *testing.T) {
 	option := WriteOption{}
-	option.URI = "hdfs://localhost:1/temp/good.parquet"
-	_, err := NewParquetFileWriter(option)
+	uri := "hdfs://localhost:1/temp/good.parquet"
+	_, err := NewParquetFileWriter(uri, option)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "connection refused")
 }
@@ -486,8 +486,8 @@ func Test_newParquetFileWriter_hdfs_bad(t *testing.T) {
 func Test_NewCSVWriter_invalid_compression_codec(t *testing.T) {
 	option := WriteOption{}
 	option.Compression = "foobar"
-	option.URI = os.TempDir() + "/csv-writer.parquet"
-	pw, err := NewCSVWriter(option, []string{"name=Id, type=INT64"})
+	uri := os.TempDir() + "/csv-writer.parquet"
+	pw, err := NewCSVWriter(uri, option, []string{"name=Id, type=INT64"})
 	require.NotNil(t, err)
 	require.Nil(t, pw)
 	require.Contains(t, "not a valid CompressionCodec string", err.Error())
@@ -496,8 +496,8 @@ func Test_NewCSVWriter_invalid_compression_codec(t *testing.T) {
 func Test_NewJSONWriter_invalid_compression_codec(t *testing.T) {
 	option := WriteOption{}
 	option.Compression = "random-dude"
-	option.URI = os.TempDir() + "/json-writer.parquet"
-	pw, err := NewJSONWriter(option, `{"Tag":"name=parquet-go-root","Fields":[{"Tag":"name=id, type=INT64"}]}`)
+	uri := os.TempDir() + "/json-writer.parquet"
+	pw, err := NewJSONWriter(uri, option, `{"Tag":"name=parquet-go-root","Fields":[{"Tag":"name=id, type=INT64"}]}`)
 	require.NotNil(t, err)
 	require.Nil(t, pw)
 	require.Contains(t, "not a valid CompressionCodec string", err.Error())
@@ -513,8 +513,8 @@ func Test_NewCSVWriter_unsupported_compression_codec(t *testing.T) {
 
 	for _, codec := range unsupportedCodec {
 		option.Compression = codec
-		option.URI = os.TempDir() + "/csv-writer.parquet"
-		pw, err := NewCSVWriter(option, []string{"name=Id, type=INT64"})
+		uri := os.TempDir() + "/csv-writer.parquet"
+		pw, err := NewCSVWriter(uri, option, []string{"name=Id, type=INT64"})
 		require.NotNil(t, err)
 		require.Nil(t, pw)
 		require.Contains(t, err.Error(), "compression is not supported at this moment")
@@ -525,8 +525,8 @@ func Test_NewJSONWriter_unsupported_compression_codec(t *testing.T) {
 	option := WriteOption{}
 	for _, codec := range unsupportedCodec {
 		option.Compression = codec
-		option.URI = os.TempDir() + "/json-writer.parquet"
-		pw, err := NewJSONWriter(option, `{"Tag":"name=parquet-go-root","Fields":[{"Tag":"name=id, type=INT64"}]}`)
+		uri := os.TempDir() + "/json-writer.parquet"
+		pw, err := NewJSONWriter(uri, option, `{"Tag":"name=parquet-go-root","Fields":[{"Tag":"name=id, type=INT64"}]}`)
 		require.NotNil(t, err)
 		require.Nil(t, pw)
 		require.Contains(t, err.Error(), "compression is not supported at this moment")

--- a/internal/jsonschema_test.go
+++ b/internal/jsonschema_test.go
@@ -10,8 +10,8 @@ import (
 
 func Test_JSONSchemaNode_Schema_good(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/all-types.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/all-types.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 

--- a/internal/schemanode_test.go
+++ b/internal/schemanode_test.go
@@ -13,8 +13,8 @@ import (
 
 func Test_NewSchemaTree(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/all-types.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/all-types.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -28,8 +28,8 @@ func Test_NewSchemaTree(t *testing.T) {
 
 func Test_SchemaNode_GetReinterpretFields(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/all-types.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/all-types.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -228,8 +228,8 @@ func Test_JSON_schema_list_variant(t *testing.T) {
 
 func Test_Json_schema_go_struct_good(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/all-types.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/all-types.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -244,8 +244,8 @@ func Test_Json_schema_go_struct_good(t *testing.T) {
 
 func Test_Json_schema_json_schema_good(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/all-types.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/all-types.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -263,8 +263,8 @@ func Test_Json_schema_json_schema_good(t *testing.T) {
 
 func Test_Json_schema_csv_schema_good(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/csv-good.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/csv-good.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -279,8 +279,8 @@ func Test_Json_schema_csv_schema_good(t *testing.T) {
 
 func Test_Json_schema_csv_schema_nested(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/csv-nested.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/csv-nested.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -294,8 +294,8 @@ func Test_Json_schema_csv_schema_nested(t *testing.T) {
 
 func Test_Json_schema_csv_schema_optional(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/csv-optional.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/csv-optional.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
@@ -309,8 +309,8 @@ func Test_Json_schema_csv_schema_optional(t *testing.T) {
 
 func Test_Json_schema_csv_schema_repeated(t *testing.T) {
 	option := ReadOption{}
-	option.URI = "../testdata/csv-repeated.parquet"
-	pr, err := NewParquetFileReader(option)
+	uri := "../testdata/csv-repeated.parquet"
+	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 


### PR DESCRIPTION
This is to prepare for concat/merge and split command when we may need both input and output and may have multiple values for them.