### PR TITLE
order command options in alphabetic order

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Once it is installed:
 $ parquet-tools
 Usage: parquet-tools <command>
 
-A utility to inspect Parquet files, for full usage see
-https://github.com/hangxie/parquet-tools/blob/main/README.md
+A utility to inspect Parquet files, for full usage see https://github.com/hangxie/parquet-tools/blob/main/README.md
 
 Flags:
   -h, --help    Show context-sensitive help.
@@ -201,13 +200,13 @@ Arguments:
 Flags:
   -h, --help                        Show context-sensitive help.
 
-      --http-multiple-connection    (HTTP URI only) use multiple HTTP connection.
-      --http-ignore-tls-error       (HTTP URI only) ignore TLS error.
-      --http-extra-headers=         (HTTP URI only) extra HTTP headers.
-      --object-version=""           (S3, GCS, and Azure only) object version.
-      --anonymous                   (S3, GCS, and Azure only) object is publicly accessible.
   -b, --base64                      deprecated, will be removed in future version
       --fail-on-int96               fail command if INT96 data type is present.
+      --anonymous                   (S3, GCS, and Azure only) object is publicly accessible.
+      --http-extra-headers=         (HTTP URI only) extra HTTP headers.
+      --http-ignore-tls-error       (HTTP URI only) ignore TLS error.
+      --http-multiple-connection    (HTTP URI only) use multiple HTTP connection.
+      --object-version=""           (S3, GCS, and Azure only) object version.
 ```
 
 Most commands can output JSON format result which can be processed by utilities like [jq](https://stedolan.github.io/jq/) or [JSON parser online](https://jsonparseronline.com/).

--- a/cmd/cat.go
+++ b/cmd/cat.go
@@ -20,17 +20,17 @@ import (
 
 // CatCmd is a kong command for cat
 type CatCmd struct {
-	pio.ReadOption
-	Skip         int64   `short:"k" help:"Skip rows before apply other logics." default:"0"`
-	SkipPageSize int64   `help:"deprecated, will be removed in future release." default:"100000"`
+	Concurrent   bool    `help:"enable concurrent output" default:"false"`
+	FailOnInt96  bool    `help:"fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
+	Format       string  `short:"f" help:"output format (json/jsonl/csv/tsv)" enum:"json,jsonl,csv,tsv" default:"json"`
 	Limit        uint64  `short:"l" help:"Max number of rows to output, 0 means no limit." default:"0"`
+	NoHeader     bool    `help:"(CSV/TSV only) do not output field name as header" default:"false"`
 	ReadPageSize int     `help:"Page size to read from Parquet." default:"1000"`
 	SampleRatio  float32 `short:"s" help:"Sample ratio (0.0-1.0)." default:"1.0"`
-	Format       string  `short:"f" help:"output format (json/jsonl/csv/tsv)" enum:"json,jsonl,csv,tsv" default:"json"`
-	NoHeader     bool    `help:"(CSV/TSV only) do not output field name as header" default:"false"`
+	Skip         int64   `short:"k" help:"Skip rows before apply other logics." default:"0"`
+	SkipPageSize int64   `help:"deprecated, will be removed in future release." default:"100000"`
 	URI          string  `arg:"" predictor:"file" help:"URI of Parquet file."`
