### PR TITLE
Add option to fail on INT96 type

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,16 @@ $ parquet-tools cat --format jsonl testdata/good.parquet
 {"Shoe_brand":"steph_curry","Shoe_name":"curry7"}
 ```
 
+You can set `--fail-on-int96` option to fail `cat` command for parquet files contain fields with INT96 type, which is [deprecated](https://issues.apache.org/jira/browse/PARQUET-323), default value for this option is `false` so you can still read INT96 type, but this behavior may change in the future.
+
+```bash
+$ parquet-tools cat --fail-on-int96 testdata/all-types.parquet
+parquet-tools: error: field Int96 has type INT96 which is not supported
+exit status 1
+$ parquet-tools cat testdata/all-types.parquet
+[{"Bool":true,"ByteArray":"ByteArray-0","Date":1640995200,...
+```
+
 #### Skip Rows
 
 `--skip` is similar to OFFSET in SQL, `parquet-tools` will skip this many rows from beginning of the parquet file before applying other logics.
@@ -541,7 +551,7 @@ Each source data file format has its own dedicated schema format:
 * JSON: you can refer to [sample in this repo](https://github.com/hangxie/parquet-tools/blob/main/testdata/json.schema).
 * JSONL: use same schema as JSON format.
 
-You cannot import INT96 data at this moment, more details can be found at https://github.com/hangxie/parquet-tools/issues/149. 
+You cannot import INT96 data at this moment, more details can be found at https://github.com/hangxie/parquet-tools/issues/149.
 
 #### Import from CSV
 
@@ -590,8 +600,9 @@ $ parquet-tools cat -f jsonl /tmp/doubled.parquet
 {"Shoe_brand":"steph_curry","Shoe_name":"curry7"}
 ```
 
-you can use `--read-page-size` to configure how many rows will be read from source file and write to target file each time, you can also use `--compression` to specify compression codec (UNCOMPRESSED/SNAPPY/GZIP/LZ4/LZ4_RAW/ZSTD) for target parquet file, default is "SNAPPY". Other read options like `--http-multiple-connection`, `--http-ignore-tls-error`, `--http-extra-headers`, `--object-version`, and `--anonymous` can still be used, but since they are applied to all source files, some of them may not make sense, eg `--object-version`.
+You can use `--read-page-size` to configure how many rows will be read from source file and write to target file each time, you can also use `--compression` to specify compression codec (UNCOMPRESSED/SNAPPY/GZIP/LZ4/LZ4_RAW/ZSTD) for target parquet file, default is "SNAPPY". Other read options like `--http-multiple-connection`, `--http-ignore-tls-error`, `--http-extra-headers`, `--object-version`, and `--anonymous` can still be used, but since they are applied to all source files, some of them may not make sense, eg `--object-version`.
 
+You can set `--fail-on-int96` option to fail `merge` command for parquet files contain fields with INT96 type, which is [deprecated](https://issues.apache.org/jira/browse/PARQUET-323), default value for this option is `false` so you can still read INT96 type, but this behavior may change in the future.
 ### meta Command
 
 `meta` command shows meta data of every row group in a parquet file.
@@ -614,6 +625,7 @@ $ parquet-tools meta --base64 testdata/good.parquet
 
 Note that MinValue, MaxValue and NullCount are optional, if they do not show up in output then it means parquet file does not have that section.
 
+You can set `--fail-on-int96` option to fail `meta` command for parquet files contain fields with INT96 type, which is [deprecated](https://issues.apache.org/jira/browse/PARQUET-323), default value for this option is `false` so you can still read INT96 type, but this behavior may change in the future.
 ### row-count Command
 
 `row-count` command provides total number of rows in the parquet file:

--- a/cmd/cat.go
+++ b/cmd/cat.go
@@ -119,11 +119,11 @@ func (c CatCmd) skipRows(fileReader *reader.ParquetReader) error {
 	rowsToSkip := c.Skip
 	for ; rowsToSkip > c.SkipPageSize; rowsToSkip -= c.SkipPageSize {
 		if err := fileReader.SkipRows(c.SkipPageSize); err != nil {
-			return fmt.Errorf("failed to skip %d rows: %s", c.Skip, err)
+			return fmt.Errorf("failed to skip %d rows: %w", c.Skip, err)
 		}
 	}
 	if err := fileReader.SkipRows(rowsToSkip); err != nil {
-		return fmt.Errorf("failed to skip %d rows: %s", c.Skip, err)
+		return fmt.Errorf("failed to skip %d rows: %w", c.Skip, err)
 	}
 	return nil
 }
@@ -161,7 +161,7 @@ func (c CatCmd) outputRows(fileReader *reader.ParquetReader) error {
 	for counter := uint64(0); counter < c.Limit; {
 		rows, err := fileReader.ReadByNumber(c.ReadPageSize)
 		if err != nil {
-			return fmt.Errorf("failed to cat: %s", err)
+			return fmt.Errorf("failed to cat: %w", err)
 		}
 		if len(rows) == 0 {
 			break

--- a/cmd/cat_test.go
+++ b/cmd/cat_test.go
@@ -397,3 +397,21 @@ func Test_CatCmd_Run_nested_tsv(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, err.Error(), "field [Map] is not scalar type, cannot output in tsv format")
 }
+
+func Test_CatCmd_Run_fail_on_int96(t *testing.T) {
+	cmd := &CatCmd{}
+	cmd.Limit = 0
+	cmd.ReadPageSize = 10
+	cmd.SampleRatio = 0.5
+	cmd.URI = "../testdata/all-types.parquet"
+	cmd.Format = "json"
+	cmd.FailOnInt96 = true
+
+	stdout, stderr := captureStdoutStderr(func() {
+		err := cmd.Run()
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "type INT96 which is not supported")
+	})
+	require.Equal(t, "", stdout)
+	require.Equal(t, "", stderr)
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/hangxie/parquet-tools/internal"
@@ -40,12 +41,17 @@ func (c ImportCmd) importCSV() error {
 	if err != nil {
 		return fmt.Errorf("failed to load schema from %s: %w", c.Schema, err)
 	}
+	if matched, _ := regexp.Match(`(?i)type\s*=\s*int96`, schemaData); matched {
+		return fmt.Errorf("import does not support INT96 type")
+	}
+
 	schema := []string{}
 	for _, line := range strings.Split(string(schemaData), "\n") {
 		line = strings.Trim(line, "\r\n\t ")
-		if line != "" {
-			schema = append(schema, line)
+		if line == "" {
+			continue
 		}
+		schema = append(schema, line)
 	}
 
 	csvFile, err := os.Open(c.Source)
@@ -91,6 +97,9 @@ func (c ImportCmd) importJSON() error {
 	if err != nil {
 		return fmt.Errorf("failed to load schema from %s: %w", c.Schema, err)
 	}
+	if matched, _ := regexp.Match(`(?i)type\s*=\s*int96`, schemaData); matched {
+		return fmt.Errorf("import does not support INT96 type")
+	}
 
 	jsonData, err := os.ReadFile(c.Source)
 	if err != nil {
@@ -128,6 +137,9 @@ func (c ImportCmd) importJSONL() error {
 	schemaData, err := os.ReadFile(c.Schema)
 	if err != nil {
 		return fmt.Errorf("failed to load schema from %s: %w", c.Schema, err)
+	}
+	if matched, _ := regexp.Match(`(?i)type\s*=\s*int96`, schemaData); matched {
+		return fmt.Errorf("import does not support INT96 type")
 	}
 
 	var dummy map[string]interface{}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -79,8 +79,10 @@ func Test_ImportCmd_Run_JSON_good(t *testing.T) {
 		Fields []interface{}
 	}
 	sourceSchemaBuf, _ := os.ReadFile(cmd.Schema)
-	reader, _ := internal.NewParquetFileReader(testFile, internal.ReadOption{})
-	schema := internal.NewSchemaTree(reader)
+	reader, err := internal.NewParquetFileReader(testFile, internal.ReadOption{})
+	require.Nil(t, err)
+	schema, err := internal.NewSchemaTree(reader, internal.SchemaOption{})
+	require.Nil(t, err)
 
 	var sourceSchema jsonSchema
 	_ = json.Unmarshal(sourceSchemaBuf, &sourceSchema)

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -145,3 +145,21 @@ func Test_MergeCmd_Run_good(t *testing.T) {
 
 	_ = os.Remove(cmd.URI)
 }
+
+func Test_MergeCmd_Run_fail_on_int96(t *testing.T) {
+	cmd := &MergeCmd{}
+	cmd.ReadPageSize = 10
+	cmd.Sources = []string{
+		"../testdata/all-types.parquet",
+		"../testdata/all-types.parquet",
+	}
+	cmd.URI = os.TempDir() + "/import-csv.parquet"
+	cmd.Compression = "SNAPPY"
+	cmd.FailOnInt96 = true
+
+	err := cmd.Run()
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "type INT96 which is not supporte")
+
+	_ = os.Remove(cmd.URI)
+}

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -17,8 +17,9 @@ import (
 // MetaCmd is a kong command for meta
 type MetaCmd struct {
 	internal.ReadOption
-	Base64 bool   `name:"base64" short:"b" help:"Encode min/max value." default:"false"`
-	URI    string `arg:"" predictor:"file" help:"URI of Parquet file."`
+	Base64      bool   `name:"base64" short:"b" help:"Encode min/max value." default:"false"`
+	URI         string `arg:"" predictor:"file" help:"URI of Parquet file."`
+	FailOnInt96 bool   `help:"fail command if INT96 data type presents." name:"fail-on-int96" default:"false"`
 }
 
 type columnMeta struct {
@@ -54,7 +55,10 @@ func (c MetaCmd) Run() error {
 		return err
 	}
 
-	schemaRoot := internal.NewSchemaTree(reader)
+	schemaRoot, err := internal.NewSchemaTree(reader, internal.SchemaOption{FailOnInt96: c.FailOnInt96})
+	if err != nil {
+		return err
+	}
 	reinterpretFields := schemaRoot.GetReinterpretFields("", false)
 
 	rowGroups := make([]rowGroupMeta, len(reader.Footer.RowGroups))

--- a/cmd/meta_test.go
+++ b/cmd/meta_test.go
@@ -272,3 +272,18 @@ func Test_MetaCmd_Run_good_reinterpret_composite(t *testing.T) {
 	require.Equal(t, expected, stdout)
 	require.Equal(t, "", stderr)
 }
+
+func Test_MetaCmd_Run_fail_on_int96(t *testing.T) {
+	cmd := &MetaCmd{}
+	cmd.Base64 = false
+	cmd.URI = "../testdata/all-types.parquet"
+	cmd.FailOnInt96 = true
+
+	stdout, stderr := captureStdoutStderr(func() {
+		err := cmd.Run()
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "type INT96 which is not supported")
+	})
+	require.Equal(t, "", stdout)
+	require.Equal(t, "", stderr)
+}

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -29,7 +29,10 @@ func (c SchemaCmd) Run() error {
 	}
 	defer reader.PFile.Close()
 
-	schemaRoot := internal.NewSchemaTree(reader)
+	schemaRoot, err := internal.NewSchemaTree(reader, internal.SchemaOption{FailOnInt96: false})
+	if err != nil {
+		return err
+	}
 	switch c.Format {
 	case formatRaw:
 		schema, _ := json.Marshal(*schemaRoot)

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_SchemaCmd_Run_invalid_uri(t *testing.T) {
+	cmd := &SchemaCmd{}
+	cmd.URI = "dummy://location"
+	cmd.Format = "invalid"
+
+	err := cmd.Run()
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "unknown location scheme")
+}
+
 func Test_SchemaCmd_Run_invalid_format(t *testing.T) {
 	cmd := &SchemaCmd{}
 	cmd.URI = "../testdata/all-types.parquet"

--- a/internal/gostruct_test.go
+++ b/internal/gostruct_test.go
@@ -21,7 +21,8 @@ func Test_GoStructNode_String_good(t *testing.T) {
 		_ = pr.PFile.Close()
 	}()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	typeStr, err := goStructNode{*schemaRoot}.String()
@@ -40,7 +41,8 @@ func Test_GoStructNode_String_composite_map_key(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	mapType := parquet.ConvertedType_MAP
@@ -61,7 +63,8 @@ func Test_GoStructNode_String_composite_map_value(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	_, err = goStructNode{*schemaRoot}.String()
@@ -76,7 +79,8 @@ func Test_GoStructNode_String_invalid_scalar(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	// A bit explanation:
@@ -94,7 +98,8 @@ func Test_GoStructNode_String_invalid_list(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	invalidType := parquet.Type(999)
@@ -115,7 +120,8 @@ func Test_GoStructNode_String_invalid_map_key(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	invalidType := parquet.Type(999)
@@ -136,7 +142,8 @@ func Test_GoStructNode_String_invalid_map_value(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	// A bit explanation:
@@ -156,7 +163,8 @@ func Test_GoStructNode_String_invalid_list_element(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	_, err = goStructNode{*schemaRoot}.String()

--- a/internal/io.go
+++ b/internal/io.go
@@ -78,7 +78,7 @@ func getS3BucketRegion(bucket string, isPublic bool) (string, error) {
 	}
 	resp, err := http.Get(fmt.Sprintf("https://%s.s3.amazonaws.com", bucket))
 	if err != nil {
-		return "", fmt.Errorf("unable to get region for S3 bucket %s: %s", bucket, err)
+		return "", fmt.Errorf("unable to get region for S3 bucket %s: %w", bucket, err)
 	}
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -98,7 +98,7 @@ func getS3BucketRegion(bucket string, isPublic bool) (string, error) {
 func getS3Client(bucket string, isPublic bool) (*s3.Client, error) {
 	region, err := getS3BucketRegion(bucket, isPublic)
 	if err != nil {
-		return nil, fmt.Errorf("unable to find region of bucket [%s]: %s", bucket, err)
+		return nil, fmt.Errorf("unable to find region of bucket [%s]: %w", bucket, err)
 	}
 	if isPublic {
 		return s3.NewFromConfig(aws.Config{Region: region}), nil

--- a/internal/jsonschema_test.go
+++ b/internal/jsonschema_test.go
@@ -15,7 +15,8 @@ func Test_JSONSchemaNode_Schema_good(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	schema := jsonSchemaNode{*schemaRoot}.Schema()

--- a/internal/schemanode_test.go
+++ b/internal/schemanode_test.go
@@ -11,14 +11,27 @@ import (
 	"github.com/xitongsys/parquet-go/types"
 )
 
-func Test_NewSchemaTree(t *testing.T) {
+func Test_NewSchemaTree_fail_on_int96(t *testing.T) {
 	option := ReadOption{}
 	uri := "../testdata/all-types.parquet"
 	pr, err := NewParquetFileReader(uri, option)
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	_, err = NewSchemaTree(pr, SchemaOption{FailOnInt96: true})
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "type INT96 which is not supporte")
+}
+
+func Test_NewSchemaTree_good(t *testing.T) {
+	option := ReadOption{}
+	uri := "../testdata/all-types.parquet"
+	pr, err := NewParquetFileReader(uri, option)
+	require.Nil(t, err)
+	defer pr.PFile.Close()
+
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	actual, _ := json.MarshalIndent(schemaRoot, "", "  ")
@@ -33,7 +46,8 @@ func Test_SchemaNode_GetReinterpretFields(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	expected := []string{
@@ -233,7 +247,8 @@ func Test_Json_schema_go_struct_good(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	actual, err := schemaRoot.GoStruct()
@@ -249,7 +264,8 @@ func Test_Json_schema_json_schema_good(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	actual := schemaRoot.JSONSchema()
@@ -268,7 +284,8 @@ func Test_Json_schema_csv_schema_good(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	actual, err := schemaRoot.CSVSchema()
@@ -284,7 +301,8 @@ func Test_Json_schema_csv_schema_nested(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	_, err = schemaRoot.CSVSchema()
@@ -299,7 +317,8 @@ func Test_Json_schema_csv_schema_optional(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	_, err = schemaRoot.CSVSchema()
@@ -314,7 +333,8 @@ func Test_Json_schema_csv_schema_repeated(t *testing.T) {
 	require.Nil(t, err)
 	defer pr.PFile.Close()
 
-	schemaRoot := NewSchemaTree(pr)
+	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	require.Nil(t, err)
 	require.NotNil(t, schemaRoot)
 
 	_, err = schemaRoot.CSVSchema()


### PR DESCRIPTION
Default is false as for now so this tool can still deal with INT96 as before, this behavior may be changed future though, as INT96 has been deprecated a while back.

Also several minor non-functional fixes.