### PR TITLE
add split command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # parquet-tools
 Utility to inspect Parquet files.
 
-## Installation
+## Quick Start
 
 `parquet-tools` support following methods to install:
 
@@ -54,6 +54,10 @@ TODO list is tracked as enhancement in issues.
 
 ## Table of Contents
 
+- [parquet-tools](#parquet-tools)
+  - [Quick Start](#quick-start)
+  - [Credit](#credit)
+  - [TODO](#todo)
 - [Installation and Usage of parquet-tools](#installation-and-usage-of-parquet-tools)
   - [Table of Contents](#table-of-contents)
   - [Installation](#installation)
@@ -93,7 +97,7 @@ TODO list is tracked as enhancement in issues.
       - [JSON Format](#json-format)
       - [Raw Format](#raw-format)
       - [Go Struct Format](#go-struct-format)
-      - [CSV Format](#CSV-format)
+      - [CSV Format](#csv-format)
     - [shell-completions Command (Experimental)](#shell-completions-command-experimental)
       - [Install Shell Completions](#install-shell-completions)
       - [Uninstall Shell Completions](#uninstall-shell-completions)
@@ -102,6 +106,9 @@ TODO list is tracked as enhancement in issues.
       - [Show Raw Size](#show-raw-size)
       - [Show Footer Size in JSON Format](#show-footer-size-in-json-format)
       - [Show All Sizes in JSON Format](#show-all-sizes-in-json-format)
+    - [split Command](#split-command)
+      - [Exact number of output files](#exact-number-of-output-files)
+      - [Maximum records in a file](#maximum-records-in-a-file)
     - [version Command](#version-command)
       - [Print Version](#print-version)
       - [Print All Information](#print-all-information)
@@ -769,6 +776,46 @@ $ parquet-tools size --query footer --json testdata/good.parquet
 ```bash
 $ parquet-tools size -q all -j testdata/good.parquet
 {"Raw":588,"Uncompressed":438,"Footer":323}
+```
+### split Command
+
+`split` command distributes data in source file into multiple parquet files, number of output files is either `--file-count` parameter, or total number of rows in source file divided by `--record-count` parameter.
+
+Name of output files is determined by `--name-format` and will be used by `fmt.Sprintf`, default value is `result-%06d.parquet` which means output files will be under current directory with name `result-000000.parquet`, `result-000001.parquet`, etc., you can use any of file locations that support write operation, eg S3, or HDFS.
+
+Other useful parameters include:
+* `--fail-on-int96` to fail the command if source parquet file contains INT96 fields
+* `--compression` to specify compression codec for output files, defailt is `SNAPPY`
+* `--read-page-size` to tell how many rows will be read per batch from source
+
+#### Exact number of output files
+
+```bash
+$ parquet-tools row-count testdata/all-types.parquet
+10
+$ parquet-tools split --file-count 3 testdata/all-types.parquet
+$ xiehang$ parquet-tools row-count result-000000.parquet
+4
+$ xiehang$ parquet-tools row-count result-000001.parquet
+3
+$ xiehang$ parquet-tools row-count result-000002.parquet
+3
+```
+
+#### Maximum records in a file
+
+```bash
+$ parquet-tools row-count testdata/all-types.parquet
+10
+$ parquet-tools split --record-count 3 --name-format %d.parquet testdata/all-types.parquet
+$ xiehang$ parquet-tools row-count 0.parquet
+3
+$ xiehang$ parquet-tools row-count 1.parquet
+3
+$ xiehang$ parquet-tools row-count 2.parquet
+3
+$ xiehang$ parquet-tools row-count 3.parquet
+1
 ```
 
 ### version Command

--- a/cmd/split.go
+++ b/cmd/split.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/xitongsys/parquet-go/reader"
+	"github.com/xitongsys/parquet-go/writer"
+
+	"github.com/hangxie/parquet-tools/internal"
+)
+
+// current writer state
+type TrunkWriter struct {
+	fileIndex    int64
+	targetFile   string
+	writer       *writer.ParquetWriter
+	recordCount  int64
+	paddingCount int64
+	schemaJSON   string
+}
+
+// SplitCmd is a kong command for split
+type SplitCmd struct {
+	internal.ReadOption
+	internal.WriteOption
+	ReadPageSize int    `help:"Page size to read from Parquet." default:"1000"`
+	URI          string `arg:"" predictor:"file" help:"URI of Parquet file."`
+	FileCount    int64  `xor:"RecordCount" help:"Generate this number of result files with potential empty ones"`
+	RecordCount  int64  `xor:"FileCount" help:"Result files will have at most this number of records"`
+	FailOnInt96  bool   `help:"Fail command if INT96 data type presents." name:"fail-on-int96" default:"false"`
+	NameFormat   string `help:"Format to populate target file names" default:"result-%06d.parquet"`
+
+	current TrunkWriter
+}
+
+func (c *SplitCmd) openReader() (*reader.ParquetReader, error) {
+	reader, err := internal.NewParquetFileReader(c.URI, c.ReadOption)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open [%s]: %w", c.URI, err)
+	}
+	defer reader.PFile.Close()
+	schemaRoot, err := internal.NewSchemaTree(reader, internal.SchemaOption{FailOnInt96: c.FailOnInt96})
+	if err != nil {
+		return nil, fmt.Errorf("failed to load schema for [%s]: %w", c.URI, err)
+	}
+	c.current.schemaJSON = schemaRoot.JSONSchema()
+
+	if c.FileCount != 0 {
+		c.RecordCount = reader.GetNumRows() / c.FileCount
+		c.current.paddingCount = reader.GetNumRows() % c.RecordCount
+	}
+
+	return reader, nil
+}
+
+func (c *SplitCmd) switchWriter() error {
+	if c.current.writer != nil {
+		if err := c.current.writer.WriteStop(); err != nil {
+			return fmt.Errorf("failed to end write [%s]: %w", c.current.targetFile, err)
+		}
+		if err := c.current.writer.PFile.Close(); err != nil {
+			return fmt.Errorf("failed to close [%s]: %w", c.current.targetFile, err)
+		}
+		c.current.writer = nil
+	}
+
+	var err error
+	c.current.targetFile = fmt.Sprintf(c.NameFormat, c.current.fileIndex)
+	c.current.writer, err = internal.NewGenericWriter(c.current.targetFile, c.WriteOption, c.current.schemaJSON)
+	if err != nil {
+		return fmt.Errorf("failed to write to [%s]: %w", c.current.targetFile, err)
+	}
+	c.current.fileIndex++
+	if c.current.paddingCount != 0 {
+		c.current.recordCount = -1
+		c.current.paddingCount--
+	} else {
+		c.current.recordCount = 0
+	}
+
+	return nil
+}
+
+// Run does actual split job
+func (c SplitCmd) Run() error {
+	if c.ReadPageSize < 1 {
+		return fmt.Errorf("invalid read page size %d, needs to be at least 1", c.ReadPageSize)
+	}
+	if c.FileCount == 0 && c.RecordCount == 0 {
+		return fmt.Errorf("needs either --file-count or --record-count")
+	}
+
+	reader, err := c.openReader()
+	if err != nil {
+		return err
+	}
+
+	c.current.fileIndex = 0
+	c.current.targetFile = ""
+	// this is to trigger open the first target file
+	c.current.recordCount = c.RecordCount
+
+	for {
+		rows, err := reader.ReadByNumber(c.ReadPageSize)
+		if err != nil {
+			return fmt.Errorf("failed to read from [%s]: %w", c.URI, err)
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, row := range rows {
+			if c.current.recordCount == c.RecordCount {
+				if err := c.switchWriter(); err != nil {
+					return err
+				}
+			}
+			if err := c.current.writer.Write(row); err != nil {
+				return fmt.Errorf("failed to write data from [%s]: %w", c.current.targetFile, err)
+			}
+			c.current.recordCount++
+		}
+	}
+	if c.current.writer != nil {
+		if err := c.current.writer.WriteStop(); err != nil {
+			return fmt.Errorf("failed to end write [%s]: %w", c.current.targetFile, err)
+		}
+		if err := c.current.writer.PFile.Close(); err != nil {
+			return fmt.Errorf("failed to close [%s]: %w", c.current.targetFile, err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/split_test.go
+++ b/cmd/split_test.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hangxie/parquet-tools/internal"
+)
+
+func Test_SplitCmd_Run_wrong_params(t *testing.T) {
+	cmd := &SplitCmd{}
+
+	err := cmd.Run()
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "invalid read page size")
+
+	cmd.ReadPageSize = 1000
+	err = cmd.Run()
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "needs either --file-count or --record-count")
+}
+
+func Test_SplitCmd_Run_failed_to_open_for_read(t *testing.T) {
+	tempDir, _ := os.MkdirTemp(os.TempDir(), "split-test")
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	cmd := &SplitCmd{}
+	cmd.URI = "file/does/not/exist"
+	cmd.ReadPageSize = 1000
+	cmd.RecordCount = 10
+	cmd.NameFormat = filepath.Join(tempDir, "unit-test-%d.parquet")
+
+	err := cmd.Run()
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "failed to open")
+}
+
+func Test_SplitCmd_Run_failed_with_int96(t *testing.T) {
+	tempDir, _ := os.MkdirTemp(os.TempDir(), "split-test")
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	cmd := &SplitCmd{}
+	cmd.URI = "../testdata/all-types.parquet"
+	cmd.FailOnInt96 = true
+	cmd.ReadPageSize = 1000
+	cmd.RecordCount = 10
+	cmd.NameFormat = filepath.Join(tempDir, "unit-test-%d.parquet")
+
+	err := cmd.Run()
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "failed to load schema")
+}
+
+func Test_SplitCmd_Run_failed_to_open_for_write(t *testing.T) {
+	cmd := &SplitCmd{}
+	cmd.URI = "../testdata/all-types.parquet"
+	cmd.WriteOption.Compression = "SNAPPY"
+	cmd.ReadPageSize = 1000
+	cmd.RecordCount = 10
+	cmd.NameFormat = "dummy://unit-test-%d.parquet"
+
+	err := cmd.Run()
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "unknown location scheme")
+}
+
+func Test_SplitCmd_Run_failed_to_close_for_write(t *testing.T) {
+	cmd := &SplitCmd{}
+	cmd.URI = "../testdata/all-types.parquet"
+	cmd.WriteOption.Compression = "SNAPPY"
+	cmd.ReadPageSize = 1000
+	cmd.RecordCount = 10
+
+	// failed to close last parquet file
+	cmd.NameFormat = "s3://daylight-openstreetmap/unit-test-%d.parquet"
+	err := cmd.Run()
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "failed to close [s3:")
+
+	// failed to close first parquet file
+	cmd.RecordCount = 3
+	cmd.NameFormat = "s3://daylight-openstreetmap/unit-test-%d.parquet"
+	err = cmd.Run()
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "failed to close [s3:")
+}
+
+func Test_SplitCmd_Run_good_with_recordcount(t *testing.T) {
+	tempDir, _ := os.MkdirTemp(os.TempDir(), "split-test")
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	cmd := &SplitCmd{}
+	cmd.URI = "../testdata/all-types.parquet"
+	cmd.WriteOption.Compression = "SNAPPY"
+	cmd.ReadPageSize = 1000
+	cmd.RecordCount = 3
+	cmd.NameFormat = filepath.Join(tempDir, "unit-test-%d.parquet")
+
+	err := cmd.Run()
+	require.Nil(t, err)
+	for i := 0; i < 4; i++ {
+		reader, err := internal.NewParquetFileReader(fmt.Sprintf(cmd.NameFormat, i), internal.ReadOption{})
+		require.Nil(t, err)
+		require.NotNil(t, reader)
+		if i == 3 {
+			// last file contains 1 record
+			require.Equal(t, reader.GetNumRows(), int64(1))
+		} else {
+			/// all other files contains 3 records
+			require.Equal(t, reader.GetNumRows(), int64(3))
+		}
+		reader.PFile.Close()
+	}
+}
+
+func Test_SplitCmd_Run_good_with_filecount(t *testing.T) {
+	tempDir, _ := os.MkdirTemp(os.TempDir(), "split-test")
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	cmd := &SplitCmd{}
+	cmd.URI = "../testdata/all-types.parquet"
+	cmd.WriteOption.Compression = "SNAPPY"
+	cmd.ReadPageSize = 1000
+	cmd.FileCount = 3
+	cmd.NameFormat = filepath.Join(tempDir, "unit-test-%d.parquet")
+
+	err := cmd.Run()
+	require.Nil(t, err)
+	for i := 0; i < 3; i++ {
+		reader, err := internal.NewParquetFileReader(fmt.Sprintf(cmd.NameFormat, i), internal.ReadOption{})
+		require.Nil(t, err)
+		require.NotNil(t, reader)
+		if i == 0 {
+			// first file contains 4 records
+			require.Equal(t, reader.GetNumRows(), int64(4))
+		} else {
+			/// all other files contains 3 records
+			require.Equal(t, reader.GetNumRows(), int64(3))
+		}
+		reader.PFile.Close()
+	}
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var cli struct {
 	Schema           cmd.SchemaCmd                `cmd:"" help:"Prints the schema."`
 	ShellCompletions kongplete.InstallCompletions `cmd:"" help:"Install/uninstall shell completions"`
 	Size             cmd.SizeCmd                  `cmd:"" help:"Prints the size."`
+	Split            cmd.SplitCmd                 `cmd:"" help:"Split into multiple parquet files."`
 	Version          cmd.VersionCmd               `cmd:"" help:"Show build version."`
 }
 


### PR DESCRIPTION
This is for https://github.com/hangxie/parquet-tools/issues/399.

Split by size is not implemented at this moment as there is no reliable way to get size of the file-to-be-written, the general workaround is to use `writer.Offset` but it does not work well in the case of smaller file size, which may confuse people.