### PR TITLE
wrap errors with %w

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -38,7 +38,7 @@ func (c ImportCmd) Run() error {
 func (c ImportCmd) importCSV() error {
 	schemaData, err := os.ReadFile(c.Schema)
 	if err != nil {
-		return fmt.Errorf("failed to load schema from %s: %s", c.Schema, err.Error())
+		return fmt.Errorf("failed to load schema from %s: %w", c.Schema, err)
 	}
 	schema := []string{}
 	for _, line := range strings.Split(string(schemaData), "\n") {
@@ -50,14 +50,14 @@ func (c ImportCmd) importCSV() error {
 
 	csvFile, err := os.Open(c.Source)
 	if err != nil {
-		return fmt.Errorf("failed to open CSV file %s: %s", c.Source, err.Error())
+		return fmt.Errorf("failed to open CSV file %s: %w", c.Source, err)
 	}
 	defer csvFile.Close()
 	csvReader := csv.NewReader(csvFile)
 
 	parquetWriter, err := internal.NewCSVWriter(c.URI, c.WriteOption, schema)
 	if err != nil {
-		return fmt.Errorf("failed to create CSV writer: %s", err.Error())
+		return fmt.Errorf("failed to create CSV writer: %w", err)
 	}
 
 	if c.SkipHeader {
@@ -73,14 +73,14 @@ func (c ImportCmd) importCSV() error {
 			parquetFields[i] = &fields[i]
 		}
 		if err = parquetWriter.WriteString(parquetFields); err != nil {
-			return fmt.Errorf("failed to write [%v] to parquet: %s", fields, err.Error())
+			return fmt.Errorf("failed to write [%v] to parquet: %w", fields, err)
 		}
 	}
 	if err := parquetWriter.WriteStop(); err != nil {
-		return fmt.Errorf("failed to close Parquet writer %s: %s", c.URI, err.Error())
+		return fmt.Errorf("failed to close Parquet writer %s: %w", c.URI, err)
 	}
 	if err := parquetWriter.PFile.Close(); err != nil {
-		return fmt.Errorf("failed to close Parquet file %s: %s", c.URI, err.Error())
+		return fmt.Errorf("failed to close Parquet file %s: %w", c.URI, err)
 	}
 
 	return nil
@@ -89,12 +89,12 @@ func (c ImportCmd) importCSV() error {
 func (c ImportCmd) importJSON() error {
 	schemaData, err := os.ReadFile(c.Schema)
 	if err != nil {
-		return fmt.Errorf("failed to load schema from %s: %s", c.Schema, err.Error())
+		return fmt.Errorf("failed to load schema from %s: %w", c.Schema, err)
 	}
 
 	jsonData, err := os.ReadFile(c.Source)
 	if err != nil {
-		return fmt.Errorf("failed to load source from %s: %s", c.Source, err.Error())
+		return fmt.Errorf("failed to load source from %s: %w", c.Source, err)
 	}
 
 	var dummy map[string]interface{}
@@ -107,18 +107,18 @@ func (c ImportCmd) importJSON() error {
 
 	parquetWriter, err := internal.NewJSONWriter(c.URI, c.WriteOption, string(schemaData))
 	if err != nil {
-		return fmt.Errorf("failed to create JSON writer: %s", err.Error())
+		return fmt.Errorf("failed to create JSON writer: %w", err)
 	}
 
 	if err := parquetWriter.Write(string(jsonData)); err != nil {
-		return fmt.Errorf("failed to write to parquet file: %s", err.Error())
+		return fmt.Errorf("failed to write to parquet file: %w", err)
 	}
 
 	if err := parquetWriter.WriteStop(); err != nil {
-		return fmt.Errorf("failed to close Parquet writer %s: %s", c.URI, err.Error())
+		return fmt.Errorf("failed to close Parquet writer %s: %w", c.URI, err)
 	}
 	if err := parquetWriter.PFile.Close(); err != nil {
-		return fmt.Errorf("failed to close Parquet file %s: %s", c.URI, err.Error())
+		return fmt.Errorf("failed to close Parquet file %s: %w", c.URI, err)
 	}
 
 	return nil
@@ -127,7 +127,7 @@ func (c ImportCmd) importJSON() error {
 func (c ImportCmd) importJSONL() error {
 	schemaData, err := os.ReadFile(c.Schema)
 	if err != nil {
-		return fmt.Errorf("failed to load schema from %s: %s", c.Schema, err.Error())
+		return fmt.Errorf("failed to load schema from %s: %w", c.Schema, err)
 	}
 
 	var dummy map[string]interface{}
@@ -145,7 +145,7 @@ func (c ImportCmd) importJSONL() error {
 
 	parquetWriter, err := internal.NewJSONWriter(c.URI, c.WriteOption, string(schemaData))
 	if err != nil {
-		return fmt.Errorf("failed to create JSON writer: %s", err.Error())
+		return fmt.Errorf("failed to create JSON writer: %w", err)
 	}
 
 	for scanner.Scan() {
@@ -155,14 +155,14 @@ func (c ImportCmd) importJSONL() error {
 		}
 
 		if err := parquetWriter.Write(string(jsonData)); err != nil {
-			return fmt.Errorf("failed to write to parquet file: %s", err.Error())
+			return fmt.Errorf("failed to write to parquet file: %w", err)
 		}
 	}
 	if err := parquetWriter.WriteStop(); err != nil {
-		return fmt.Errorf("failed to close Parquet writer %s: %s", c.URI, err.Error())
+		return fmt.Errorf("failed to close Parquet writer %s: %w", c.URI, err)
 	}
 	if err := parquetWriter.PFile.Close(); err != nil {
-		return fmt.Errorf("failed to close Parquet file %s: %s", c.URI, err.Error())
+		return fmt.Errorf("failed to close Parquet file %s: %w", c.URI, err)
 	}
 
 	return nil

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -40,7 +40,7 @@ func (c MergeCmd) Run() error {
 
 	fileWriter, err := internal.NewGenericWriter(c.URI, c.WriteOption, schema)
 	if err != nil {
-		return fmt.Errorf("failed to write to [%s]: %v", c.URI, err)
+		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)
 	}
 	defer func() {
 		_ = fileWriter.WriteStop()
@@ -51,23 +51,23 @@ func (c MergeCmd) Run() error {
 		for {
 			rows, err := fileReaders[i].ReadByNumber(c.ReadPageSize)
 			if err != nil {
-				return fmt.Errorf("failed to read from [%s]: %v", c.Sources[i], err)
+				return fmt.Errorf("failed to read from [%s]: %w", c.Sources[i], err)
 			}
 			if len(rows) == 0 {
 				break
 			}
 			for _, row := range rows {
 				if err := fileWriter.Write(row); err != nil {
-					return fmt.Errorf("failed to write data from [%s] to [%s]: %v", c.Sources[i], c.URI, err)
+					return fmt.Errorf("failed to write data from [%s] to [%s]: %w", c.Sources[i], c.URI, err)
 				}
 			}
 		}
 	}
 	if err := fileWriter.WriteStop(); err != nil {
-		return fmt.Errorf("failed to end write [%s]: %v", c.URI, err)
+		return fmt.Errorf("failed to end write [%s]: %w", c.URI, err)
 	}
 	if err := fileWriter.PFile.Close(); err != nil {
-		return fmt.Errorf("failed to close [%s]: %v", c.URI, err)
+		return fmt.Errorf("failed to close [%s]: %w", c.URI, err)
 	}
 
 	return nil
@@ -80,7 +80,7 @@ func (c MergeCmd) openSources() ([]*reader.ParquetReader, error) {
 	for i, source := range c.Sources {
 		fileReaders[i], err = internal.NewParquetFileReader(source, c.ReadOption)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read from [%s]: %v", source, err)
+			return nil, fmt.Errorf("failed to read from [%s]: %w", source, err)
 		}
 
 		currSchema := internal.NewSchemaTree(fileReaders[i])

--- a/internal/io.go
+++ b/internal/io.go
@@ -56,7 +56,7 @@ type WriteOption struct {
 func parseURI(uri string) (*url.URL, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse file location [%s]: %s", uri, err.Error())
+		return nil, fmt.Errorf("unable to parse file location [%s]: %w", uri, err)
 	}
 
 	if u.Scheme == "" {
@@ -107,7 +107,7 @@ func getS3Client(bucket string, isPublic bool) (*s3.Client, error) {
 	ctx := context.TODO()
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithDefaultRegion("us-east-1"))
 	if err != nil {
-		return nil, fmt.Errorf("failed to load config to determine bucket region: %s", err.Error())
+		return nil, fmt.Errorf("failed to load config to determine bucket region: %w", err)
 	}
 	cfg.Region = region
 	return s3.NewFromConfig(cfg), nil
@@ -116,7 +116,7 @@ func getS3Client(bucket string, isPublic bool) (*s3.Client, error) {
 func newLocalReader(u *url.URL, option ReadOption) (*reader.ParquetReader, error) {
 	fileReader, err := local.NewLocalFileReader(u.Path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open local file [%s]: %s", u.Path, err.Error())
+		return nil, fmt.Errorf("failed to open local file [%s]: %w", u.Path, err)
 	}
 	return reader.NewParquetReader(fileReader, nil, int64(runtime.NumCPU()))
 }
@@ -133,7 +133,7 @@ func newAWSS3Reader(u *url.URL, option ReadOption) (*reader.ParquetReader, error
 	}
 	fileReader, err := s3v2.NewS3FileReaderWithClientVersioned(context.Background(), s3Client, u.Host, strings.TrimLeft(u.Path, "/"), objVersion)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open S3 object [%s] version [%s]: %s", u.String(), option.ObjectVersion, err.Error())
+		return nil, fmt.Errorf("failed to open S3 object [%s] version [%s]: %w", u.String(), option.ObjectVersion, err)
 	}
 	return reader.NewParquetReader(fileReader, nil, int64(runtime.NumCPU()))
 }
@@ -146,7 +146,7 @@ func newAzureStorageBlobReader(u *url.URL, option ReadOption) (*reader.ParquetRe
 
 	fileReader, err := pqtazblob.NewAzBlobFileReaderWithSharedKey(context.Background(), azURL, cred, blockblob.ClientOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to open Azure blob object [%s]: %s", u.String(), err.Error())
+		return nil, fmt.Errorf("failed to open Azure blob object [%s]: %w", u.String(), err)
 	}
 	return reader.NewParquetReader(fileReader, nil, int64(runtime.NumCPU()))
 }
@@ -154,7 +154,7 @@ func newAzureStorageBlobReader(u *url.URL, option ReadOption) (*reader.ParquetRe
 func newGoogleCloudStorageReader(u *url.URL, option ReadOption) (*reader.ParquetReader, error) {
 	fileReader, err := gcs.NewGcsFileReader(context.Background(), "", u.Host, strings.TrimLeft(u.Path, "/"))
 	if err != nil {
-		return nil, fmt.Errorf("failed to open GCS object [%s]: %s", u.String(), err.Error())
+		return nil, fmt.Errorf("failed to open GCS object [%s]: %w", u.String(), err)
 	}
 	return reader.NewParquetReader(fileReader, nil, int64(runtime.NumCPU()))
 }
@@ -162,7 +162,7 @@ func newGoogleCloudStorageReader(u *url.URL, option ReadOption) (*reader.Parquet
 func newHTTPReader(u *url.URL, option ReadOption) (*reader.ParquetReader, error) {
 	fileReader, err := pqhttp.NewHttpReader(u.String(), option.HTTPMultipleConnection, option.HTTPIgnoreTLSError, option.HTTPExtraHeaders)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open HTTP source [%s]: %s", u.String(), err.Error())
+		return nil, fmt.Errorf("failed to open HTTP source [%s]: %w", u.String(), err)
 	}
 	return reader.NewParquetReader(fileReader, nil, int64(runtime.NumCPU()))
 }
@@ -178,7 +178,7 @@ func newHDFSReader(u *url.URL, option ReadOption) (*reader.ParquetReader, error)
 
 	fileReader, err := hdfs.NewHdfsFileReader([]string{u.Host}, userName, u.Path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open HDFS source [%s]: %s", u.String(), err.Error())
+		return nil, fmt.Errorf("failed to open HDFS source [%s]: %w", u.String(), err)
 	}
 	return reader.NewParquetReader(fileReader, nil, int64(runtime.NumCPU()))
 }
@@ -208,7 +208,7 @@ func NewParquetFileReader(URI string, option ReadOption) (*reader.ParquetReader,
 func newLocalWriter(u *url.URL, option WriteOption) (source.ParquetFile, error) {
 	fileWriter, err := local.NewLocalFileWriter(u.Path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open local file [%s]: %s", u.Path, err.Error())
+		return nil, fmt.Errorf("failed to open local file [%s]: %w", u.Path, err)
 	}
 	return fileWriter, nil
 }
@@ -221,7 +221,7 @@ func newAWSS3Writer(u *url.URL, option WriteOption) (source.ParquetFile, error) 
 
 	fileWriter, err := s3v2.NewS3FileWriterWithClient(context.Background(), s3Client, u.Host, strings.TrimLeft(u.Path, "/"), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open S3 object [%s]: %s", u.String(), err.Error())
+		return nil, fmt.Errorf("failed to open S3 object [%s]: %w", u.String(), err)
 	}
 	return fileWriter, nil
 }
@@ -229,7 +229,7 @@ func newAWSS3Writer(u *url.URL, option WriteOption) (source.ParquetFile, error) 
 func newGoogleCloudStorageWriter(u *url.URL, option WriteOption) (source.ParquetFile, error) {
 	fileWriter, err := gcs.NewGcsFileWriter(context.Background(), "", u.Host, strings.TrimLeft(u.Path, "/"))
 	if err != nil {
-		return nil, fmt.Errorf("failed to open GCS object [%s]: %s", u.String(), err.Error())
+		return nil, fmt.Errorf("failed to open GCS object [%s]: %w", u.String(), err)
 	}
 	return fileWriter, nil
 }
@@ -243,7 +243,7 @@ func newAzureStorageBlobWriter(u *url.URL, option WriteOption) (source.ParquetFi
 
 	fileWriter, err := pqtazblob.NewAzBlobFileWriterWithSharedKey(context.Background(), azURL, cred, blockblob.ClientOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to open Azure blob object [%s]: %s", u.String(), err.Error())
+		return nil, fmt.Errorf("failed to open Azure blob object [%s]: %w", u.String(), err)
 	}
 	return fileWriter, nil
 }
@@ -262,7 +262,7 @@ func newHDFSWriter(u *url.URL, option WriteOption) (source.ParquetFile, error) {
 	}
 	fileWriter, err := hdfs.NewHdfsFileWriter([]string{u.Host}, userName, u.Path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open HDFS source [%s]: %s", u.String(), err.Error())
+		return nil, fmt.Errorf("failed to open HDFS source [%s]: %w", u.String(), err)
 	}
 	return fileWriter, nil
 }
@@ -363,7 +363,7 @@ func azureAccessDetail(azURL url.URL, anonymous bool) (string, *azblob.SharedKey
 
 	credential, err := azblob.NewSharedKeyCredential(strings.Split(azURL.Host, ".")[0], accessKey)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to create Azure credential: %v", err)
+		return "", nil, fmt.Errorf("failed to create Azure credential: %w", err)
 	}
 
 	return httpURL, credential, nil


### PR DESCRIPTION
I may use custom error type when exposing `internal`.

Someone told me that they want to use reinterpret feature from `internal`.