### PR TITLE
use invalid hostname to deal with DNS server that returns NXDOMAIN

### DIFF
--- a/internal/io/reader_test.go
+++ b/internal/io/reader_test.go
@@ -31,7 +31,7 @@ func Test_NewParquetFileReader(t *testing.T) {
 		"gcs-good":               {gcsURL, ReadOption{Anonymous: true}, ""},
 		"azblob-no-permission":   {azblobURL, rOpt, "Server failed to authenticate the request"},
 		"azblob-good":            {azblobURL, ReadOption{Anonymous: true}, ""},
-		"http-bad-url":           {"https://no-such-host.tld/", rOpt, "no such host"},
+		"http-bad-url":           {"https://.../", rOpt, "no such host"},
 		"http-no-range-support":  {"https://www.google.com/", rOpt, "does not support range"},
 		"http-good":              {httpURL, rOpt, ""},
 		"hdfs-failed":            {"hdfs://localhost:1/temp/good.parquet", rOpt, "connection refused"},


### PR DESCRIPTION
This is for https://github.com/hangxie/parquet-tools/issues/582.

Provide an invalid domain so it should not be resolved, I don't have an environment to test though.