### PR TITLE
upgrade to unified parquet-go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.2
 	github.com/google/uuid v1.6.0
-	github.com/hangxie/parquet-go v1.8.3
-	github.com/hangxie/parquet-go-source v1.0.0
+	github.com/hangxie/parquet-go v1.9.0
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.10.0
 	github.com/willabides/kongplete v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -148,10 +148,8 @@ github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyC
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
-github.com/hangxie/parquet-go v1.8.3 h1:mVUklZMbznlQGp8ClkESElNLs2dTBLKIe2GA7VHYb0A=
-github.com/hangxie/parquet-go v1.8.3/go.mod h1:1TcQ6ZCxdVUUFhjNCfwcaN7JjYiGfAlZbJvJ/2LujbM=
-github.com/hangxie/parquet-go-source v1.0.0 h1:6+AeWKBV2xJJAoE47Ce0TEs6AuFa5FVc5g8m2jLM6Hg=
-github.com/hangxie/parquet-go-source v1.0.0/go.mod h1:W7r+Xf081yPArDQt07Ml3WRq6xvqmdj8q5LqY7CRV30=
+github.com/hangxie/parquet-go v1.9.0 h1:lYwNboRGfvRLM3TQFM3RWbXJTGpPfpun36NsE95oQlw=
+github.com/hangxie/parquet-go v1.9.0/go.mod h1:uplfAByu+6//vOdC2feBrOmwPcJGt0wNRBG4f9tLvDQ=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/internal/io/reader.go
+++ b/internal/io/reader.go
@@ -10,14 +10,14 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
-	pqtazblob "github.com/hangxie/parquet-go-source/azblob"
-	"github.com/hangxie/parquet-go-source/gcs"
-	"github.com/hangxie/parquet-go-source/hdfs"
-	pqhttp "github.com/hangxie/parquet-go-source/http"
-	"github.com/hangxie/parquet-go-source/local"
-	"github.com/hangxie/parquet-go-source/s3v2"
 	"github.com/hangxie/parquet-go/reader"
 	"github.com/hangxie/parquet-go/source"
+	pqtazblob "github.com/hangxie/parquet-go/source/azblob"
+	"github.com/hangxie/parquet-go/source/gcs"
+	"github.com/hangxie/parquet-go/source/hdfs"
+	pqhttp "github.com/hangxie/parquet-go/source/http"
+	"github.com/hangxie/parquet-go/source/local"
+	"github.com/hangxie/parquet-go/source/s3v2"
 	googleoption "google.golang.org/api/option"
 )
 

--- a/internal/io/writer.go
+++ b/internal/io/writer.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
-	pqtazblob "github.com/hangxie/parquet-go-source/azblob"
-	"github.com/hangxie/parquet-go-source/gcs"
-	"github.com/hangxie/parquet-go-source/hdfs"
-	"github.com/hangxie/parquet-go-source/local"
-	"github.com/hangxie/parquet-go-source/s3v2"
 	"github.com/hangxie/parquet-go/source"
+	pqtazblob "github.com/hangxie/parquet-go/source/azblob"
+	"github.com/hangxie/parquet-go/source/gcs"
+	"github.com/hangxie/parquet-go/source/hdfs"
+	"github.com/hangxie/parquet-go/source/local"
+	"github.com/hangxie/parquet-go/source/s3v2"
 	"github.com/hangxie/parquet-go/writer"
 )
 

--- a/testdata/gen/all-types/main.go
+++ b/testdata/gen/all-types/main.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hangxie/parquet-go-source/local"
 	"github.com/hangxie/parquet-go/parquet"
+	"github.com/hangxie/parquet-go/source/local"
 	"github.com/hangxie/parquet-go/types"
 	"github.com/hangxie/parquet-go/writer"
 )

--- a/testdata/gen/csv/main.go
+++ b/testdata/gen/csv/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/hangxie/parquet-go-source/local"
 	"github.com/hangxie/parquet-go/parquet"
+	"github.com/hangxie/parquet-go/source/local"
 	"github.com/hangxie/parquet-go/writer"
 )
 

--- a/testdata/gen/empty/main.go
+++ b/testdata/gen/empty/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
-	"github.com/hangxie/parquet-go-source/local"
 	"github.com/hangxie/parquet-go/parquet"
+	"github.com/hangxie/parquet-go/source/local"
 	"github.com/hangxie/parquet-go/writer"
 )
 

--- a/testdata/gen/good/main.go
+++ b/testdata/gen/good/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/hangxie/parquet-go-source/local"
 	"github.com/hangxie/parquet-go/parquet"
+	"github.com/hangxie/parquet-go/source/local"
 	"github.com/hangxie/parquet-go/writer"
 )
 

--- a/testdata/gen/int96-nil-min-max/main.go
+++ b/testdata/gen/int96-nil-min-max/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/hangxie/parquet-go-source/local"
 	"github.com/hangxie/parquet-go/parquet"
+	"github.com/hangxie/parquet-go/source/local"
 	"github.com/hangxie/parquet-go/writer"
 )
 

--- a/testdata/gen/list-of-list/main.go
+++ b/testdata/gen/list-of-list/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hangxie/parquet-go-source/local"
 	"github.com/hangxie/parquet-go/parquet"
+	"github.com/hangxie/parquet-go/source/local"
 	"github.com/hangxie/parquet-go/writer"
 )
 

--- a/testdata/gen/map-composite-map/main.go
+++ b/testdata/gen/map-composite-map/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/hangxie/parquet-go-source/local"
 	"github.com/hangxie/parquet-go/parquet"
+	"github.com/hangxie/parquet-go/source/local"
 	"github.com/hangxie/parquet-go/writer"
 )
 

--- a/testdata/gen/map-value-map/main.go
+++ b/testdata/gen/map-value-map/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/hangxie/parquet-go-source/local"
 	"github.com/hangxie/parquet-go/parquet"
+	"github.com/hangxie/parquet-go/source/local"
 	"github.com/hangxie/parquet-go/writer"
 )
 

--- a/testdata/gen/pargo-prefix/main.go
+++ b/testdata/gen/pargo-prefix/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hangxie/parquet-go-source/local"
 	"github.com/hangxie/parquet-go/parquet"
+	"github.com/hangxie/parquet-go/source/local"
 	"github.com/hangxie/parquet-go/types"
 	"github.com/hangxie/parquet-go/writer"
 )

--- a/testdata/gen/reinterpret-fields/main.go
+++ b/testdata/gen/reinterpret-fields/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/hangxie/parquet-go-source/local"
+	"github.com/hangxie/parquet-go/source/local"
 	"github.com/hangxie/parquet-go/types"
 	"github.com/hangxie/parquet-go/writer"
 )

--- a/testdata/gen/top-level-tag/main.go
+++ b/testdata/gen/top-level-tag/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/hangxie/parquet-go-source/local"
 	"github.com/hangxie/parquet-go/parquet"
+	"github.com/hangxie/parquet-go/source/local"
 	"github.com/hangxie/parquet-go/writer"
 )
 


### PR DESCRIPTION
Use new version from https://github.com/hangxie/parquet-go/pull/17.