-	FailOnInt96  bool    `help:"fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
-	Concurrent   bool    `help:"enable concurrent output" default:"false"`
+	pio.ReadOption
 
 	// reusable CSV writer components
 	csvBuf    *strings.Builder

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -18,12 +18,12 @@ import (
 
 // ImportCmd is a kong command for import
 type ImportCmd struct {
-	pio.WriteOption
-	Source     string `required:"" short:"s" predictor:"file" help:"Source file name."`
 	Format     string `help:"Source file formats (csv/json/jsonl)." short:"f" enum:"csv,json,jsonl" default:"csv"`
 	Schema     string `required:"" short:"m" predictor:"file" help:"Schema file name."`
 	SkipHeader bool   `help:"Skip first line of CSV files" default:"false"`
+	Source     string `required:"" short:"s" predictor:"file" help:"Source file name."`
 	URI        string `arg:"" predictor:"file" help:"URI of Parquet file."`
+	pio.WriteOption
 }
 
 // Run does actual import job

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -17,31 +17,31 @@ func Test_ImportCmd_Run_error(t *testing.T) {
 		cmd    ImportCmd
 		errMsg string
 	}{
-		"write-format":          {ImportCmd{wOpt, "src", "random", "../testdata/csv.schema", false, "dummy"}, "is not a recognized source format"},
-		"write-compression":     {ImportCmd{pio.WriteOption{Compression: "foobar"}, "../testdata/json.source", "json", "../testdata/json.schema", false, filepath.Join(tempDir, "dummy")}, "not a valid CompressionCodec string"},
-		"csv-schema-file":       {ImportCmd{wOpt, "does/not/exist", "csv", "schema", false, "dummy"}, "failed to load schema from"},
-		"csv-source-file":       {ImportCmd{wOpt, "file/does/not/exist", "csv", "../testdata/csv.schema", false, "dummy"}, "failed to open CSV file"},
-		"csv-target-file":       {ImportCmd{wOpt, "../testdata/csv.source", "csv", "../testdata/csv.schema", false, "://uri"}, "unable to parse file location"},
-		"csv-schema":            {ImportCmd{wOpt, "../testdata/csv.source", "csv", "../testdata/json.schema", false, filepath.Join(tempDir, "dummy")}, "expect 'key=value' but got '{'"},
-		"csv-source":            {ImportCmd{wOpt, "../testdata/json.source", "csv", "../testdata/csv.schema", false, filepath.Join(tempDir, "dummy")}, "failed to write [[{]] to parquet"},
-		"csv-target":            {ImportCmd{wOpt, "../testdata/csv.source", "csv", "../testdata/csv.schema", false, "s3://target"}, "failed to close Parquet file"},
-		"csv-int96":             {ImportCmd{wOpt, "../testdata/csv.source", "csv", "../testdata/int96-csv.schema", false, filepath.Join(tempDir, "tgt")}, "import does not support INT96 type"},
-		"json-schema-file":      {ImportCmd{wOpt, "does/not/exist", "json", "schema", false, "dummy"}, "failed to load schema from"},
-		"json-source-file":      {ImportCmd{wOpt, "file/does/not/exist", "json", "../testdata/json.schema", false, "dummy"}, "failed to load source from"},
-		"json-target-file":      {ImportCmd{wOpt, "../testdata/json.source", "json", "../testdata/json.schema", false, "://uri"}, "unable to parse file location"},
-		"json-schema":           {ImportCmd{wOpt, "../testdata/json.source", "json", "../testdata/csv.schema", false, "dummy"}, "is not a valid schema JSON"},
-		"json-source":           {ImportCmd{wOpt, "../testdata/csv.source", "json", "../testdata/json.schema", false, "dummy"}, "invalid JSON string:"},
-		"json-target":           {ImportCmd{wOpt, "../testdata/json.source", "json", "../testdata/json.schema", false, "s3://target"}, "failed to close Parquet file"},
-		"json-schema-mismatch":  {ImportCmd{wOpt, "../testdata/json.bad-source", "json", "../testdata/json.schema", false, filepath.Join(tempDir, "dummy")}, "failed to close Parquet writer"},
-		"json-int96":            {ImportCmd{wOpt, "src", "json", "../testdata/int96-json.schema", false, "dummy"}, "import does not support INT96 type"},
-		"jsonl-schema-file":     {ImportCmd{wOpt, "does/not/exist", "jsonl", "schema", false, "dummy"}, "failed to load schema from"},
-		"jsonl-source-file":     {ImportCmd{wOpt, "file/does/not/exist", "jsonl", "../testdata/jsonl.schema", false, "dummy"}, "failed to open source file"},
-		"jsonl-target-file":     {ImportCmd{wOpt, "../testdata/jsonl.source", "jsonl", "../testdata/jsonl.schema", false, "://uri"}, "unable to parse file location"},
-		"jsonl-schema":          {ImportCmd{wOpt, "../testdata/jsonl.source", "jsonl", "../testdata/csv.schema", false, "dummy"}, "is not a valid schema JSON"},
-		"jsonl-source":          {ImportCmd{wOpt, "../testdata/csv.source", "jsonl", "../testdata/jsonl.schema", false, filepath.Join(tempDir, "dummy")}, "invalid JSON string:"},
-		"jsonl-target":          {ImportCmd{wOpt, "../testdata/jsonl.source", "jsonl", "../testdata/jsonl.schema", false, "s3://target"}, "failed to close Parquet file"},
-		"jsonl-schema-mismatch": {ImportCmd{wOpt, "../testdata/jsonl.source", "jsonl", "../testdata/json.schema", false, filepath.Join(tempDir, "dummy")}, "failed to close Parquet writer"},
-		"jsonl-int96":           {ImportCmd{wOpt, "src", "jsonl", "../testdata/int96-json.schema", false, "dummy"}, "import does not support INT96 type"},
+		"write-format":          {ImportCmd{WriteOption: wOpt, Source: "src", Format: "random", Schema: "../testdata/csv.schema", SkipHeader: false, URI: "dummy"}, "is not a recognized source format"},
+		"write-compression":     {ImportCmd{WriteOption: pio.WriteOption{Compression: "foobar"}, Source: "../testdata/json.source", Format: "json", Schema: "../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "not a valid CompressionCodec string"},
+		"csv-schema-file":       {ImportCmd{WriteOption: wOpt, Source: "does/not/exist", Format: "csv", Schema: "schema", SkipHeader: false, URI: "dummy"}, "failed to load schema from"},
+		"csv-source-file":       {ImportCmd{WriteOption: wOpt, Source: "file/does/not/exist", Format: "csv", Schema: "../testdata/csv.schema", SkipHeader: false, URI: "dummy"}, "failed to open CSV file"},
+		"csv-target-file":       {ImportCmd{WriteOption: wOpt, Source: "../testdata/csv.source", Format: "csv", Schema: "../testdata/csv.schema", SkipHeader: false, URI: "://uri"}, "unable to parse file location"},
+		"csv-schema":            {ImportCmd{WriteOption: wOpt, Source: "../testdata/csv.source", Format: "csv", Schema: "../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "expect 'key=value' but got '{'"},
+		"csv-source":            {ImportCmd{WriteOption: wOpt, Source: "../testdata/json.source", Format: "csv", Schema: "../testdata/csv.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "failed to write [[{]] to parquet"},
+		"csv-target":            {ImportCmd{WriteOption: wOpt, Source: "../testdata/csv.source", Format: "csv", Schema: "../testdata/csv.schema", SkipHeader: false, URI: "s3://target"}, "failed to close Parquet file"},
+		"csv-int96":             {ImportCmd{WriteOption: wOpt, Source: "../testdata/csv.source", Format: "csv", Schema: "../testdata/int96-csv.schema", SkipHeader: false, URI: filepath.Join(tempDir, "tgt")}, "import does not support INT96 type"},
+		"json-schema-file":      {ImportCmd{WriteOption: wOpt, Source: "does/not/exist", Format: "json", Schema: "schema", SkipHeader: false, URI: "dummy"}, "failed to load schema from"},
+		"json-source-file":      {ImportCmd{WriteOption: wOpt, Source: "file/does/not/exist", Format: "json", Schema: "../testdata/json.schema", SkipHeader: false, URI: "dummy"}, "failed to load source from"},
+		"json-target-file":      {ImportCmd{WriteOption: wOpt, Source: "../testdata/json.source", Format: "json", Schema: "../testdata/json.schema", SkipHeader: false, URI: "://uri"}, "unable to parse file location"},
+		"json-schema":           {ImportCmd{WriteOption: wOpt, Source: "../testdata/json.source", Format: "json", Schema: "../testdata/csv.schema", SkipHeader: false, URI: "dummy"}, "is not a valid schema JSON"},
+		"json-source":           {ImportCmd{WriteOption: wOpt, Source: "../testdata/csv.source", Format: "json", Schema: "../testdata/json.schema", SkipHeader: false, URI: "dummy"}, "invalid JSON string:"},
+		"json-target":           {ImportCmd{WriteOption: wOpt, Source: "../testdata/json.source", Format: "json", Schema: "../testdata/json.schema", SkipHeader: false, URI: "s3://target"}, "failed to close Parquet file"},
+		"json-schema-mismatch":  {ImportCmd{WriteOption: wOpt, Source: "../testdata/json.bad-source", Format: "json", Schema: "../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "failed to close Parquet writer"},
+		"json-int96":            {ImportCmd{WriteOption: wOpt, Source: "src", Format: "json", Schema: "../testdata/int96-json.schema", SkipHeader: false, URI: "dummy"}, "import does not support INT96 type"},
+		"jsonl-schema-file":     {ImportCmd{WriteOption: wOpt, Source: "does/not/exist", Format: "jsonl", Schema: "schema", SkipHeader: false, URI: "dummy"}, "failed to load schema from"},
+		"jsonl-source-file":     {ImportCmd{WriteOption: wOpt, Source: "file/does/not/exist", Format: "jsonl", Schema: "../testdata/jsonl.schema", SkipHeader: false, URI: "dummy"}, "failed to open source file"},
+		"jsonl-target-file":     {ImportCmd{WriteOption: wOpt, Source: "../testdata/jsonl.source", Format: "jsonl", Schema: "../testdata/jsonl.schema", SkipHeader: false, URI: "://uri"}, "unable to parse file location"},
+		"jsonl-schema":          {ImportCmd{WriteOption: wOpt, Source: "../testdata/jsonl.source", Format: "jsonl", Schema: "../testdata/csv.schema", SkipHeader: false, URI: "dummy"}, "is not a valid schema JSON"},
+		"jsonl-source":          {ImportCmd{WriteOption: wOpt, Source: "../testdata/csv.source", Format: "jsonl", Schema: "../testdata/jsonl.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "invalid JSON string:"},
+		"jsonl-target":          {ImportCmd{WriteOption: wOpt, Source: "../testdata/jsonl.source", Format: "jsonl", Schema: "../testdata/jsonl.schema", SkipHeader: false, URI: "s3://target"}, "failed to close Parquet file"},
+		"jsonl-schema-mismatch": {ImportCmd{WriteOption: wOpt, Source: "../testdata/jsonl.source", Format: "jsonl", Schema: "../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "failed to close Parquet writer"},
+		"jsonl-int96":           {ImportCmd{WriteOption: wOpt, Source: "src", Format: "jsonl", Schema: "../testdata/int96-json.schema", SkipHeader: false, URI: "dummy"}, "import does not support INT96 type"},
 	}
 
 	for name, tc := range testCases {
@@ -60,10 +60,10 @@ func Test_ImportCmd_Run_good(t *testing.T) {
 		cmd      ImportCmd
 		rowCount int64
 	}{
-		"csv-wo-header": {ImportCmd{wOpt, "csv.source", "csv", "csv.schema", false, ""}, 7},
-		"csv-w-header":  {ImportCmd{wOpt, "csv-with-header.source", "csv", "csv.schema", true, ""}, 7},
-		"json":          {ImportCmd{wOpt, "json.source", "json", "json.schema", false, ""}, 1},
-		"jsonl":         {ImportCmd{wOpt, "jsonl.source", "jsonl", "jsonl.schema", false, ""}, 7},
+		"csv-wo-header": {ImportCmd{WriteOption: wOpt, Source: "csv.source", Format: "csv", Schema: "csv.schema", SkipHeader: false, URI: ""}, 7},
+		"csv-w-header":  {ImportCmd{WriteOption: wOpt, Source: "csv-with-header.source", Format: "csv", Schema: "csv.schema", SkipHeader: true, URI: ""}, 7},
+		"json":          {ImportCmd{WriteOption: wOpt, Source: "json.source", Format: "json", Schema: "json.schema", SkipHeader: false, URI: ""}, 1},
+		"jsonl":         {ImportCmd{WriteOption: wOpt, Source: "jsonl.source", Format: "jsonl", Schema: "jsonl.schema", SkipHeader: false, URI: ""}, 7},
 	}
 
 	tempDir := t.TempDir()

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -15,13 +15,13 @@ import (
 
 // MergeCmd is a kong command for merge
 type MergeCmd struct {
-	pio.ReadOption
-	pio.WriteOption
+	Concurrent   bool     `help:"enable concurrent processing" default:"false"`
+	FailOnInt96  bool     `help:"fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
 	ReadPageSize int      `help:"Page size to read from Parquet." default:"1000"`
 	Source       []string `short:"s" help:"Files to be merged."`
 	URI          string   `arg:"" predictor:"file" help:"URI of Parquet file."`
