### PR TITLE
trigger dependabot check on friday so I can work on them during weekend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: friday


### PR DESCRIPTION
Default is Monday https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#schedule- which does not match my schedule well.