### PR TITLE
build(deps): bump parquet-go to v3.3.1, add type constraint negative tests

### DIFF
--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -152,6 +152,18 @@ func TestCmd(t *testing.T) {
 				Cmd{WriteOption: wOpt, Source: "../../testdata/unknown-type-bad.csv", Format: "csv", Schema: "../../testdata/unknown-type-csv.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
 				"UNKNOWN column",
 			},
+			"csv-invalid-logical-type": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/csv.source", Format: "csv", Schema: "../../testdata/invalid-logical-type.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
+				"LogicalType DECIMAL can only be used",
+			},
+			"json-invalid-logical-type": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/json.source", Format: "json", Schema: "../../testdata/invalid-logical-type-json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
+				"LogicalType DECIMAL can only be used",
+			},
+			"jsonl-invalid-logical-type": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "jsonl", Schema: "../../testdata/invalid-logical-type-json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
+				"LogicalType DECIMAL can only be used",
+			},
 		}
 
 		for name, tc := range testCases {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.25
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0
 	github.com/google/uuid v1.6.0
-	github.com/hangxie/parquet-go/v3 v3.3.0
+	github.com/hangxie/parquet-go/v3 v3.3.1
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.11.1
 	github.com/willabides/kongplete v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyC
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
-github.com/hangxie/parquet-go/v3 v3.3.0 h1:FhqLQfXSoSXRllJEyHb4Ja/SuGd/Y9gETU9cAtxlhjg=
-github.com/hangxie/parquet-go/v3 v3.3.0/go.mod h1:CtE+uU+m/wfqlA1Y6zoMLwqcQaLl8KWJWmNZ+pFCqdY=
+github.com/hangxie/parquet-go/v3 v3.3.1 h1:LKBFAXdM3Cj8NHj39gNGo1OCsQA1SpYDlt62Vap3ecQ=
+github.com/hangxie/parquet-go/v3 v3.3.1/go.mod h1:CtE+uU+m/wfqlA1Y6zoMLwqcQaLl8KWJWmNZ+pFCqdY=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/io/writer_test.go
+++ b/io/writer_test.go
@@ -460,6 +460,30 @@ func TestNewCSVWriter(t *testing.T) {
 			[]string{"name=Id, type=INT64"},
 			"",
 		},
+		"invalid-schema-decimal-float": {
+			wOpt,
+			tempFile,
+			[]string{"name=val, type=FLOAT, convertedtype=DECIMAL, scale=2, precision=9"},
+			"LogicalType DECIMAL can only be used",
+		},
+		"invalid-schema-date-int64": {
+			wOpt,
+			tempFile,
+			[]string{"name=val, type=INT64, logicaltype=DATE"},
+			"LogicalType DATE can only be used with INT32",
+		},
+		"invalid-schema-timestamp-int32": {
+			wOpt,
+			tempFile,
+			[]string{"name=val, type=INT32, logicaltype=TIMESTAMP, logicaltype.isadjustedtoutc=true, logicaltype.unit=MILLIS"},
+			"LogicalType TIMESTAMP can only be used with INT64",
+		},
+		"invalid-schema-float16-byte-array": {
+			wOpt,
+			tempFile,
+			[]string{"name=val, type=BYTE_ARRAY, logicaltype=FLOAT16"},
+			"LogicalType FLOAT16 can only be used with FIXED_LEN_BYTE_ARRAY",
+		},
 		"column-key-parse-error": {
 			WriteOption{
 				WriterFooterKey:  testWriterKeyBase64(16),
@@ -753,6 +777,30 @@ func TestNewGenericWriter(t *testing.T) {
 			WriteOption{CompressionCodec: "GZIP"},
 			schema,
 			"",
+		},
+		"schema-decimal-float": {
+			tempFile,
+			WriteOption{},
+			`{"Tag":"name=root","Fields":[{"Tag":"name=val, type=FLOAT, convertedtype=DECIMAL, scale=2, precision=9"}]}`,
+			"LogicalType DECIMAL can only be used",
+		},
+		"schema-date-int64": {
+			tempFile,
+			WriteOption{},
+			`{"Tag":"name=root","Fields":[{"Tag":"name=val, type=INT64, logicaltype=DATE"}]}`,
+			"LogicalType DATE can only be used with INT32",
+		},
+		"schema-timestamp-int32": {
+			tempFile,
+			WriteOption{},
+			`{"Tag":"name=root","Fields":[{"Tag":"name=val, type=INT32, logicaltype=TIMESTAMP, logicaltype.isadjustedtoutc=true, logicaltype.unit=MILLIS"}]}`,
+			"LogicalType TIMESTAMP can only be used with INT64",
+		},
+		"schema-float16-byte-array": {
+			tempFile,
+			WriteOption{},
+			`{"Tag":"name=root","Fields":[{"Tag":"name=val, type=BYTE_ARRAY, logicaltype=FLOAT16"}]}`,
+			"LogicalType FLOAT16 can only be used with FIXED_LEN_BYTE_ARRAY",
 		},
 		"column-key-parse-error": {
 			tempFile,

--- a/testdata/invalid-logical-type-json.schema
+++ b/testdata/invalid-logical-type-json.schema
@@ -1,0 +1,8 @@
+{
+  "Tag": "name=parquet-go-root",
+  "Fields": [
+    {
+      "Tag": "name=val, type=FLOAT, convertedtype=DECIMAL, scale=2, precision=9"
+    }
+  ]
+}

--- a/testdata/invalid-logical-type.schema
+++ b/testdata/invalid-logical-type.schema
@@ -1,0 +1,1 @@
+name=val, type=FLOAT, convertedtype=DECIMAL, scale=2, precision=9


### PR DESCRIPTION
## Summary

- Bump `github.com/hangxie/parquet-go/v3` from v3.3.0 to v3.3.1
- Add negative test cases for the new logical type physical constraint enforcement

## Background

parquet-go v3.3.1 ships `fix(schema): enforce logical type physical constraints`, which rejects invalid schema combinations at write time:
- `DECIMAL` (logical/converted) requires INT32, INT64, BYTE\_ARRAY, or FIXED\_LEN\_BYTE\_ARRAY
- `DATE` requires INT32; `TIMESTAMP` requires INT64
- `FLOAT16` requires FIXED\_LEN\_BYTE\_ARRAY
- `STRING`/`JSON`/`BSON`/`ENUM` require BYTE\_ARRAY; `UUID`/`GEOMETRY`/`GEOGRAPHY` require their respective fixed types

All existing tests pass unchanged — the existing test data and gen files already use valid physical types.

## Test plan

- [ ] `make all` passes (all 14 packages green)
- [ ] `TestNewCSVWriter`: 4 new invalid-schema cases catch the enforcement errors at the writer unit level
- [ ] `TestNewGenericWriter`: 4 new invalid-schema cases for the JSON schema path
- [ ] `cmd/import` error cases: `csv-invalid-logical-type`, `json-invalid-logical-type`, `jsonl-invalid-logical-type` verify end-to-end error propagation for all three import formats