### PR TITLE
change dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
This is to reduce number of commits as I'm moving to monthly release to address dependencies.