### PR TITLE
avoid test cases from CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ You can pull the image from either location:
 
 ```bash
 $ docker run --rm hangxie/parquet-tools version
-v1.25.12
+v1.28.0
 $ podman run --rm ghcr.io/hangxie/parquet-tools version
-v1.25.12
+v1.28.0
 ```
 
 ### Prebuilt RPM and deb Packages
@@ -174,20 +174,20 @@ RPM and deb package can be found on [release page](https://github.com/hangxie/pa
 * On Debian/Ubuntu:
 
 ```bash
-$ sudo dpkg -i parquet-tools_1.25.12_amd64.deb
-Preparing to unpack parquet-tools_1.25.12_amd64.deb ...
-Unpacking parquet-tools (1.25.12) ...
-Setting up parquet-tools (1.25.12) ...
+$ sudo dpkg -i parquet-tools_1.28.0_amd64.deb
+Preparing to unpack parquet-tools_1.28.0_amd64.deb ...
+Unpacking parquet-tools (1.28.0) ...
+Setting up parquet-tools (1.28.0) ...
 ```
 
 * On CentOS/Fedora:
 
 ```bash
-$ sudo rpm -Uhv parquet-tools-1.25.12-1.x86_64.rpm
-Verifying...                          ################################# [100%]
-Preparing...                          ################################# [100%]
+$ sudo rpm -Uhv parquet-tools-1.28.0-1.x86_64.rpm
+Verifying...                         ################################# [100%]
+Preparing...                         ################################# [100%]
 Updating / installing...
-   1:parquet-tools-1.25.12-1          ################################# [100%]
+   1:parquet-tools-1.28.0-1          ################################# [100%]
 ```
 
 ## Usage
@@ -911,7 +911,7 @@ $ parquet-tools row-count 3.parquet
 
 ```bash
 $ parquet-tools version
-v1.25.12
+v1.28.0
 ```
 
 #### Print All Information
@@ -920,8 +920,8 @@ v1.25.12
 
 ```bash
 $ parquet-tools version -a
-v1.25.12
-2024-12-30T03:24:47Z
+v1.28.0
+2025-04-04T16:27:10Z
 Homebrew
 ```
 
@@ -929,14 +929,14 @@ Homebrew
 
 ```bash
 $ parquet-tools version --build-time --json
-{"Version":"v1.25.12","BuildTime":"2024-12-30T03:24:47Z"}
+{"Version":"v1.28.0","BuildTime":"2025-04-04T16:27:10Z"}
 ```
 
 #### Print Version in JSON Format
 
 ```bash
 $ parquet-tools version -j
-{"Version":"v1.25.12"}
+{"Version":"v1.28.0"}
 ```
 
 ## Credit

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -171,6 +171,7 @@ func Test_NewParquetFileReader(t *testing.T) {
 	s3URL := "s3://daylight-openstreetmap/parquet/osm_features/release=v1.46/type=way/20240506_151445_00143_nanmw_fb5fe2f1-fec8-494f-8c2e-0feb15cedff0"
 	gcsURL := "gs://cloud-samples-data/bigquery/us-states/us-states.parquet"
 	azblobURL := "wasbs://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet"
+	httpURL := "https://dpla-provider-export.s3.amazonaws.com/2021/04/all.parquet/part-00000-471427c6-8097-428d-9703-a751a6572cca-c000.snappy.parquet"
 	testCases := map[string]struct {
 		uri    string
 		option ReadOption
@@ -190,7 +191,7 @@ func Test_NewParquetFileReader(t *testing.T) {
 		"azblob-good":            {azblobURL, ReadOption{Anonymous: true}, ""},
 		"http-bad-url":           {"https://no-such-host.tld/", rOpt, "no such host"},
 		"http-no-range-support":  {"https://www.google.com/", rOpt, "does not support range"},
-		"http-good":              {"https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-01.parquet", rOpt, ""},
+		"http-good":              {httpURL, rOpt, ""},
 		"hdfs-failed":            {"hdfs://localhost:1/temp/good.parquet", rOpt, "connection refused"},
 	}
 


### PR DESCRIPTION
It seems CDN based test cases are not stable, follow test case passed locally and over PR, but failed at release build:

> Expected nil, but got: &fmt.wrapError{msg:"failed to open HTTP source [https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-01.parquet]: remote [https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-01.parquet] does not support range", err:(*errors.errorString)(0xc00006d170)}