-	FailOnInt96  bool     `help:"fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
-	Concurrent   bool     `help:"enable concurrent processing" default:"false"`
+	pio.ReadOption
+	pio.WriteOption
 }
 
 func (c MergeCmd) writer(ctx context.Context, fileWriter *writer.ParquetWriter, writerChan chan any) error {

--- a/cmd/meta.go
+++ b/cmd/meta.go
@@ -18,10 +18,10 @@ import (
 
 // MetaCmd is a kong command for meta
 type MetaCmd struct {
-	pio.ReadOption
 	Base64      bool   `name:"base64" short:"b" help:"deprecated, will be removed in future version" default:"false"`
-	URI         string `arg:"" predictor:"file" help:"URI of Parquet file."`
 	FailOnInt96 bool   `help:"fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
+	URI         string `arg:"" predictor:"file" help:"URI of Parquet file."`
+	pio.ReadOption
 }
 
 type columnMeta struct {

--- a/cmd/meta_test.go
+++ b/cmd/meta_test.go
@@ -168,8 +168,8 @@ func Test_MetaCmd_Run_error(t *testing.T) {
 		cmd    MetaCmd
 		errMsg string
 	}{
-		"non-existent": {MetaCmd{rOpt, false, "file/does/not/exist", false}, "no such file or directory"},
-		"no-int96":     {MetaCmd{rOpt, false, "../testdata/all-types.parquet", true}, "type INT96 which is not supported"},
+		"non-existent": {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: false, URI: "file/does/not/exist"}, "no such file or directory"},
+		"no-int96":     {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: true, URI: "../testdata/all-types.parquet"}, "type INT96 which is not supported"},
 	}
 
 	for name, tc := range testCases {
@@ -187,16 +187,16 @@ func Test_MetaCmd_Run_good(t *testing.T) {
 		cmd    MetaCmd
 		golden string
 	}{
-		"raw":          {MetaCmd{rOpt, false, "good.parquet", false}, "meta-good-raw.json"},
-		"nil-stat":     {MetaCmd{rOpt, false, "nil-statistics.parquet", false}, "meta-nil-statistics-raw.json"},
-		"sorting-col":  {MetaCmd{rOpt, false, "sorting-col.parquet", false}, "meta-sorting-col-raw.json"},
-		"RI-scalar":    {MetaCmd{rOpt, false, "reinterpret-scalar.parquet", false}, "meta-reinterpret-scalar-raw.json"},
-		"RI-pointer":   {MetaCmd{rOpt, false, "reinterpret-pointer.parquet", false}, "meta-reinterpret-pointer-raw.json"},
-		"RI-list":      {MetaCmd{rOpt, false, "reinterpret-list.parquet", false}, "meta-reinterpret-list-raw.json"},
-		"RI-map-key":   {MetaCmd{rOpt, false, "reinterpret-map-key.parquet", false}, "meta-reinterpret-map-key-raw.json"},
-		"RI-map-value": {MetaCmd{rOpt, false, "reinterpret-map-value.parquet", false}, "meta-reinterpret-map-value-raw.json"},
-		"RI-composite": {MetaCmd{rOpt, false, "reinterpret-composite.parquet", false}, "meta-reinterpret-composite-raw.json"},
-		"all-types":    {MetaCmd{rOpt, false, "all-types.parquet", false}, "meta-all-types-raw.json"},
+		"raw":          {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: false, URI: "good.parquet"}, "meta-good-raw.json"},
+		"nil-stat":     {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: false, URI: "nil-statistics.parquet"}, "meta-nil-statistics-raw.json"},
+		"sorting-col":  {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: false, URI: "sorting-col.parquet"}, "meta-sorting-col-raw.json"},
+		"RI-scalar":    {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: false, URI: "reinterpret-scalar.parquet"}, "meta-reinterpret-scalar-raw.json"},
+		"RI-pointer":   {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: false, URI: "reinterpret-pointer.parquet"}, "meta-reinterpret-pointer-raw.json"},
+		"RI-list":      {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: false, URI: "reinterpret-list.parquet"}, "meta-reinterpret-list-raw.json"},
+		"RI-map-key":   {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: false, URI: "reinterpret-map-key.parquet"}, "meta-reinterpret-map-key-raw.json"},
+		"RI-map-value": {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: false, URI: "reinterpret-map-value.parquet"}, "meta-reinterpret-map-value-raw.json"},
+		"RI-composite": {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: false, URI: "reinterpret-composite.parquet"}, "meta-reinterpret-composite-raw.json"},
+		"all-types":    {MetaCmd{ReadOption: rOpt, Base64: false, FailOnInt96: false, URI: "all-types.parquet"}, "meta-all-types-raw.json"},
 	}
 
 	for name, tc := range testCases {

--- a/cmd/rowcount.go
+++ b/cmd/rowcount.go
@@ -8,8 +8,8 @@ import (
 
 // RowCountCmd is a kong command for rowcount
 type RowCountCmd struct {
-	pio.ReadOption
 	URI string `arg:"" predictor:"file" help:"URI of Parquet file."`
+	pio.ReadOption
 }
 
 // Run does actual rowcount job

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -17,9 +17,9 @@ var (
 
 // SchemaCmd is a kong command for schema
 type SchemaCmd struct {
-	pio.ReadOption
 	Format string `short:"f" help:"Schema format (raw/json/go/csv)." enum:"raw,json,go,csv" default:"json"`
 	URI    string `arg:"" predictor:"file" help:"URI of Parquet file."`
+	pio.ReadOption
 }
 
 // Run does actual schema job

--- a/cmd/schema_test.go
+++ b/cmd/schema_test.go
@@ -15,13 +15,13 @@ func Test_SchemaCmd_Run_error(t *testing.T) {
 		cmd    SchemaCmd
 		errMsg string
 	}{
-		"invalid-uri":    {SchemaCmd{rOpt, "foobar", "dummy://location"}, "unknown location scheme"},
-		"invalid-format": {SchemaCmd{rOpt, "foobar", "../testdata/good.parquet"}, "unknown schema format"},
-		"go-map-value":   {SchemaCmd{rOpt, "go", "../testdata/map-composite-value.parquet"}, "go struct does not support composite type as map value in field [Parquet_go_root.Scores]"},
-		"go-list-item":   {SchemaCmd{rOpt, "go", "../testdata/list-of-list.parquet"}, "go struct does not support composite type as list element in field [Parquet_go_root.Lol]"},
-		"csv-nested":     {SchemaCmd{rOpt, "csv", "../testdata/csv-nested.parquet"}, "CSV supports flat schema only"},
-		"csv-optional":   {SchemaCmd{rOpt, "csv", "../testdata/csv-optional.parquet"}, "CSV does not support optional column"},
-		"csv-repeated":   {SchemaCmd{rOpt, "csv", "../testdata/csv-repeated.parquet"}, "CSV does not support column in LIST type"},
+		"invalid-uri":    {SchemaCmd{ReadOption: rOpt, Format: "foobar", URI: "dummy://location"}, "unknown location scheme"},
+		"invalid-format": {SchemaCmd{ReadOption: rOpt, Format: "foobar", URI: "../testdata/good.parquet"}, "unknown schema format"},
+		"go-map-value":   {SchemaCmd{ReadOption: rOpt, Format: "go", URI: "../testdata/map-composite-value.parquet"}, "go struct does not support composite type as map value in field [Parquet_go_root.Scores]"},
+		"go-list-item":   {SchemaCmd{ReadOption: rOpt, Format: "go", URI: "../testdata/list-of-list.parquet"}, "go struct does not support composite type as list element in field [Parquet_go_root.Lol]"},
+		"csv-nested":     {SchemaCmd{ReadOption: rOpt, Format: "csv", URI: "../testdata/csv-nested.parquet"}, "CSV supports flat schema only"},
+		"csv-optional":   {SchemaCmd{ReadOption: rOpt, Format: "csv", URI: "../testdata/csv-optional.parquet"}, "CSV does not support optional column"},
+		"csv-repeated":   {SchemaCmd{ReadOption: rOpt, Format: "csv", URI: "../testdata/csv-repeated.parquet"}, "CSV does not support column in LIST type"},
 	}
 
 	for name, tc := range testCases {
@@ -39,15 +39,15 @@ func Test_SchemaCmd_Run_good(t *testing.T) {
 		cmd    SchemaCmd
 		golden string
 	}{
-		"raw":                 {SchemaCmd{rOpt, "raw", "all-types.parquet"}, "schema-all-types-raw.json"},
-		"json":                {SchemaCmd{rOpt, "json", "all-types.parquet"}, "schema-all-types-json.json"},
-		"go":                  {SchemaCmd{rOpt, "go", "all-types.parquet"}, "schema-all-types-go.txt"},
-		"csv":                 {SchemaCmd{rOpt, "csv", "csv-good.parquet"}, "schema-csv-good.txt"},
-		"raw-map-value-list":  {SchemaCmd{rOpt, "raw", "map-composite-value.parquet"}, "schema-map-composite-value-raw.json"},
-		"json-map-value-list": {SchemaCmd{rOpt, "json", "map-composite-value.parquet"}, "schema-map-composite-value-json.json"},
-		"json-map-value-map":  {SchemaCmd{rOpt, "json", "map-value-map.parquet"}, "schema-map-value-map-json.json"},
-		"pargo-prefix-flat":   {SchemaCmd{rOpt, "go", "pargo-prefix-flat.parquet"}, "schema-pargo-prefix-flat-go.txt"},
-		"pargo-prefix-nested": {SchemaCmd{rOpt, "go", "pargo-prefix-nested.parquet"}, "schema-pargo-prefix-nested-go.txt"},
+		"raw":                 {SchemaCmd{ReadOption: rOpt, Format: "raw", URI: "all-types.parquet"}, "schema-all-types-raw.json"},
+		"json":                {SchemaCmd{ReadOption: rOpt, Format: "json", URI: "all-types.parquet"}, "schema-all-types-json.json"},
+		"go":                  {SchemaCmd{ReadOption: rOpt, Format: "go", URI: "all-types.parquet"}, "schema-all-types-go.txt"},
+		"csv":                 {SchemaCmd{ReadOption: rOpt, Format: "csv", URI: "csv-good.parquet"}, "schema-csv-good.txt"},
+		"raw-map-value-list":  {SchemaCmd{ReadOption: rOpt, Format: "raw", URI: "map-composite-value.parquet"}, "schema-map-composite-value-raw.json"},
+		"json-map-value-list": {SchemaCmd{ReadOption: rOpt, Format: "json", URI: "map-composite-value.parquet"}, "schema-map-composite-value-json.json"},
+		"json-map-value-map":  {SchemaCmd{ReadOption: rOpt, Format: "json", URI: "map-value-map.parquet"}, "schema-map-value-map-json.json"},
+		"pargo-prefix-flat":   {SchemaCmd{ReadOption: rOpt, Format: "go", URI: "pargo-prefix-flat.parquet"}, "schema-pargo-prefix-flat-go.txt"},
+		"pargo-prefix-nested": {SchemaCmd{ReadOption: rOpt, Format: "go", URI: "pargo-prefix-nested.parquet"}, "schema-pargo-prefix-nested-go.txt"},
 	}
 
 	for name, tc := range testCases {

--- a/cmd/size.go
+++ b/cmd/size.go
@@ -16,10 +16,10 @@ var (
 
 // SizeCmd is a kong command for size
 type SizeCmd struct {
-	pio.ReadOption
 	Query string `short:"q" help:"Size to query (raw/uncompressed/footer/all)." enum:"raw,uncompressed,footer,all" default:"raw"`
 	JSON  bool   `short:"j" help:"Output in JSON format." default:"false"`
 	URI   string `arg:"" predictor:"file" help:"URI of Parquet file."`
+	pio.ReadOption
 }
 
 // Run does actual size job

--- a/cmd/size_test.go
+++ b/cmd/size_test.go
@@ -33,14 +33,14 @@ func Test_SizeCmd_Run_good(t *testing.T) {
 		cmd    SizeCmd
 		stdout string
 	}{
-		"raw":               {SizeCmd{rOpt, "raw", false, "../testdata/all-types.parquet"}, "19195\n"},
-		"raw-json":          {SizeCmd{rOpt, "raw", true, "../testdata/all-types.parquet"}, `{"Raw":19195}` + "\n"},
-		"uncompressed":      {SizeCmd{rOpt, "uncompressed", false, "../testdata/all-types.parquet"}, "28020\n"},
-		"uncompressed-json": {SizeCmd{rOpt, "uncompressed", true, "../testdata/all-types.parquet"}, `{"Uncompressed":28020}` + "\n"},
-		"footer":            {SizeCmd{rOpt, "footer", false, "../testdata/all-types.parquet"}, "7057\n"},
-		"footer-json":       {SizeCmd{rOpt, "footer", true, "../testdata/all-types.parquet"}, `{"Footer":7057}` + "\n"},
-		"all":               {SizeCmd{rOpt, "all", false, "../testdata/all-types.parquet"}, "19195 28020 7057\n"},
-		"all-json":          {SizeCmd{rOpt, "all", true, "../testdata/all-types.parquet"}, `{"Raw":19195,"Uncompressed":28020,"Footer":7057}` + "\n"},
+		"raw":               {SizeCmd{ReadOption: rOpt, Query: "raw", JSON: false, URI: "../testdata/all-types.parquet"}, "19195\n"},
+		"raw-json":          {SizeCmd{ReadOption: rOpt, Query: "raw", JSON: true, URI: "../testdata/all-types.parquet"}, `{"Raw":19195}` + "\n"},
+		"uncompressed":      {SizeCmd{ReadOption: rOpt, Query: "uncompressed", JSON: false, URI: "../testdata/all-types.parquet"}, "28020\n"},
+		"uncompressed-json": {SizeCmd{ReadOption: rOpt, Query: "uncompressed", JSON: true, URI: "../testdata/all-types.parquet"}, `{"Uncompressed":28020}` + "\n"},
+		"footer":            {SizeCmd{ReadOption: rOpt, Query: "footer", JSON: false, URI: "../testdata/all-types.parquet"}, "7057\n"},
+		"footer-json":       {SizeCmd{ReadOption: rOpt, Query: "footer", JSON: true, URI: "../testdata/all-types.parquet"}, `{"Footer":7057}` + "\n"},
+		"all":               {SizeCmd{ReadOption: rOpt, Query: "all", JSON: false, URI: "../testdata/all-types.parquet"}, "19195 28020 7057\n"},
+		"all-json":          {SizeCmd{ReadOption: rOpt, Query: "all", JSON: true, URI: "../testdata/all-types.parquet"}, `{"Raw":19195,"Uncompressed":28020,"Footer":7057}` + "\n"},
 	}
 
 	for name, tc := range testCases {

--- a/cmd/split.go
+++ b/cmd/split.go
@@ -23,14 +23,14 @@ type TrunkWriter struct {
 
 // SplitCmd is a kong command for split
 type SplitCmd struct {
+	FailOnInt96  bool   `help:"Fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
+	FileCount    int64  `xor:"RecordCount" help:"Generate this number of result files with potential empty ones"`
+	NameFormat   string `help:"Format to populate target file names" default:"result-%06d.parquet"`
+	ReadPageSize int    `help:"Page size to read from Parquet." default:"1000"`
+	RecordCount  int64  `xor:"FileCount" help:"Result files will have at most this number of records"`
+	URI          string `arg:"" predictor:"file" help:"URI of Parquet file."`
 	pio.ReadOption
 	pio.WriteOption
-	ReadPageSize int    `help:"Page size to read from Parquet." default:"1000"`
-	URI          string `arg:"" predictor:"file" help:"URI of Parquet file."`
-	FileCount    int64  `xor:"RecordCount" help:"Generate this number of result files with potential empty ones"`
-	RecordCount  int64  `xor:"FileCount" help:"Result files will have at most this number of records"`
-	FailOnInt96  bool   `help:"Fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
-	NameFormat   string `help:"Format to populate target file names" default:"result-%06d.parquet"`
 
 	current TrunkWriter
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -12,14 +12,14 @@ func Test_versionCmd(t *testing.T) {
 		cmd    VersionCmd
 		stdout string
 	}{
-		"plain":             {cmd: VersionCmd{false, false, false, false}, stdout: "v1.2.3\n"},
-		"plain-with-build":  {cmd: VersionCmd{false, false, true, false}, stdout: "v1.2.3\ntoday\n"},
-		"plain-with-source": {cmd: VersionCmd{false, false, false, true}, stdout: "v1.2.3\nUT\n"},
-		"plain-with-all":    {cmd: VersionCmd{false, true, false, false}, stdout: "v1.2.3\ntoday\nUT\n"},
-		"json":              {cmd: VersionCmd{true, false, false, false}, stdout: `{"Version":"v1.2.3"}` + "\n"},
-		"json-with-build":   {cmd: VersionCmd{true, false, true, false}, stdout: `{"Version":"v1.2.3","BuildTime":"today"}` + "\n"},
-		"json-with-source":  {cmd: VersionCmd{true, false, false, true}, stdout: `{"Version":"v1.2.3","Source":"UT"}` + "\n"},
-		"json-with-all":     {cmd: VersionCmd{true, true, false, false}, stdout: `{"Version":"v1.2.3","BuildTime":"today","Source":"UT"}` + "\n"},
+		"plain":             {cmd: VersionCmd{JSON: false, All: false, BuildTime: false, Source: false}, stdout: "v1.2.3\n"},
+		"plain-with-build":  {cmd: VersionCmd{JSON: false, All: false, BuildTime: true, Source: false}, stdout: "v1.2.3\ntoday\n"},
+		"plain-with-source": {cmd: VersionCmd{JSON: false, All: false, BuildTime: false, Source: true}, stdout: "v1.2.3\nUT\n"},
+		"plain-with-all":    {cmd: VersionCmd{JSON: false, All: true, BuildTime: false, Source: false}, stdout: "v1.2.3\ntoday\nUT\n"},
+		"json":              {cmd: VersionCmd{JSON: true, All: false, BuildTime: false, Source: false}, stdout: `{"Version":"v1.2.3"}` + "\n"},
+		"json-with-build":   {cmd: VersionCmd{JSON: true, All: false, BuildTime: true, Source: false}, stdout: `{"Version":"v1.2.3","BuildTime":"today"}` + "\n"},
+		"json-with-source":  {cmd: VersionCmd{JSON: true, All: false, BuildTime: false, Source: true}, stdout: `{"Version":"v1.2.3","Source":"UT"}` + "\n"},
+		"json-with-all":     {cmd: VersionCmd{JSON: true, All: true, BuildTime: false, Source: false}, stdout: `{"Version":"v1.2.3","BuildTime":"today","Source":"UT"}` + "\n"},
 	}
 
 	version = "v1.2.3"

--- a/internal/io/reader.go
+++ b/internal/io/reader.go
@@ -24,11 +24,11 @@ import (
 
 // ReadOption includes options for read operation
 type ReadOption struct {
-	HTTPMultipleConnection bool              `help:"(HTTP URI only) use multiple HTTP connection." default:"false"`
-	HTTPIgnoreTLSError     bool              `help:"(HTTP URI only) ignore TLS error." default:"false"`
-	HTTPExtraHeaders       map[string]string `mapsep:"," help:"(HTTP URI only) extra HTTP headers." default:""`
-	ObjectVersion          string            `help:"(S3, GCS, and Azure only) object version." default:""`
 	Anonymous              bool              `help:"(S3, GCS, and Azure only) object is publicly accessible." default:"false"`
+	HTTPExtraHeaders       map[string]string `mapsep:"," help:"(HTTP URI only) extra HTTP headers." default:""`
+	HTTPIgnoreTLSError     bool              `help:"(HTTP URI only) ignore TLS error." default:"false"`
+	HTTPMultipleConnection bool              `help:"(HTTP URI only) use multiple HTTP connection." default:"false"`
+	ObjectVersion          string            `help:"(S3, GCS, and Azure only) object version." default:""`
 }
 
 func newLocalReader(u *url.URL, option ReadOption) (source.ParquetFileReader, error) {


### PR DESCRIPTION
1. Options for commands are not in order which make it hard to read and maintain whenever they are getting long, this PR change them to alphabetic order.
2. Move IO related options to end of the above list, as they are used less frequently.
   * still want to find a way to add a newline between command options and IO options ....
4. Update tests to use named field to make it easier to add more fields
5. update README