### PR TITLE
test: expand one-line map entries to multi-line format

### DIFF
--- a/cmd/cat/cat_test.go
+++ b/cmd/cat/cat_test.go
@@ -28,53 +28,188 @@ func TestCmd(t *testing.T) {
 		errMsg string
 	}{
 		// error cases
-		"non-existent-file":                 {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "file/does/not/exist"}, errMsg: "no such file or directory"},
-		"parquet-1481":                      {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "../../testdata/PARQUET-1481.parquet"}, errMsg: "unknown parquet type: <UNSET>"},
-		"arrow-rs-gh-6229":                  {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "../../testdata/ARROW-RS-GH-6229-LEVELS.parquet"}, errMsg: "expected 21 values but got 1 from RLE/bit-packed hybrid decoder"},
-		"invalid-read-page-size":            {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 0, SampleRatio: 0.5, Format: "json", NoHeader: false, URI: "does/not/matter", Concurrent: true}, errMsg: "invalid read page size"},
-		"invalid-skip-size":                 {cmd: Cmd{ReadOption: rOpt, Skip: -10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "json", NoHeader: false, URI: "does/not/matter"}, errMsg: "invalid skip -10"},
-		"sampling-too-high":                 {cmd: Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 2.0, Format: "json", NoHeader: false, URI: "does/not/matter", Concurrent: true}, errMsg: "invalid sampling"},
-		"sampling-too-low":                  {cmd: Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: -0.5, Format: "json", NoHeader: false, URI: "does/not/matter"}, errMsg: "invalid sampling"},
-		"invalid-format":                    {cmd: Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "foobar", NoHeader: false, URI: "does/not/matter"}, errMsg: "unknown format: [foobar]"},
-		"fail-on-int96":                     {cmd: Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "json", NoHeader: true, URI: "../../testdata/all-types.parquet", FailOnInt96: true}, errMsg: "type INT96 which is not supported"},
-		"nested-schema-csv":                 {cmd: Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "csv", NoHeader: true, URI: "../../testdata/all-types.parquet"}, errMsg: "field [Variant] is not scalar type"},
-		"nested-schema-tsv":                 {cmd: Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "tsv", NoHeader: true, URI: "../../testdata/all-types.parquet"}, errMsg: "field [Variant] is not scalar type"},
-		"geospatial-csv":                    {cmd: Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "csv", NoHeader: true, URI: "../../testdata/geospatial.parquet"}, errMsg: "field [Geometry] is not scalar type"},
-		"geospatial-tsv":                    {cmd: Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "tsv", NoHeader: true, URI: "../../testdata/geospatial.parquet"}, errMsg: "field [Geometry] is not scalar type"},
-		"nan-json-error":                    {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "../../testdata/nan.parquet"}, errMsg: "json: unsupported value: NaN"},
-		"arrow-gh-41321":                    {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "../../testdata/ARROW-GH-41321.parquet"}, errMsg: "failed to cat"},
-		"concurrent-non-existent":           {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "file/does/not/exist", Concurrent: true}, errMsg: "no such file or directory"},
-		"concurrent-nan-json":               {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "../../testdata/nan.parquet", Concurrent: true}, errMsg: "json: unsupported value: NaN"},
-		"concurrent-int96":                  {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "json", NoHeader: true, URI: "../../testdata/all-types.parquet", Concurrent: true, FailOnInt96: true}, errMsg: "type INT96 which is not supported"},
-		"concurrent-nested-csv":             {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "csv", NoHeader: true, URI: "../../testdata/all-types.parquet", Concurrent: true}, errMsg: "is not scalar type"},
-		"encrypted-footer-no-key":           {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", URI: "../../testdata/encrypted-footer.parquet"}, errMsg: "decryption key required for footer"},
-		"encrypted-footer-wrong-key":        {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, Skip: 0, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", URI: "../../testdata/encrypted-footer.parquet"}, errMsg: "decrypt"},
-		"encrypted-columns-missing-col-key": {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, Skip: 0, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", URI: "../../testdata/encrypted-columns.parquet"}, errMsg: "decryption key required for column"},
-		"encrypted-aad-missing":             {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, Skip: 0, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", URI: "../../testdata/encrypted-aad.parquet"}, errMsg: "AAD prefix"},
+		"non-existent-file": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "file/does/not/exist"},
+			errMsg: "no such file or directory",
+		},
+		"parquet-1481": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "../../testdata/PARQUET-1481.parquet"},
+			errMsg: "unknown parquet type: <UNSET>",
+		},
+		"arrow-rs-gh-6229": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "../../testdata/ARROW-RS-GH-6229-LEVELS.parquet"},
+			errMsg: "expected 21 values but got 1 from RLE/bit-packed hybrid decoder",
+		},
+		"invalid-read-page-size": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 0, SampleRatio: 0.5, Format: "json", NoHeader: false, URI: "does/not/matter", Concurrent: true},
+			errMsg: "invalid read page size",
+		},
+		"invalid-skip-size": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: -10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "json", NoHeader: false, URI: "does/not/matter"},
+			errMsg: "invalid skip -10",
+		},
+		"sampling-too-high": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 2.0, Format: "json", NoHeader: false, URI: "does/not/matter", Concurrent: true},
+			errMsg: "invalid sampling",
+		},
+		"sampling-too-low": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: -0.5, Format: "json", NoHeader: false, URI: "does/not/matter"},
+			errMsg: "invalid sampling",
+		},
+		"invalid-format": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "foobar", NoHeader: false, URI: "does/not/matter"},
+			errMsg: "unknown format: [foobar]",
+		},
+		"fail-on-int96": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "json", NoHeader: true, URI: "../../testdata/all-types.parquet", FailOnInt96: true},
+			errMsg: "type INT96 which is not supported",
+		},
+		"nested-schema-csv": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "csv", NoHeader: true, URI: "../../testdata/all-types.parquet"},
+			errMsg: "field [Variant] is not scalar type",
+		},
+		"nested-schema-tsv": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "tsv", NoHeader: true, URI: "../../testdata/all-types.parquet"},
+			errMsg: "field [Variant] is not scalar type",
+		},
+		"geospatial-csv": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "csv", NoHeader: true, URI: "../../testdata/geospatial.parquet"},
+			errMsg: "field [Geometry] is not scalar type",
+		},
+		"geospatial-tsv": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 10, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "tsv", NoHeader: true, URI: "../../testdata/geospatial.parquet"},
+			errMsg: "field [Geometry] is not scalar type",
+		},
+		"nan-json-error": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "../../testdata/nan.parquet"},
+			errMsg: "json: unsupported value: NaN",
+		},
+		"arrow-gh-41321": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "../../testdata/ARROW-GH-41321.parquet"},
+			errMsg: "failed to cat",
+		},
+		"concurrent-non-existent": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "file/does/not/exist", Concurrent: true},
+			errMsg: "no such file or directory",
+		},
+		"concurrent-nan-json": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "../../testdata/nan.parquet", Concurrent: true},
+			errMsg: "json: unsupported value: NaN",
+		},
+		"concurrent-int96": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "json", NoHeader: true, URI: "../../testdata/all-types.parquet", Concurrent: true, FailOnInt96: true},
+			errMsg: "type INT96 which is not supported",
+		},
+		"concurrent-nested-csv": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 10, ReadPageSize: 10, SampleRatio: 0.5, Format: "csv", NoHeader: true, URI: "../../testdata/all-types.parquet", Concurrent: true},
+			errMsg: "is not scalar type",
+		},
+		"encrypted-footer-no-key": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", URI: "../../testdata/encrypted-footer.parquet"},
+			errMsg: "decryption key required for footer",
+		},
+		"encrypted-footer-wrong-key": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, Skip: 0, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", URI: "../../testdata/encrypted-footer.parquet"},
+			errMsg: "decrypt",
+		},
+		"encrypted-columns-missing-col-key": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, Skip: 0, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", URI: "../../testdata/encrypted-columns.parquet"},
+			errMsg: "decryption key required for column",
+		},
+		"encrypted-aad-missing": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, Skip: 0, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", URI: "../../testdata/encrypted-aad.parquet"},
+			errMsg: "AAD prefix",
+		},
 
 		// good cases
-		"default":            {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "good.parquet"}, golden: "cat-good-json.json"},
-		"limit-0":            {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "good.parquet"}, golden: "cat-good-json.json"},
-		"limit-2":            {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 2, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "good.parquet"}, golden: "cat-good-json-limit-2.json"},
-		"skip-2":             {cmd: Cmd{ReadOption: rOpt, Skip: 2, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "good.parquet", Concurrent: true}, golden: "cat-good-json-skip-2.json"},
-		"skip-all":           {cmd: Cmd{ReadOption: rOpt, Skip: 20, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "good.parquet"}, golden: "empty-json.txt"},
-		"sampling-0":         {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 0.0, Format: "json", NoHeader: false, URI: "good.parquet"}, golden: "empty-json.txt"},
-		"empty":              {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "empty.parquet"}, golden: "empty-json.txt"},
-		"jsonl":              {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: false, URI: "good.parquet"}, golden: "cat-good-jsonl.jsonl"},
-		"csv":                {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "csv", NoHeader: false, URI: "good.parquet"}, golden: "cat-good-csv.txt"},
-		"csv-no-header":      {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "csv", NoHeader: true, URI: "good.parquet"}, golden: "cat-good-csv-no-header.txt"},
-		"tsv":                {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "tsv", NoHeader: false, URI: "good.parquet"}, golden: "cat-good-tsv.txt"},
-		"tsv-no-header":      {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "tsv", NoHeader: true, URI: "good.parquet"}, golden: "cat-good-tsv-no-header.txt"},
-		"all-types":          {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "all-types.parquet"}, golden: "cat-all-types.jsonl"},
-		"geospatial-hex":     {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", GeoFormat: "hex", NoHeader: true, URI: "geospatial.parquet"}, golden: "cat-geospatial-hex.jsonl"},
-		"geospatial-base64":  {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", GeoFormat: "base64", NoHeader: true, URI: "geospatial.parquet"}, golden: "cat-geospatial-base64.jsonl"},
-		"geospatial-geojson": {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "geospatial.parquet"}, golden: "cat-geospatial-geojson.jsonl"},
-		"old-style-list":     {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "old-style-list.parquet"}, golden: "cat-old-style-list.jsonl"},
-		"multi-row-groups":   {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "row-group.parquet"}, golden: "cat-row-group.jsonl"},
-		"dict-page":          {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "dict-page.parquet"}, golden: "cat-dict-page.jsonl"},
-		"high-compression":   {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "high-compression.parquet"}, golden: "cat-high-compression.jsonl"},
-		"unknown-type":       {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "unknown-type.parquet"}, golden: "cat-unknown-type.jsonl"},
-		"unknown-type-raw":   {cmd: Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "unknown-type.parquet", RawUnknown: true}, golden: "cat-unknown-type-raw.jsonl"},
+		"default": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "good.parquet"},
+			golden: "cat-good-json.json",
+		},
+		"limit-0": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "good.parquet"},
+			golden: "cat-good-json.json",
+		},
+		"limit-2": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 2, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "good.parquet"},
+			golden: "cat-good-json-limit-2.json",
+		},
+		"skip-2": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 2, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "good.parquet", Concurrent: true},
+			golden: "cat-good-json-skip-2.json",
+		},
+		"skip-all": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 20, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "good.parquet"},
+			golden: "empty-json.txt",
+		},
+		"sampling-0": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 0.0, Format: "json", NoHeader: false, URI: "good.parquet"},
+			golden: "empty-json.txt",
+		},
+		"empty": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "json", NoHeader: false, URI: "empty.parquet"},
+			golden: "empty-json.txt",
+		},
+		"jsonl": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: false, URI: "good.parquet"},
+			golden: "cat-good-jsonl.jsonl",
+		},
+		"csv": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "csv", NoHeader: false, URI: "good.parquet"},
+			golden: "cat-good-csv.txt",
+		},
+		"csv-no-header": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "csv", NoHeader: true, URI: "good.parquet"},
+			golden: "cat-good-csv-no-header.txt",
+		},
+		"tsv": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "tsv", NoHeader: false, URI: "good.parquet"},
+			golden: "cat-good-tsv.txt",
+		},
+		"tsv-no-header": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "tsv", NoHeader: true, URI: "good.parquet"},
+			golden: "cat-good-tsv-no-header.txt",
+		},
+		"all-types": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "all-types.parquet"},
+			golden: "cat-all-types.jsonl",
+		},
+		"geospatial-hex": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", GeoFormat: "hex", NoHeader: true, URI: "geospatial.parquet"},
+			golden: "cat-geospatial-hex.jsonl",
+		},
+		"geospatial-base64": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", GeoFormat: "base64", NoHeader: true, URI: "geospatial.parquet"},
+			golden: "cat-geospatial-base64.jsonl",
+		},
+		"geospatial-geojson": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "geospatial.parquet"},
+			golden: "cat-geospatial-geojson.jsonl",
+		},
+		"old-style-list": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "old-style-list.parquet"},
+			golden: "cat-old-style-list.jsonl",
+		},
+		"multi-row-groups": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "row-group.parquet"},
+			golden: "cat-row-group.jsonl",
+		},
+		"dict-page": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "dict-page.parquet"},
+			golden: "cat-dict-page.jsonl",
+		},
+		"high-compression": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "high-compression.parquet"},
+			golden: "cat-high-compression.jsonl",
+		},
+		"unknown-type": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "unknown-type.parquet"},
+			golden: "cat-unknown-type.jsonl",
+		},
+		"unknown-type-raw": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "unknown-type.parquet", RawUnknown: true},
+			golden: "cat-unknown-type-raw.jsonl",
+		},
 	}
 
 	for name, tc := range testCases {

--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -52,31 +52,106 @@ func TestCmd(t *testing.T) {
 			cmd    Cmd
 			errMsg string
 		}{
-			"write-format":          {Cmd{WriteOption: wOpt, Source: "src", Format: "random", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "dummy"}, "is not a recognized source format"},
-			"write-compression":     {Cmd{WriteOption: pio.WriteOption{CompressionCodec: "foobar"}, Source: "../../testdata/json.source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "not a valid CompressionCodec string"},
-			"csv-schema-file":       {Cmd{WriteOption: wOpt, Source: "does/not/exist", Format: "csv", Schema: "schema", SkipHeader: false, URI: "dummy"}, "failed to load schema from"},
-			"csv-source-file":       {Cmd{WriteOption: wOpt, Source: "file/does/not/exist", Format: "csv", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "dummy"}, "failed to open CSV file"},
-			"csv-target-file":       {Cmd{WriteOption: wOpt, Source: "../../testdata/csv.source", Format: "csv", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "://uri"}, "unable to parse file location"},
-			"csv-schema":            {Cmd{WriteOption: wOpt, Source: "../../testdata/csv.source", Format: "csv", Schema: "../../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "expect 'key=value' but got '{'"},
-			"csv-source":            {Cmd{WriteOption: wOpt, Source: "../../testdata/json.source", Format: "csv", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "failed to read CSV record from"},
-			"csv-malformed":         {Cmd{WriteOption: wOpt, Source: "../../testdata/csv-malformed.source", Format: "csv", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "failed to read CSV record from"},
-			"csv-target":            {Cmd{WriteOption: wOpt, Source: "../../testdata/csv.source", Format: "csv", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "s3://target"}, "failed to close Parquet file"},
-			"json-schema-file":      {Cmd{WriteOption: wOpt, Source: "does/not/exist", Format: "json", Schema: "schema", SkipHeader: false, URI: "dummy"}, "failed to load schema from"},
-			"json-source-file":      {Cmd{WriteOption: wOpt, Source: "file/does/not/exist", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: "dummy"}, "failed to load source from"},
-			"json-target-file":      {Cmd{WriteOption: wOpt, Source: "../../testdata/json.source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: "://uri"}, "unable to parse file location"},
-			"json-schema":           {Cmd{WriteOption: wOpt, Source: "../../testdata/json.source", Format: "json", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "dummy"}, "is not a valid schema JSON"},
-			"json-source":           {Cmd{WriteOption: wOpt, Source: "../../testdata/csv.source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: "dummy"}, "is not a valid JSON array"},
-			"json-source-not-array": {Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: "dummy"}, "is not a valid JSON array"},
-			"json-target":           {Cmd{WriteOption: wOpt, Source: "../../testdata/json.source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: "s3://target"}, "failed to close Parquet file"},
-			"json-schema-mismatch":  {Cmd{WriteOption: wOpt, Source: "../../testdata/json.bad-source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "failed to close Parquet writer"},
-			"jsonl-schema-file":     {Cmd{WriteOption: wOpt, Source: "does/not/exist", Format: "jsonl", Schema: "schema", SkipHeader: false, URI: "dummy"}, "failed to load schema from"},
-			"jsonl-source-file":     {Cmd{WriteOption: wOpt, Source: "file/does/not/exist", Format: "jsonl", Schema: "../../testdata/jsonl.schema", SkipHeader: false, URI: "dummy"}, "failed to open source file"},
-			"jsonl-target-file":     {Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "jsonl", Schema: "../../testdata/jsonl.schema", SkipHeader: false, URI: "://uri"}, "unable to parse file location"},
-			"jsonl-schema":          {Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "jsonl", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "dummy"}, "is not a valid schema JSON"},
-			"jsonl-source":          {Cmd{WriteOption: wOpt, Source: "../../testdata/csv.source", Format: "jsonl", Schema: "../../testdata/jsonl.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "invalid JSON string:"},
-			"jsonl-target":          {Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "jsonl", Schema: "../../testdata/jsonl.schema", SkipHeader: false, URI: "s3://target"}, "failed to close Parquet file"},
-			"jsonl-schema-mismatch": {Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "jsonl", Schema: "../../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "failed to close Parquet writer"},
-			"csv-unknown-not-nil":   {Cmd{WriteOption: wOpt, Source: "../../testdata/unknown-type-bad.csv", Format: "csv", Schema: "../../testdata/unknown-type-csv.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")}, "UNKNOWN column"},
+			"write-format": {
+				Cmd{WriteOption: wOpt, Source: "src", Format: "random", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "dummy"},
+				"is not a recognized source format",
+			},
+			"write-compression": {
+				Cmd{WriteOption: pio.WriteOption{CompressionCodec: "foobar"}, Source: "../../testdata/json.source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
+				"not a valid CompressionCodec string",
+			},
+			"csv-schema-file": {
+				Cmd{WriteOption: wOpt, Source: "does/not/exist", Format: "csv", Schema: "schema", SkipHeader: false, URI: "dummy"},
+				"failed to load schema from",
+			},
+			"csv-source-file": {
+				Cmd{WriteOption: wOpt, Source: "file/does/not/exist", Format: "csv", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "dummy"},
+				"failed to open CSV file",
+			},
+			"csv-target-file": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/csv.source", Format: "csv", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "://uri"},
+				"unable to parse file location",
+			},
+			"csv-schema": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/csv.source", Format: "csv", Schema: "../../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
+				"expect 'key=value' but got '{'",
+			},
+			"csv-source": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/json.source", Format: "csv", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
+				"failed to read CSV record from",
+			},
+			"csv-malformed": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/csv-malformed.source", Format: "csv", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
+				"failed to read CSV record from",
+			},
+			"csv-target": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/csv.source", Format: "csv", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "s3://target"},
+				"failed to close Parquet file",
+			},
+			"json-schema-file": {
+				Cmd{WriteOption: wOpt, Source: "does/not/exist", Format: "json", Schema: "schema", SkipHeader: false, URI: "dummy"},
+				"failed to load schema from",
+			},
+			"json-source-file": {
+				Cmd{WriteOption: wOpt, Source: "file/does/not/exist", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: "dummy"},
+				"failed to load source from",
+			},
+			"json-target-file": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/json.source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: "://uri"},
+				"unable to parse file location",
+			},
+			"json-schema": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/json.source", Format: "json", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "dummy"},
+				"is not a valid schema JSON",
+			},
+			"json-source": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/csv.source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: "dummy"},
+				"is not a valid JSON array",
+			},
+			"json-source-not-array": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: "dummy"},
+				"is not a valid JSON array",
+			},
+			"json-target": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/json.source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: "s3://target"},
+				"failed to close Parquet file",
+			},
+			"json-schema-mismatch": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/json.bad-source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
+				"failed to close Parquet writer",
+			},
+			"jsonl-schema-file": {
+				Cmd{WriteOption: wOpt, Source: "does/not/exist", Format: "jsonl", Schema: "schema", SkipHeader: false, URI: "dummy"},
+				"failed to load schema from",
+			},
+			"jsonl-source-file": {
+				Cmd{WriteOption: wOpt, Source: "file/does/not/exist", Format: "jsonl", Schema: "../../testdata/jsonl.schema", SkipHeader: false, URI: "dummy"},
+				"failed to open source file",
+			},
+			"jsonl-target-file": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "jsonl", Schema: "../../testdata/jsonl.schema", SkipHeader: false, URI: "://uri"},
+				"unable to parse file location",
+			},
+			"jsonl-schema": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "jsonl", Schema: "../../testdata/csv.schema", SkipHeader: false, URI: "dummy"},
+				"is not a valid schema JSON",
+			},
+			"jsonl-source": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/csv.source", Format: "jsonl", Schema: "../../testdata/jsonl.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
+				"invalid JSON string:",
+			},
+			"jsonl-target": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "jsonl", Schema: "../../testdata/jsonl.schema", SkipHeader: false, URI: "s3://target"},
+				"failed to close Parquet file",
+			},
+			"jsonl-schema-mismatch": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "jsonl", Schema: "../../testdata/json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
+				"failed to close Parquet writer",
+			},
+			"csv-unknown-not-nil": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/unknown-type-bad.csv", Format: "csv", Schema: "../../testdata/unknown-type-csv.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
+				"UNKNOWN column",
+			},
 		}
 
 		for name, tc := range testCases {
@@ -99,11 +174,26 @@ func TestCmd(t *testing.T) {
 			cmd      Cmd
 			rowCount int64
 		}{
-			"csv-wo-header": {Cmd{WriteOption: wOpt, Source: "csv.source", Format: "csv", Schema: "csv.schema", SkipHeader: false, URI: ""}, 10},
-			"csv-w-header":  {Cmd{WriteOption: wOpt, Source: "csv-with-header.source", Format: "csv", Schema: "csv.schema", SkipHeader: true, URI: ""}, 10},
-			"json":          {Cmd{WriteOption: wOpt, Source: "json.source", Format: "json", Schema: "json.schema", SkipHeader: false, URI: ""}, 1},
-			"jsonl":         {Cmd{WriteOption: wOpt, Source: "jsonl.source", Format: "jsonl", Schema: "jsonl.schema", SkipHeader: false, URI: ""}, 10},
-			"json-unknown":  {Cmd{WriteOption: wOpt, Source: "unknown-type-json.source", Format: "json", Schema: "unknown-type.schema", SkipHeader: false, URI: ""}, 3},
+			"csv-wo-header": {
+				Cmd{WriteOption: wOpt, Source: "csv.source", Format: "csv", Schema: "csv.schema", SkipHeader: false, URI: ""},
+				10,
+			},
+			"csv-w-header": {
+				Cmd{WriteOption: wOpt, Source: "csv-with-header.source", Format: "csv", Schema: "csv.schema", SkipHeader: true, URI: ""},
+				10,
+			},
+			"json": {
+				Cmd{WriteOption: wOpt, Source: "json.source", Format: "json", Schema: "json.schema", SkipHeader: false, URI: ""},
+				1,
+			},
+			"jsonl": {
+				Cmd{WriteOption: wOpt, Source: "jsonl.source", Format: "jsonl", Schema: "jsonl.schema", SkipHeader: false, URI: ""},
+				10,
+			},
+			"json-unknown": {
+				Cmd{WriteOption: wOpt, Source: "unknown-type-json.source", Format: "json", Schema: "unknown-type.schema", SkipHeader: false, URI: ""},
+				3,
+			},
 		}
 
 		tempDir := t.TempDir()

--- a/cmd/inspect/inspect_test.go
+++ b/cmd/inspect/inspect_test.go
@@ -32,61 +32,217 @@ func TestInspect(t *testing.T) {
 		errMsg string
 	}{
 		// file level
-		"file/good":                      {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet"}, golden: "inspect-good-file.json"},
-		"file/encrypted-no-key":          {cmd: Cmd{ReadOption: rOpt, URI: "encrypted-footer.parquet"}, errMsg: "decryption key required for footer"},
-		"file/encrypted-wrong-key":       {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, URI: "encrypted-footer.parquet"}, errMsg: "decrypt"},
-		"file/encrypted-columns":         {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, URI: "encrypted-columns.parquet"}, golden: "inspect-enc-columns-file.json"},
-		"file/encrypted-columns-no-keys": {cmd: Cmd{ReadOption: rOpt, URI: "encrypted-columns.parquet"}, golden: "inspect-enc-columns-file.json"},
-		"file/encrypted-footer":          {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, URI: "encrypted-footer.parquet"}, golden: "inspect-enc-footer-file.json"},
-		"file/encrypted-uniform":         {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "uniform-encryption.parquet"}, golden: "inspect-enc-uniform-file.json"},
-		"file/dict-page":                 {cmd: Cmd{ReadOption: rOpt, URI: "dict-page.parquet"}, golden: "inspect-dict-page-file.json"},
-		"file/row-group":                 {cmd: Cmd{ReadOption: rOpt, URI: "row-group.parquet"}, golden: "inspect-row-group-file.json"},
-		"file/non-existent":              {cmd: Cmd{ReadOption: rOpt, URI: "nonexistent.parquet"}, errMsg: "no such file or directory"},
+		"file/good": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet"},
+			golden: "inspect-good-file.json",
+		},
+		"file/encrypted-no-key": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "encrypted-footer.parquet"},
+			errMsg: "decryption key required for footer",
+		},
+		"file/encrypted-wrong-key": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, URI: "encrypted-footer.parquet"},
+			errMsg: "decrypt",
+		},
+		"file/encrypted-columns": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, URI: "encrypted-columns.parquet"},
+			golden: "inspect-enc-columns-file.json",
+		},
+		"file/encrypted-columns-no-keys": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "encrypted-columns.parquet"},
+			golden: "inspect-enc-columns-file.json",
+		},
+		"file/encrypted-footer": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, URI: "encrypted-footer.parquet"},
+			golden: "inspect-enc-footer-file.json",
+		},
+		"file/encrypted-uniform": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "uniform-encryption.parquet"},
+			golden: "inspect-enc-uniform-file.json",
+		},
+		"file/dict-page": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "dict-page.parquet"},
+			golden: "inspect-dict-page-file.json",
+		},
+		"file/row-group": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "row-group.parquet"},
+			golden: "inspect-row-group-file.json",
+		},
+		"file/non-existent": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "nonexistent.parquet"},
+			errMsg: "no such file or directory",
+		},
 		// row group level
-		"row-group/good-rg-0":                     {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0)}, golden: "inspect-good-rg0.json"},
-		"row-group/encrypted-columns-rg0":         {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, URI: "encrypted-columns.parquet", RowGroup: new(0)}, golden: "inspect-enc-columns-rg0.json"},
-		"row-group/encrypted-columns-no-keys-rg0": {cmd: Cmd{ReadOption: rOpt, URI: "encrypted-columns.parquet", RowGroup: new(0)}, golden: "inspect-enc-columns-no-keys-rg0.json"},
-		"row-group/encrypted-uniform-rg0":         {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "uniform-encryption.parquet", RowGroup: new(0)}, golden: "inspect-enc-uniform-rg0.json"},
-		"row-group/row-group-rg-0":                {cmd: Cmd{ReadOption: rOpt, URI: "row-group.parquet", RowGroup: new(0)}, golden: "inspect-row-group-rg0.json"},
-		"row-group/row-group-rg-1":                {cmd: Cmd{ReadOption: rOpt, URI: "row-group.parquet", RowGroup: new(1)}, golden: "inspect-row-group-rg1.json"},
-		"row-group/negative-index":                {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(-1)}, errMsg: "row group index -1 out of range"},
-		"row-group/out-of-range":                  {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(999)}, errMsg: "row group index 999 out of range"},
-		"row-group/geospatial":                    {cmd: Cmd{ReadOption: rOpt, URI: "geospatial.parquet", RowGroup: new(0)}, golden: "inspect-geospatial-rg0.json"},
-		"row-group/nil-statistics":                {cmd: Cmd{ReadOption: rOpt, URI: "nil-statistics.parquet", RowGroup: new(0)}, golden: "inspect-nil-statistics-rg0.json"},
-		"row-group/all-types":                     {cmd: Cmd{ReadOption: rOpt, URI: "all-types.parquet", RowGroup: new(0)}, golden: "inspect-all-types-rg0.json"},
-		"row-group/unknown-type":                  {cmd: Cmd{ReadOption: rOpt, URI: "unknown-type.parquet", RowGroup: new(0)}, golden: "inspect-unknown-type-rg0.json"},
-		"row-group/bloom-filter":                  {cmd: Cmd{ReadOption: rOpt, URI: "bloom-filter.parquet", RowGroup: new(0)}, golden: "inspect-bloom-filter-rg0.json"},
+		"row-group/good-rg-0": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0)},
+			golden: "inspect-good-rg0.json",
+		},
+		"row-group/encrypted-columns-rg0": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, URI: "encrypted-columns.parquet", RowGroup: new(0)},
+			golden: "inspect-enc-columns-rg0.json",
+		},
+		"row-group/encrypted-columns-no-keys-rg0": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "encrypted-columns.parquet", RowGroup: new(0)},
+			golden: "inspect-enc-columns-no-keys-rg0.json",
+		},
+		"row-group/encrypted-uniform-rg0": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "uniform-encryption.parquet", RowGroup: new(0)},
+			golden: "inspect-enc-uniform-rg0.json",
+		},
+		"row-group/row-group-rg-0": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "row-group.parquet", RowGroup: new(0)},
+			golden: "inspect-row-group-rg0.json",
+		},
+		"row-group/row-group-rg-1": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "row-group.parquet", RowGroup: new(1)},
+			golden: "inspect-row-group-rg1.json",
+		},
+		"row-group/negative-index": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(-1)},
+			errMsg: "row group index -1 out of range",
+		},
+		"row-group/out-of-range": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(999)},
+			errMsg: "row group index 999 out of range",
+		},
+		"row-group/geospatial": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "geospatial.parquet", RowGroup: new(0)},
+			golden: "inspect-geospatial-rg0.json",
+		},
+		"row-group/nil-statistics": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "nil-statistics.parquet", RowGroup: new(0)},
+			golden: "inspect-nil-statistics-rg0.json",
+		},
+		"row-group/all-types": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "all-types.parquet", RowGroup: new(0)},
+			golden: "inspect-all-types-rg0.json",
+		},
+		"row-group/unknown-type": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "unknown-type.parquet", RowGroup: new(0)},
+			golden: "inspect-unknown-type-rg0.json",
+		},
+		"row-group/bloom-filter": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "bloom-filter.parquet", RowGroup: new(0)},
+			golden: "inspect-bloom-filter-rg0.json",
+		},
 		// column chunk level
-		"column-chunk/good-col-0":                {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(0)}, golden: "inspect-good-rg0-cc0.json"},
-		"column-chunk/encrypted-columns-float":   {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, URI: "encrypted-columns.parquet", RowGroup: new(0), ColumnChunk: new(4)}, golden: "inspect-enc-columns-rg0-cc4.json"},
-		"column-chunk/encrypted-uniform-boolean": {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "uniform-encryption.parquet", RowGroup: new(0), ColumnChunk: new(0)}, golden: "inspect-enc-uniform-rg0-cc0.json"},
-		"column-chunk/encrypted-columns-no-key":  {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "encrypted-columns.parquet", RowGroup: new(0), ColumnChunk: new(4)}, errMsg: "decryption key required for column schema.float_field"},
-		"column-chunk/dict-page-col-0":           {cmd: Cmd{ReadOption: rOpt, URI: "dict-page.parquet", RowGroup: new(0), ColumnChunk: new(0)}, golden: "inspect-dict-page-rg0-cc0.json"},
-		"column-chunk/all-types-interval":        {cmd: Cmd{ReadOption: rOpt, URI: "all-types.parquet", RowGroup: new(0), ColumnChunk: new(39)}, golden: "inspect-all-types-rg0-cc39.json"},
-		"column-chunk/unknown-type-col-1":        {cmd: Cmd{ReadOption: rOpt, URI: "unknown-type.parquet", RowGroup: new(0), ColumnChunk: new(1)}, golden: "inspect-unknown-type-rg0-cc1.json"},
-		"column-chunk/bloom-filter-col-0":        {cmd: Cmd{ReadOption: rOpt, URI: "bloom-filter.parquet", RowGroup: new(0), ColumnChunk: new(0)}, golden: "inspect-bloom-filter-rg0-cc0.json"},
-		"column-chunk/negative-column-index":     {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(-1)}, errMsg: "column chunk index -1 out of range"},
-		"column-chunk/out-of-range-column":       {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(999)}, errMsg: "column chunk index 999 out of range"},
-		"column-chunk/without-row-group":         {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", ColumnChunk: new(0)}, errMsg: "--column-chunk requires --row-group"},
-		"column-chunk/negative-row-group":        {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(-1), ColumnChunk: new(0)}, errMsg: "row group index -1 out of range"},
-		"column-chunk/out-of-range-row-group":    {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(999), ColumnChunk: new(0)}, errMsg: "row group index 999 out of range"},
+		"column-chunk/good-col-0": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(0)},
+			golden: "inspect-good-rg0-cc0.json",
+		},
+		"column-chunk/encrypted-columns-float": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, URI: "encrypted-columns.parquet", RowGroup: new(0), ColumnChunk: new(4)},
+			golden: "inspect-enc-columns-rg0-cc4.json",
+		},
+		"column-chunk/encrypted-uniform-boolean": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "uniform-encryption.parquet", RowGroup: new(0), ColumnChunk: new(0)},
+			golden: "inspect-enc-uniform-rg0-cc0.json",
+		},
+		"column-chunk/encrypted-columns-no-key": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "encrypted-columns.parquet", RowGroup: new(0), ColumnChunk: new(4)},
+			errMsg: "decryption key required for column schema.float_field",
+		},
+		"column-chunk/dict-page-col-0": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "dict-page.parquet", RowGroup: new(0), ColumnChunk: new(0)},
+			golden: "inspect-dict-page-rg0-cc0.json",
+		},
+		"column-chunk/all-types-interval": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "all-types.parquet", RowGroup: new(0), ColumnChunk: new(39)},
+			golden: "inspect-all-types-rg0-cc39.json",
+		},
+		"column-chunk/unknown-type-col-1": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "unknown-type.parquet", RowGroup: new(0), ColumnChunk: new(1)},
+			golden: "inspect-unknown-type-rg0-cc1.json",
+		},
+		"column-chunk/bloom-filter-col-0": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "bloom-filter.parquet", RowGroup: new(0), ColumnChunk: new(0)},
+			golden: "inspect-bloom-filter-rg0-cc0.json",
+		},
+		"column-chunk/negative-column-index": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(-1)},
+			errMsg: "column chunk index -1 out of range",
+		},
+		"column-chunk/out-of-range-column": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(999)},
+			errMsg: "column chunk index 999 out of range",
+		},
+		"column-chunk/without-row-group": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", ColumnChunk: new(0)},
+			errMsg: "--column-chunk requires --row-group",
+		},
+		"column-chunk/negative-row-group": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(-1), ColumnChunk: new(0)},
+			errMsg: "row group index -1 out of range",
+		},
+		"column-chunk/out-of-range-row-group": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(999), ColumnChunk: new(0)},
+			errMsg: "row group index 999 out of range",
+		},
 		// page level
-		"page/good-page-0":                  {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(0)}, golden: "inspect-good-rg0-cc0-pg0.json"},
-		"page/dict-page-page-0":             {cmd: Cmd{ReadOption: rOpt, URI: "dict-page.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(0)}, golden: "inspect-dict-page-rg0-cc0-pg0.json"},
-		"page/dict-page-page-1":             {cmd: Cmd{ReadOption: rOpt, URI: "dict-page.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(1)}, golden: "inspect-dict-page-rg0-cc0-pg1.json"},
-		"page/row-group-rg1-page-0":         {cmd: Cmd{ReadOption: rOpt, URI: "row-group.parquet", RowGroup: new(1), ColumnChunk: new(0), Page: new(0)}, golden: "inspect-row-group-rg1-cc0-pg0.json"},
-		"page/data-page-v2-page-0":          {cmd: Cmd{ReadOption: rOpt, URI: "data-page-v2.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(0)}, golden: "inspect-data-page-v2-rg0-cc0-pg0.json"},
-		"page/crc32-page-0":                 {cmd: Cmd{ReadOption: rOpt, URI: "crc32.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(0)}, golden: "inspect-crc32-rg0-cc0-pg0.json"},
-		"page/good-page-1":                  {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(1)}, golden: "inspect-good-rg0-cc0-pg1.json"},
-		"page/row-group-page-5":             {cmd: Cmd{ReadOption: rOpt, URI: "row-group.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(5)}, golden: "inspect-row-group-rg0-cc0-pg5.json"},
-		"page/negative-page-index":          {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(-1)}, errMsg: "page index -1 out of range"},
-		"page/out-of-range-page":            {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(999)}, errMsg: "page index 999 out of range"},
-		"page/without-row-group-and-column": {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", Page: new(0)}, errMsg: "--page requires both --row-group and --column-chunk"},
-		"page/without-column":               {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), Page: new(0)}, errMsg: "--page requires both --row-group and --column-chunk"},
-		"page/negative-row-group":           {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(-1), ColumnChunk: new(0), Page: new(0)}, errMsg: "row group index -1 out of range"},
-		"page/out-of-range-row-group":       {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(999), ColumnChunk: new(0), Page: new(0)}, errMsg: "row group index 999 out of range"},
-		"page/negative-column-chunk":        {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(-1), Page: new(0)}, errMsg: "column chunk index -1 out of range"},
-		"page/out-of-range-column-chunk":    {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(999), Page: new(0)}, errMsg: "column chunk index 999 out of range"},
+		"page/good-page-0": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(0)},
+			golden: "inspect-good-rg0-cc0-pg0.json",
+		},
+		"page/dict-page-page-0": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "dict-page.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(0)},
+			golden: "inspect-dict-page-rg0-cc0-pg0.json",
+		},
+		"page/dict-page-page-1": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "dict-page.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(1)},
+			golden: "inspect-dict-page-rg0-cc0-pg1.json",
+		},
+		"page/row-group-rg1-page-0": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "row-group.parquet", RowGroup: new(1), ColumnChunk: new(0), Page: new(0)},
+			golden: "inspect-row-group-rg1-cc0-pg0.json",
+		},
+		"page/data-page-v2-page-0": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "data-page-v2.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(0)},
+			golden: "inspect-data-page-v2-rg0-cc0-pg0.json",
+		},
+		"page/crc32-page-0": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "crc32.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(0)},
+			golden: "inspect-crc32-rg0-cc0-pg0.json",
+		},
+		"page/good-page-1": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(1)},
+			golden: "inspect-good-rg0-cc0-pg1.json",
+		},
+		"page/row-group-page-5": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "row-group.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(5)},
+			golden: "inspect-row-group-rg0-cc0-pg5.json",
+		},
+		"page/negative-page-index": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(-1)},
+			errMsg: "page index -1 out of range",
+		},
+		"page/out-of-range-page": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(0), Page: new(999)},
+			errMsg: "page index 999 out of range",
+		},
+		"page/without-row-group-and-column": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", Page: new(0)},
+			errMsg: "--page requires both --row-group and --column-chunk",
+		},
+		"page/without-column": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), Page: new(0)},
+			errMsg: "--page requires both --row-group and --column-chunk",
+		},
+		"page/negative-row-group": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(-1), ColumnChunk: new(0), Page: new(0)},
+			errMsg: "row group index -1 out of range",
+		},
+		"page/out-of-range-row-group": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(999), ColumnChunk: new(0), Page: new(0)},
+			errMsg: "row group index 999 out of range",
+		},
+		"page/negative-column-chunk": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(-1), Page: new(0)},
+			errMsg: "column chunk index -1 out of range",
+		},
+		"page/out-of-range-column-chunk": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet", RowGroup: new(0), ColumnChunk: new(999), Page: new(0)},
+			errMsg: "column chunk index 999 out of range",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -117,9 +273,18 @@ func TestInspectEncrypted(t *testing.T) {
 		ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey},
 	}
 	testCases := map[string]Cmd{
-		"footer":  {ReadOption: encReadOption, URI: "../../testdata/encrypted-footer.parquet"},
-		"columns": {ReadOption: encReadOption, URI: "../../testdata/encrypted-columns.parquet"},
-		"uniform": {ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "../../testdata/uniform-encryption.parquet"},
+		"footer": {
+			ReadOption: encReadOption,
+			URI:        "../../testdata/encrypted-footer.parquet",
+		},
+		"columns": {
+			ReadOption: encReadOption,
+			URI:        "../../testdata/encrypted-columns.parquet",
+		},
+		"uniform": {
+			ReadOption: pio.ReadOption{FooterKey: encFooterKey},
+			URI:        "../../testdata/uniform-encryption.parquet",
+		},
 		"aad": {
 			ReadOption: pio.ReadOption{
 				FooterKey:  encFooterKey,
@@ -235,14 +400,18 @@ func TestResolvePathInSchema(t *testing.T) {
 		"found-in-map": {
 			pathInSchema: []string{"col1"},
 			inExNameMap: map[string][]string{
-				"col1": {"ExternalCol1"},
+				"col1": {
+					"ExternalCol1",
+				},
 			},
 			want: []string{"ExternalCol1"},
 		},
 		"not-found-in-map": {
 			pathInSchema: []string{"col2"},
 			inExNameMap: map[string][]string{
-				"col1": {"ExternalCol1"},
+				"col1": {
+					"ExternalCol1",
+				},
 			},
 			want: []string{"col2"},
 		},

--- a/cmd/merge/merge_test.go
+++ b/cmd/merge/merge_test.go
@@ -22,14 +22,38 @@ func TestCmd(t *testing.T) {
 			cmd    Cmd
 			errMsg string
 		}{
-			"pagesize-too-small":  {Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: true, ReadPageSize: 0, Source: []string{"src"}, URI: "dummy"}, "invalid read page size"},
-			"source-need-more":    {Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"../../testdata/good.parquet"}, URI: "dummy"}, "needs at least 2 source files"},
-			"source-non-existent": {Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: true, ReadPageSize: 10, Source: []string{"does/not/exist1", "does/not/exist2"}, URI: "dummy"}, "no such file or directory"},
-			"source-not-parquet":  {Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"../../testdata/not-a-parquet-file", "../../testdata/not-a-parquet-file"}, URI: "dummy"}, "failed to read from"},
-			"source-diff-schema":  {Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: true, ReadPageSize: 10, Source: []string{"../../testdata/good.parquet", "../../testdata/empty.parquet"}, URI: "dummy"}, "does not have same schema"},
-			"target-file":         {Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"../../testdata/good.parquet", "../../testdata/good.parquet"}, URI: "://uri"}, "unable to parse file location"},
-			"target-write":        {Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"../../testdata/good.parquet", "../../testdata/good.parquet"}, URI: "s3://target"}, "failed to close"},
-			"int96":               {Cmd{ReadOption: rOpt, Concurrent: true, FailOnInt96: true, ReadPageSize: 10, Source: []string{"../../testdata/all-types.parquet", "../../testdata/all-types.parquet"}, URI: "dummy"}, "type INT96 which is not supported"},
+			"pagesize-too-small": {
+				Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: true, ReadPageSize: 0, Source: []string{"src"}, URI: "dummy"},
+				"invalid read page size",
+			},
+			"source-need-more": {
+				Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"../../testdata/good.parquet"}, URI: "dummy"},
+				"needs at least 2 source files",
+			},
+			"source-non-existent": {
+				Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: true, ReadPageSize: 10, Source: []string{"does/not/exist1", "does/not/exist2"}, URI: "dummy"},
+				"no such file or directory",
+			},
+			"source-not-parquet": {
+				Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"../../testdata/not-a-parquet-file", "../../testdata/not-a-parquet-file"}, URI: "dummy"},
+				"failed to read from",
+			},
+			"source-diff-schema": {
+				Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: true, ReadPageSize: 10, Source: []string{"../../testdata/good.parquet", "../../testdata/empty.parquet"}, URI: "dummy"},
+				"does not have same schema",
+			},
+			"target-file": {
+				Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"../../testdata/good.parquet", "../../testdata/good.parquet"}, URI: "://uri"},
+				"unable to parse file location",
+			},
+			"target-write": {
+				Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"../../testdata/good.parquet", "../../testdata/good.parquet"}, URI: "s3://target"},
+				"failed to close",
+			},
+			"int96": {
+				Cmd{ReadOption: rOpt, Concurrent: true, FailOnInt96: true, ReadPageSize: 10, Source: []string{"../../testdata/all-types.parquet", "../../testdata/all-types.parquet"}, URI: "dummy"},
+				"type INT96 which is not supported",
+			},
 		}
 
 		for name, tc := range testCases {
@@ -47,10 +71,22 @@ func TestCmd(t *testing.T) {
 			cmd      Cmd
 			rowCount int64
 		}{
-			"good":      {Cmd{ReadOption: rOpt, Concurrent: true, FailOnInt96: false, ReadPageSize: 10, Source: []string{"good.parquet", "good.parquet"}, URI: ""}, 6},
-			"all-types": {Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"all-types.parquet", "all-types.parquet"}, URI: ""}, 10},
-			"empty":     {Cmd{ReadOption: rOpt, Concurrent: true, FailOnInt96: false, ReadPageSize: 10, Source: []string{"empty.parquet", "empty.parquet"}, URI: ""}, 0},
-			"top-tag":   {Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"top-level-tag1.parquet", "top-level-tag2.parquet"}, URI: ""}, 6},
+			"good": {
+				Cmd{ReadOption: rOpt, Concurrent: true, FailOnInt96: false, ReadPageSize: 10, Source: []string{"good.parquet", "good.parquet"}, URI: ""},
+				6,
+			},
+			"all-types": {
+				Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"all-types.parquet", "all-types.parquet"}, URI: ""},
+				10,
+			},
+			"empty": {
+				Cmd{ReadOption: rOpt, Concurrent: true, FailOnInt96: false, ReadPageSize: 10, Source: []string{"empty.parquet", "empty.parquet"}, URI: ""},
+				0,
+			},
+			"top-tag": {
+				Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, Source: []string{"top-level-tag1.parquet", "top-level-tag2.parquet"}, URI: ""},
+				6,
+			},
 		}
 		tempDir := t.TempDir()
 

--- a/cmd/meta/meta_test.go
+++ b/cmd/meta/meta_test.go
@@ -100,28 +100,88 @@ func TestCmd(t *testing.T) {
 		errMsg string
 	}{
 		// error cases
-		"non-existent":            {cmd: Cmd{ReadOption: rOpt, URI: "file/does/not/exist"}, errMsg: "no such file or directory"},
-		"encrypted-no-key":        {cmd: Cmd{ReadOption: rOpt, URI: "../../testdata/encrypted-footer.parquet"}, errMsg: "decryption key required for footer"},
-		"encrypted-wrong-key":     {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, URI: "../../testdata/encrypted-footer.parquet"}, errMsg: "decrypt"},
-		"encrypted-wrong-col-key": {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encWrongKey, "float_field=" + encWrongKey}}, URI: "../../testdata/encrypted-columns.parquet"}, errMsg: "decrypt"},
-		"peek-key-not-encrypted":  {cmd: Cmd{ReadOption: rOpt, ShowKeyMetadata: true, URI: "../../testdata/good.parquet"}, errMsg: "file is not encrypted"},
+		"non-existent": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "file/does/not/exist"},
+			errMsg: "no such file or directory",
+		},
+		"encrypted-no-key": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "../../testdata/encrypted-footer.parquet"},
+			errMsg: "decryption key required for footer",
+		},
+		"encrypted-wrong-key": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, URI: "../../testdata/encrypted-footer.parquet"},
+			errMsg: "decrypt",
+		},
+		"encrypted-wrong-col-key": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encWrongKey, "float_field=" + encWrongKey}}, URI: "../../testdata/encrypted-columns.parquet"},
+			errMsg: "decrypt",
+		},
+		"peek-key-not-encrypted": {
+			cmd:    Cmd{ReadOption: rOpt, ShowKeyMetadata: true, URI: "../../testdata/good.parquet"},
+			errMsg: "file is not encrypted",
+		},
 		// --show-key-metadata flag: show key_metadata hints so users can retrieve the right key from KMS
-		"enc-no-key-footer":     {cmd: Cmd{ReadOption: rOpt, ShowKeyMetadata: true, URI: "encrypted-footer.parquet"}, golden: "meta-enc-no-key-footer-raw.json"},
-		"enc-no-key-columns":    {cmd: Cmd{ReadOption: rOpt, ShowKeyMetadata: true, URI: "encrypted-columns.parquet"}, golden: "meta-enc-no-key-columns-raw.json"},
-		"enc-no-key-uniform":    {cmd: Cmd{ReadOption: rOpt, ShowKeyMetadata: true, URI: "uniform-encryption.parquet"}, golden: "meta-enc-no-key-uniform-raw.json"},
-		"enc-no-key-aad":        {cmd: Cmd{ReadOption: rOpt, ShowKeyMetadata: true, URI: "encrypted-aad.parquet"}, golden: "meta-enc-no-key-aad-raw.json"},
-		"encrypted-aad-missing": {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, URI: "../../testdata/encrypted-aad.parquet"}, errMsg: "AAD prefix"},
-		"no-int96":              {cmd: Cmd{ReadOption: rOpt, FailOnInt96: true, URI: "../../testdata/all-types.parquet"}, errMsg: "type INT96 which is not supported"},
-		"nan-json-error":        {cmd: Cmd{ReadOption: rOpt, URI: "../../testdata/nan.parquet"}, errMsg: "json: unsupported value: NaN"},
-		"arrow-gh-41317":        {cmd: Cmd{ReadOption: rOpt, URI: "../../testdata/ARROW-GH-41317.parquet"}, errMsg: "schema node not found for column path"},
+		"enc-no-key-footer": {
+			cmd:    Cmd{ReadOption: rOpt, ShowKeyMetadata: true, URI: "encrypted-footer.parquet"},
+			golden: "meta-enc-no-key-footer-raw.json",
+		},
+		"enc-no-key-columns": {
+			cmd:    Cmd{ReadOption: rOpt, ShowKeyMetadata: true, URI: "encrypted-columns.parquet"},
+			golden: "meta-enc-no-key-columns-raw.json",
+		},
+		"enc-no-key-uniform": {
+			cmd:    Cmd{ReadOption: rOpt, ShowKeyMetadata: true, URI: "uniform-encryption.parquet"},
+			golden: "meta-enc-no-key-uniform-raw.json",
+		},
+		"enc-no-key-aad": {
+			cmd:    Cmd{ReadOption: rOpt, ShowKeyMetadata: true, URI: "encrypted-aad.parquet"},
+			golden: "meta-enc-no-key-aad-raw.json",
+		},
+		"encrypted-aad-missing": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}}, URI: "../../testdata/encrypted-aad.parquet"},
+			errMsg: "AAD prefix",
+		},
+		"no-int96": {
+			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: true, URI: "../../testdata/all-types.parquet"},
+			errMsg: "type INT96 which is not supported",
+		},
+		"nan-json-error": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "../../testdata/nan.parquet"},
+			errMsg: "json: unsupported value: NaN",
+		},
+		"arrow-gh-41317": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "../../testdata/ARROW-GH-41317.parquet"},
+			errMsg: "schema node not found for column path",
+		},
 		// good cases - URI will be prefixed with "../../testdata/"
-		"raw":          {cmd: Cmd{ReadOption: rOpt, URI: "good.parquet"}, golden: "meta-good-raw.json"},
-		"nil-stat":     {cmd: Cmd{ReadOption: rOpt, URI: "nil-statistics.parquet"}, golden: "meta-nil-statistics-raw.json"},
-		"sorting-col":  {cmd: Cmd{ReadOption: rOpt, URI: "sorting-col.parquet"}, golden: "meta-sorting-col-raw.json"},
-		"all-types":    {cmd: Cmd{ReadOption: rOpt, URI: "all-types.parquet"}, golden: "meta-all-types-raw.json"},
-		"geospatial":   {cmd: Cmd{ReadOption: rOpt, URI: "geospatial.parquet"}, golden: "meta-geospatial-raw.json"},
-		"row-group":    {cmd: Cmd{ReadOption: rOpt, URI: "row-group.parquet"}, golden: "meta-row-group-raw.json"},
-		"bloom-filter": {cmd: Cmd{ReadOption: rOpt, URI: "bloom-filter.parquet"}, golden: "meta-bloom-filter-raw.json"},
+		"raw": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "good.parquet"},
+			golden: "meta-good-raw.json",
+		},
+		"nil-stat": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "nil-statistics.parquet"},
+			golden: "meta-nil-statistics-raw.json",
+		},
+		"sorting-col": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "sorting-col.parquet"},
+			golden: "meta-sorting-col-raw.json",
+		},
+		"all-types": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "all-types.parquet"},
+			golden: "meta-all-types-raw.json",
+		},
+		"geospatial": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "geospatial.parquet"},
+			golden: "meta-geospatial-raw.json",
+		},
+		"row-group": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "row-group.parquet"},
+			golden: "meta-row-group-raw.json",
+		},
+		"bloom-filter": {
+			cmd:    Cmd{ReadOption: rOpt, URI: "bloom-filter.parquet"},
+			golden: "meta-bloom-filter-raw.json",
+		},
 		// encrypted cases: column-level keys with KeyMetadata, uniform footer-key encryption,
 		// and footer with both column-level keys and file-level FooterKeyMetadata
 		"enc-columns": {

--- a/cmd/retype/retype_test.go
+++ b/cmd/retype/retype_test.go
@@ -26,11 +26,26 @@ func TestCmd(t *testing.T) {
 			cmd    Cmd
 			errMsg string
 		}{
-			"pagesize-too-small":  {Cmd{ReadOption: rOpt, ReadPageSize: 0, Source: "../../testdata/good.parquet", URI: "dummy"}, "invalid read page size"},
-			"source-non-existent": {Cmd{ReadOption: rOpt, ReadPageSize: 10, Source: "does/not/exist", URI: "dummy"}, "no such file or directory"},
-			"source-not-parquet":  {Cmd{ReadOption: rOpt, ReadPageSize: 10, Source: "../../testdata/not-a-parquet-file", URI: "dummy"}, "failed to read from"},
-			"target-file":         {Cmd{ReadOption: rOpt, ReadPageSize: 10, Source: "../../testdata/good.parquet", URI: "://uri"}, "unable to parse file location"},
-			"source-schema-error": {Cmd{ReadOption: rOpt, ReadPageSize: 10, Source: "../../testdata/ARROW-GH-41317.parquet", URI: "dummy"}, "failed to build encoding map"},
+			"pagesize-too-small": {
+				Cmd{ReadOption: rOpt, ReadPageSize: 0, Source: "../../testdata/good.parquet", URI: "dummy"},
+				"invalid read page size",
+			},
+			"source-non-existent": {
+				Cmd{ReadOption: rOpt, ReadPageSize: 10, Source: "does/not/exist", URI: "dummy"},
+				"no such file or directory",
+			},
+			"source-not-parquet": {
+				Cmd{ReadOption: rOpt, ReadPageSize: 10, Source: "../../testdata/not-a-parquet-file", URI: "dummy"},
+				"failed to read from",
+			},
+			"target-file": {
+				Cmd{ReadOption: rOpt, ReadPageSize: 10, Source: "../../testdata/good.parquet", URI: "://uri"},
+				"unable to parse file location",
+			},
+			"source-schema-error": {
+				Cmd{ReadOption: rOpt, ReadPageSize: 10, Source: "../../testdata/ARROW-GH-41317.parquet", URI: "dummy"},
+				"failed to build encoding map",
+			},
 		}
 
 		for name, tc := range testCases {

--- a/cmd/rowcount/rowcount_test.go
+++ b/cmd/rowcount/rowcount_test.go
@@ -51,17 +51,41 @@ func TestCmdEncrypted(t *testing.T) {
 		stdout string
 		errMsg string
 	}{
-		"footer":    {cmd: Cmd{ReadOption: encReadOption, URI: "../../testdata/encrypted-footer.parquet"}, stdout: "50\n"},
-		"columns":   {cmd: Cmd{ReadOption: encReadOption, URI: "../../testdata/encrypted-columns.parquet"}, stdout: "50\n"},
-		"aad":       {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}, AADPrefix: encAADPrefix}, URI: "../../testdata/encrypted-aad.parquet"}, stdout: "50\n"},
-		"uniform":   {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "../../testdata/uniform-encryption.parquet"}, stdout: "50\n"},
-		"no-key":    {cmd: Cmd{ReadOption: pio.ReadOption{}, URI: "../../testdata/encrypted-footer.parquet"}, errMsg: "decryption key required for footer"},
-		"wrong-key": {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, URI: "../../testdata/encrypted-footer.parquet"}, errMsg: "decrypt"},
+		"footer": {
+			cmd:    Cmd{ReadOption: encReadOption, URI: "../../testdata/encrypted-footer.parquet"},
+			stdout: "50\n",
+		},
+		"columns": {
+			cmd:    Cmd{ReadOption: encReadOption, URI: "../../testdata/encrypted-columns.parquet"},
+			stdout: "50\n",
+		},
+		"aad": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey, ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey}, AADPrefix: encAADPrefix}, URI: "../../testdata/encrypted-aad.parquet"},
+			stdout: "50\n",
+		},
+		"uniform": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "../../testdata/uniform-encryption.parquet"},
+			stdout: "50\n",
+		},
+		"no-key": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{}, URI: "../../testdata/encrypted-footer.parquet"},
+			errMsg: "decryption key required for footer",
+		},
+		"wrong-key": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, URI: "../../testdata/encrypted-footer.parquet"},
+			errMsg: "decrypt",
+		},
 		// Mixed plaintext/encrypted: row count only needs row-group metadata, so a footer
 		// key alone is enough even when some column keys are missing.
-		"footer-only-mixed": {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "../../testdata/encrypted-columns.parquet"}, stdout: "50\n"},
+		"footer-only-mixed": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, URI: "../../testdata/encrypted-columns.parquet"},
+			stdout: "50\n",
+		},
 		// Plaintext-signed footer in encrypted-columns.parquet does not require any key for row count.
-		"no-key-mixed": {cmd: Cmd{ReadOption: pio.ReadOption{}, URI: "../../testdata/encrypted-columns.parquet"}, stdout: "50\n"},
+		"no-key-mixed": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{}, URI: "../../testdata/encrypted-columns.parquet"},
+			stdout: "50\n",
+		},
 	}
 
 	for name, tc := range testCases {

--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -27,43 +27,142 @@ func TestCmd(t *testing.T) {
 		errMsg string
 	}{
 		// error cases
-		"invalid-uri":       {cmd: schema.Cmd{ReadOption: rOpt, Format: "foobar", URI: "dummy://location"}, errMsg: "unknown location scheme"},
-		"invalid-format":    {cmd: schema.Cmd{ReadOption: rOpt, Format: "foobar", URI: "../../testdata/good.parquet"}, errMsg: "unknown schema format"},
-		"go-map-value":      {cmd: schema.Cmd{ReadOption: rOpt, Format: "go", URI: "../../testdata/map-composite-value.parquet"}, errMsg: "go struct does not support LIST as MAP value in [Parquet_go_root.Scores]"},
-		"go-list-value":     {cmd: schema.Cmd{ReadOption: rOpt, Format: "go", URI: "../../testdata/list-of-list.parquet"}, errMsg: "go struct does not support LIST of LIST in [Parquet_go_root.Lol]"},
-		"go-old-style-list": {cmd: schema.Cmd{ReadOption: rOpt, Format: "go", URI: "../../testdata/old-style-list.parquet"}, errMsg: "go struct does not support LIST of LIST in [My_record.First.Second.A]"},
-		"csv-nested":        {cmd: schema.Cmd{ReadOption: rOpt, Format: "csv", URI: "../../testdata/csv-nested.parquet"}, errMsg: "CSV supports flat schema only"},
-		"csv-optional":      {cmd: schema.Cmd{ReadOption: rOpt, Format: "csv", URI: "../../testdata/csv-optional.parquet"}, errMsg: "CSV does not support optional column"},
-		"csv-repeated":      {cmd: schema.Cmd{ReadOption: rOpt, Format: "csv", URI: "../../testdata/csv-repeated.parquet"}, errMsg: "CSV does not support column in LIST type"},
+		"invalid-uri": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "foobar", URI: "dummy://location"},
+			errMsg: "unknown location scheme",
+		},
+		"invalid-format": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "foobar", URI: "../../testdata/good.parquet"},
+			errMsg: "unknown schema format",
+		},
+		"go-map-value": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "go", URI: "../../testdata/map-composite-value.parquet"},
+			errMsg: "go struct does not support LIST as MAP value in [Parquet_go_root.Scores]",
+		},
+		"go-list-value": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "go", URI: "../../testdata/list-of-list.parquet"},
+			errMsg: "go struct does not support LIST of LIST in [Parquet_go_root.Lol]",
+		},
+		"go-old-style-list": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "go", URI: "../../testdata/old-style-list.parquet"},
+			errMsg: "go struct does not support LIST of LIST in [My_record.First.Second.A]",
+		},
+		"csv-nested": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "csv", URI: "../../testdata/csv-nested.parquet"},
+			errMsg: "CSV supports flat schema only",
+		},
+		"csv-optional": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "csv", URI: "../../testdata/csv-optional.parquet"},
+			errMsg: "CSV does not support optional column",
+		},
+		"csv-repeated": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "csv", URI: "../../testdata/csv-repeated.parquet"},
+			errMsg: "CSV does not support column in LIST type",
+		},
 		// encrypted error cases
-		"encrypted-footer-no-key":    {cmd: schema.Cmd{ReadOption: rOpt, Format: "json", URI: "../../testdata/encrypted-footer.parquet"}, errMsg: "decryption key required for footer"},
-		"encrypted-footer-wrong-key": {cmd: schema.Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, Format: "json", URI: "../../testdata/encrypted-footer.parquet"}, errMsg: "decrypt"},
+		"encrypted-footer-no-key": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "json", URI: "../../testdata/encrypted-footer.parquet"},
+			errMsg: "decryption key required for footer",
+		},
+		"encrypted-footer-wrong-key": {
+			cmd:    schema.Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, Format: "json", URI: "../../testdata/encrypted-footer.parquet"},
+			errMsg: "decrypt",
+		},
 		// Mixed plaintext/encrypted: schema only needs the plaintext-signed footer,
 		// so no keys at all are required even when columns are encrypted.
-		"enc-columns-no-keys": {cmd: schema.Cmd{ReadOption: rOpt, Format: "json", URI: "encrypted-columns.parquet"}, golden: "schema-enc-columns-json.json"},
+		"enc-columns-no-keys": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "json", URI: "encrypted-columns.parquet"},
+			golden: "schema-enc-columns-json.json",
+		},
 		// good cases - URI will be prefixed with "../../testdata/"
-		"raw":                    {cmd: schema.Cmd{ReadOption: rOpt, Format: "raw", URI: "all-types.parquet"}, golden: "schema-all-types-raw.json"},
-		"json":                   {cmd: schema.Cmd{ReadOption: rOpt, Format: "json", URI: "all-types.parquet"}, golden: "schema-all-types-json.json"},
-		"go":                     {cmd: schema.Cmd{ReadOption: rOpt, Format: "go", URI: "all-types.parquet"}, golden: "schema-all-types-go.txt"},
-		"csv":                    {cmd: schema.Cmd{ReadOption: rOpt, Format: "csv", URI: "csv-good.parquet"}, golden: "schema-csv-good.txt"},
-		"raw-map-value-list":     {cmd: schema.Cmd{ReadOption: rOpt, Format: "raw", URI: "map-composite-value.parquet"}, golden: "schema-map-composite-value-raw.json"},
-		"json-map-value-list":    {cmd: schema.Cmd{ReadOption: rOpt, Format: "json", URI: "map-composite-value.parquet"}, golden: "schema-map-composite-value-json.json"},
-		"json-map-value-map":     {cmd: schema.Cmd{ReadOption: rOpt, Format: "json", URI: "map-value-map.parquet"}, golden: "schema-map-value-map-json.json"},
-		"pargo-prefix-flat":      {cmd: schema.Cmd{ReadOption: rOpt, Format: "go", URI: "pargo-prefix-flat.parquet"}, golden: "schema-pargo-prefix-flat-go.txt"},
-		"pargo-prefix-nested":    {cmd: schema.Cmd{ReadOption: rOpt, Format: "go", URI: "pargo-prefix-nested.parquet"}, golden: "schema-pargo-prefix-nested-go.txt"},
-		"geospatial-go":          {cmd: schema.Cmd{ReadOption: rOpt, Format: "go", URI: "geospatial.parquet"}, golden: "schema-geospatial-go.txt"},
-		"geospatial-json":        {cmd: schema.Cmd{ReadOption: rOpt, Format: "json", URI: "geospatial.parquet"}, golden: "schema-geospatial-json.json"},
-		"geospatial-raw":         {cmd: schema.Cmd{ReadOption: rOpt, Format: "raw", URI: "geospatial.parquet"}, golden: "schema-geospatial-raw.json"},
-		"camel-case":             {cmd: schema.Cmd{ReadOption: rOpt, Format: "go", CamelCase: true, URI: "good.parquet"}, golden: "schema-good-go-camel-case.txt"},
-		"skip-page-encoding":     {cmd: schema.Cmd{ReadOption: rOpt, Format: "json", SkipPageEncoding: true, URI: "good.parquet"}, golden: "schema-good-skip-page-encoding.json"},
-		"skip-page-encoding-raw": {cmd: schema.Cmd{ReadOption: rOpt, Format: "raw", SkipPageEncoding: true, URI: "good.parquet"}, golden: "schema-good-skip-page-encoding-raw.json"},
-		"skip-page-encoding-go":  {cmd: schema.Cmd{ReadOption: rOpt, Format: "go", SkipPageEncoding: true, URI: "good.parquet"}, golden: "schema-good-skip-page-encoding-go.txt"},
-		"unknown-type-raw":       {cmd: schema.Cmd{ReadOption: rOpt, Format: "raw", URI: "unknown-type.parquet"}, golden: "schema-unknown-type-raw.json"},
-		"unknown-type-json":      {cmd: schema.Cmd{ReadOption: rOpt, Format: "json", URI: "unknown-type.parquet"}, golden: "schema-unknown-type-json.json"},
-		"unknown-type-go":        {cmd: schema.Cmd{ReadOption: rOpt, Format: "go", URI: "unknown-type.parquet"}, golden: "schema-unknown-type-go.txt"},
-		"bloom-filter-raw":       {cmd: schema.Cmd{ReadOption: rOpt, Format: "raw", URI: "bloom-filter.parquet"}, golden: "schema-bloom-filter-raw.json"},
-		"bloom-filter-json":      {cmd: schema.Cmd{ReadOption: rOpt, Format: "json", URI: "bloom-filter.parquet"}, golden: "schema-bloom-filter-json.json"},
-		"bloom-filter-go":        {cmd: schema.Cmd{ReadOption: rOpt, Format: "go", URI: "bloom-filter.parquet"}, golden: "schema-bloom-filter-go.txt"},
+		"raw": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "raw", URI: "all-types.parquet"},
+			golden: "schema-all-types-raw.json",
+		},
+		"json": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "json", URI: "all-types.parquet"},
+			golden: "schema-all-types-json.json",
+		},
+		"go": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "go", URI: "all-types.parquet"},
+			golden: "schema-all-types-go.txt",
+		},
+		"csv": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "csv", URI: "csv-good.parquet"},
+			golden: "schema-csv-good.txt",
+		},
+		"raw-map-value-list": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "raw", URI: "map-composite-value.parquet"},
+			golden: "schema-map-composite-value-raw.json",
+		},
+		"json-map-value-list": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "json", URI: "map-composite-value.parquet"},
+			golden: "schema-map-composite-value-json.json",
+		},
+		"json-map-value-map": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "json", URI: "map-value-map.parquet"},
+			golden: "schema-map-value-map-json.json",
+		},
+		"pargo-prefix-flat": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "go", URI: "pargo-prefix-flat.parquet"},
+			golden: "schema-pargo-prefix-flat-go.txt",
+		},
+		"pargo-prefix-nested": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "go", URI: "pargo-prefix-nested.parquet"},
+			golden: "schema-pargo-prefix-nested-go.txt",
+		},
+		"geospatial-go": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "go", URI: "geospatial.parquet"},
+			golden: "schema-geospatial-go.txt",
+		},
+		"geospatial-json": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "json", URI: "geospatial.parquet"},
+			golden: "schema-geospatial-json.json",
+		},
+		"geospatial-raw": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "raw", URI: "geospatial.parquet"},
+			golden: "schema-geospatial-raw.json",
+		},
+		"camel-case": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "go", CamelCase: true, URI: "good.parquet"},
+			golden: "schema-good-go-camel-case.txt",
+		},
+		"skip-page-encoding": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "json", SkipPageEncoding: true, URI: "good.parquet"},
+			golden: "schema-good-skip-page-encoding.json",
+		},
+		"skip-page-encoding-raw": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "raw", SkipPageEncoding: true, URI: "good.parquet"},
+			golden: "schema-good-skip-page-encoding-raw.json",
+		},
+		"skip-page-encoding-go": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "go", SkipPageEncoding: true, URI: "good.parquet"},
+			golden: "schema-good-skip-page-encoding-go.txt",
+		},
+		"unknown-type-raw": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "raw", URI: "unknown-type.parquet"},
+			golden: "schema-unknown-type-raw.json",
+		},
+		"unknown-type-json": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "json", URI: "unknown-type.parquet"},
+			golden: "schema-unknown-type-json.json",
+		},
+		"unknown-type-go": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "go", URI: "unknown-type.parquet"},
+			golden: "schema-unknown-type-go.txt",
+		},
+		"bloom-filter-raw": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "raw", URI: "bloom-filter.parquet"},
+			golden: "schema-bloom-filter-raw.json",
+		},
+		"bloom-filter-json": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "json", URI: "bloom-filter.parquet"},
+			golden: "schema-bloom-filter-json.json",
+		},
+		"bloom-filter-go": {
+			cmd:    schema.Cmd{ReadOption: rOpt, Format: "go", URI: "bloom-filter.parquet"},
+			golden: "schema-bloom-filter-go.txt",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -96,9 +195,21 @@ func TestCmdEncrypted(t *testing.T) {
 		ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey},
 	}
 	testCases := map[string]schema.Cmd{
-		"footer":  {ReadOption: encReadOption, Format: "json", URI: "../../testdata/encrypted-footer.parquet"},
-		"columns": {ReadOption: encReadOption, Format: "json", URI: "../../testdata/encrypted-columns.parquet"},
-		"uniform": {ReadOption: pio.ReadOption{FooterKey: encFooterKey}, Format: "json", URI: "../../testdata/uniform-encryption.parquet"},
+		"footer": {
+			ReadOption: encReadOption,
+			Format:     "json",
+			URI:        "../../testdata/encrypted-footer.parquet",
+		},
+		"columns": {
+			ReadOption: encReadOption,
+			Format:     "json",
+			URI:        "../../testdata/encrypted-columns.parquet",
+		},
+		"uniform": {
+			ReadOption: pio.ReadOption{FooterKey: encFooterKey},
+			Format:     "json",
+			URI:        "../../testdata/uniform-encryption.parquet",
+		},
 		"aad": {
 			ReadOption: pio.ReadOption{
 				FooterKey:  encFooterKey,

--- a/cmd/size/size_test.go
+++ b/cmd/size/size_test.go
@@ -27,23 +27,65 @@ func TestCmd(t *testing.T) {
 		errMsg string
 	}{
 		// error cases
-		"non-existent-file":   {cmd: Cmd{URI: "file/does/not/exist"}, errMsg: "no such file or directory"},
-		"invalid-query":       {cmd: Cmd{Query: "invalid", URI: "../../testdata/good.parquet"}, errMsg: "unknown query type"},
-		"encrypted-no-key":    {cmd: Cmd{Query: "raw", URI: "../../testdata/encrypted-footer.parquet"}, errMsg: "decryption key required for footer"},
-		"encrypted-wrong-key": {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, Query: "raw", URI: "../../testdata/encrypted-footer.parquet"}, errMsg: "decrypt"},
+		"non-existent-file": {
+			cmd:    Cmd{URI: "file/does/not/exist"},
+			errMsg: "no such file or directory",
+		},
+		"invalid-query": {
+			cmd:    Cmd{Query: "invalid", URI: "../../testdata/good.parquet"},
+			errMsg: "unknown query type",
+		},
+		"encrypted-no-key": {
+			cmd:    Cmd{Query: "raw", URI: "../../testdata/encrypted-footer.parquet"},
+			errMsg: "decryption key required for footer",
+		},
+		"encrypted-wrong-key": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encWrongKey}, Query: "raw", URI: "../../testdata/encrypted-footer.parquet"},
+			errMsg: "decrypt",
+		},
 		// Mixed plaintext/encrypted: size only needs structural metadata, so a footer
 		// key alone — or no keys at all — works even when column keys are missing.
-		"encrypted-footer-only-mixed": {cmd: Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, Query: "raw", URI: "../../testdata/encrypted-columns.parquet"}, stdout: "3129\n"},
-		"encrypted-no-keys-mixed":     {cmd: Cmd{ReadOption: pio.ReadOption{}, Query: "raw", URI: "../../testdata/encrypted-columns.parquet"}, stdout: "3129\n"},
+		"encrypted-footer-only-mixed": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{FooterKey: encFooterKey}, Query: "raw", URI: "../../testdata/encrypted-columns.parquet"},
+			stdout: "3129\n",
+		},
+		"encrypted-no-keys-mixed": {
+			cmd:    Cmd{ReadOption: pio.ReadOption{}, Query: "raw", URI: "../../testdata/encrypted-columns.parquet"},
+			stdout: "3129\n",
+		},
 		// good cases
-		"raw":               {cmd: Cmd{ReadOption: rOpt, Query: "raw", JSON: false, URI: "../../testdata/good.parquet"}, stdout: "588\n"},
-		"raw-json":          {cmd: Cmd{ReadOption: rOpt, Query: "raw", JSON: true, URI: "../../testdata/good.parquet"}, stdout: `{"Raw":588}` + "\n"},
-		"uncompressed":      {cmd: Cmd{ReadOption: rOpt, Query: "uncompressed", JSON: false, URI: "../../testdata/good.parquet"}, stdout: "438\n"},
-		"uncompressed-json": {cmd: Cmd{ReadOption: rOpt, Query: "uncompressed", JSON: true, URI: "../../testdata/good.parquet"}, stdout: `{"Uncompressed":438}` + "\n"},
-		"footer":            {cmd: Cmd{ReadOption: rOpt, Query: "footer", JSON: false, URI: "../../testdata/good.parquet"}, stdout: "335\n"},
-		"footer-json":       {cmd: Cmd{ReadOption: rOpt, Query: "footer", JSON: true, URI: "../../testdata/good.parquet"}, stdout: `{"Footer":335}` + "\n"},
-		"all":               {cmd: Cmd{ReadOption: rOpt, Query: "all", JSON: false, URI: "../../testdata/good.parquet"}, stdout: "588 438 335\n"},
-		"all-json":          {cmd: Cmd{ReadOption: rOpt, Query: "all", JSON: true, URI: "../../testdata/good.parquet"}, stdout: `{"Raw":588,"Uncompressed":438,"Footer":335}` + "\n"},
+		"raw": {
+			cmd:    Cmd{ReadOption: rOpt, Query: "raw", JSON: false, URI: "../../testdata/good.parquet"},
+			stdout: "588\n",
+		},
+		"raw-json": {
+			cmd:    Cmd{ReadOption: rOpt, Query: "raw", JSON: true, URI: "../../testdata/good.parquet"},
+			stdout: `{"Raw":588}` + "\n",
+		},
+		"uncompressed": {
+			cmd:    Cmd{ReadOption: rOpt, Query: "uncompressed", JSON: false, URI: "../../testdata/good.parquet"},
+			stdout: "438\n",
+		},
+		"uncompressed-json": {
+			cmd:    Cmd{ReadOption: rOpt, Query: "uncompressed", JSON: true, URI: "../../testdata/good.parquet"},
+			stdout: `{"Uncompressed":438}` + "\n",
+		},
+		"footer": {
+			cmd:    Cmd{ReadOption: rOpt, Query: "footer", JSON: false, URI: "../../testdata/good.parquet"},
+			stdout: "335\n",
+		},
+		"footer-json": {
+			cmd:    Cmd{ReadOption: rOpt, Query: "footer", JSON: true, URI: "../../testdata/good.parquet"},
+			stdout: `{"Footer":335}` + "\n",
+		},
+		"all": {
+			cmd:    Cmd{ReadOption: rOpt, Query: "all", JSON: false, URI: "../../testdata/good.parquet"},
+			stdout: "588 438 335\n",
+		},
+		"all-json": {
+			cmd:    Cmd{ReadOption: rOpt, Query: "all", JSON: true, URI: "../../testdata/good.parquet"},
+			stdout: `{"Raw":588,"Uncompressed":438,"Footer":335}` + "\n",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -72,9 +114,21 @@ func TestCmdEncrypted(t *testing.T) {
 		ColumnKeys: []string{"double_field=" + encDoubleKey, "float_field=" + encFloatKey},
 	}
 	testCases := map[string]Cmd{
-		"footer":  {ReadOption: encReadOption, Query: "raw", URI: "../../testdata/encrypted-footer.parquet"},
-		"columns": {ReadOption: encReadOption, Query: "raw", URI: "../../testdata/encrypted-columns.parquet"},
-		"uniform": {ReadOption: pio.ReadOption{FooterKey: encFooterKey}, Query: "raw", URI: "../../testdata/uniform-encryption.parquet"},
+		"footer": {
+			ReadOption: encReadOption,
+			Query:      "raw",
+			URI:        "../../testdata/encrypted-footer.parquet",
+		},
+		"columns": {
+			ReadOption: encReadOption,
+			Query:      "raw",
+			URI:        "../../testdata/encrypted-columns.parquet",
+		},
+		"uniform": {
+			ReadOption: pio.ReadOption{FooterKey: encFooterKey},
+			Query:      "raw",
+			URI:        "../../testdata/uniform-encryption.parquet",
+		},
 		"aad": {
 			ReadOption: pio.ReadOption{
 				FooterKey:  encFooterKey,

--- a/cmd/split/split_test.go
+++ b/cmd/split/split_test.go
@@ -23,14 +23,38 @@ func TestCmd(t *testing.T) {
 		errMsg string
 	}{
 		// error cases
-		"page-size":   {cmd: Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "", ReadPageSize: 0, RecordCount: 0, URI: "dummy", current: tw}, errMsg: "invalid read page size"},
-		"no-count":    {cmd: Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "", ReadPageSize: 1000, RecordCount: 0, URI: "dummy", current: tw}, errMsg: "needs either --file-count or --record-count"},
-		"name-format": {cmd: Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "ut-%%parquet", ReadPageSize: 1000, RecordCount: 10, URI: "", current: tw}, errMsg: "lack of useable verb"},
-		"source-file": {cmd: Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "%d", ReadPageSize: 1000, RecordCount: 10, URI: "does/not/exist", current: tw}, errMsg: "failed to open"},
-		"int96":       {cmd: Cmd{ReadOption: rOpt, FailOnInt96: true, FileCount: 0, NameFormat: "%d", ReadPageSize: 1000, RecordCount: 10, URI: "../../testdata/all-types.parquet", current: tw}, errMsg: "has type INT96 which is not supported"},
-		"target-file": {cmd: Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "dummy://%d.parquet", ReadPageSize: 1000, RecordCount: 2, URI: "../../testdata/good.parquet", current: tw}, errMsg: "unknown location scheme"},
-		"first-write": {cmd: Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "s3://target/%d.parquet", ReadPageSize: 1000, RecordCount: 1, URI: "../../testdata/good.parquet", current: tw}, errMsg: "failed to close"},
-		"last-write":  {cmd: Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "s3://target/%d.parquet", ReadPageSize: 1000, RecordCount: 3, URI: "../../testdata/good.parquet", current: tw}, errMsg: "failed to close"},
+		"page-size": {
+			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "", ReadPageSize: 0, RecordCount: 0, URI: "dummy", current: tw},
+			errMsg: "invalid read page size",
+		},
+		"no-count": {
+			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "", ReadPageSize: 1000, RecordCount: 0, URI: "dummy", current: tw},
+			errMsg: "needs either --file-count or --record-count",
+		},
+		"name-format": {
+			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "ut-%%parquet", ReadPageSize: 1000, RecordCount: 10, URI: "", current: tw},
+			errMsg: "lack of useable verb",
+		},
+		"source-file": {
+			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "%d", ReadPageSize: 1000, RecordCount: 10, URI: "does/not/exist", current: tw},
+			errMsg: "failed to open",
+		},
+		"int96": {
+			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: true, FileCount: 0, NameFormat: "%d", ReadPageSize: 1000, RecordCount: 10, URI: "../../testdata/all-types.parquet", current: tw},
+			errMsg: "has type INT96 which is not supported",
+		},
+		"target-file": {
+			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "dummy://%d.parquet", ReadPageSize: 1000, RecordCount: 2, URI: "../../testdata/good.parquet", current: tw},
+			errMsg: "unknown location scheme",
+		},
+		"first-write": {
+			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "s3://target/%d.parquet", ReadPageSize: 1000, RecordCount: 1, URI: "../../testdata/good.parquet", current: tw},
+			errMsg: "failed to close",
+		},
+		"last-write": {
+			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "s3://target/%d.parquet", ReadPageSize: 1000, RecordCount: 3, URI: "../../testdata/good.parquet", current: tw},
+			errMsg: "failed to close",
+		},
 		// good cases - URI will be prefixed with "../../testdata/"
 		"record-count": {
 			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "ut-%d.parquet", ReadPageSize: 1000, RecordCount: 2, URI: "all-types.parquet", current: trunkWriter{}},

--- a/cmd/transcode/transcode_test.go
+++ b/cmd/transcode/transcode_test.go
@@ -67,12 +67,30 @@ func testCmdError(t *testing.T) {
 		cmd    Cmd
 		errMsg string
 	}{
-		"pagesize-too-small":  {Cmd{ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 0, Source: "../../testdata/good.parquet", URI: "dummy"}, "invalid read page size"},
-		"source-non-existent": {Cmd{ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 10, Source: "does/not/exist", URI: "dummy"}, "no such file or directory"},
-		"source-not-parquet":  {Cmd{ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 10, Source: "../../testdata/not-a-parquet-file", URI: "dummy"}, "failed to read from"},
-		"target-file":         {Cmd{ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 10, Source: "../../testdata/good.parquet", URI: "://uri"}, "unable to parse file location"},
-		"target-write":        {Cmd{ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 10, Source: "../../testdata/good.parquet", URI: "s3://target"}, "failed to close"},
-		"fail-on-int96":       {Cmd{FailOnInt96: true, ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 10, Source: "../../testdata/all-types.parquet", URI: filepath.Join(tempDir, "dummy")}, "has type INT96 which is not supported"},
+		"pagesize-too-small": {
+			Cmd{ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 0, Source: "../../testdata/good.parquet", URI: "dummy"},
+			"invalid read page size",
+		},
+		"source-non-existent": {
+			Cmd{ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 10, Source: "does/not/exist", URI: "dummy"},
+			"no such file or directory",
+		},
+		"source-not-parquet": {
+			Cmd{ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 10, Source: "../../testdata/not-a-parquet-file", URI: "dummy"},
+			"failed to read from",
+		},
+		"target-file": {
+			Cmd{ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 10, Source: "../../testdata/good.parquet", URI: "://uri"},
+			"unable to parse file location",
+		},
+		"target-write": {
+			Cmd{ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 10, Source: "../../testdata/good.parquet", URI: "s3://target"},
+			"failed to close",
+		},
+		"fail-on-int96": {
+			Cmd{FailOnInt96: true, ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 10, Source: "../../testdata/all-types.parquet", URI: filepath.Join(tempDir, "dummy")},
+			"has type INT96 which is not supported",
+		},
 		"target-compression": {Cmd{ReadOption: rOpt, WriteOption: pio.WriteOption{
 			CompressionCodec: "INVALID",
 			PageSize:         1024 * 1024,
@@ -98,21 +116,111 @@ func testCmdGood(t *testing.T) {
 		omitStats       string
 		rowCount        int64
 	}{
-		"good-gzip":         {"good.parquet", "GZIP", 1, "", 3},
-		"good-zstd":         {"good.parquet", "ZSTD", 1, "", 3},
-		"good-uncompressed": {"good.parquet", "UNCOMPRESSED", 1, "", 3},
-		"good-lz4":          {"good.parquet", "LZ4", 1, "", 3},
-		"good-brotli":       {"good.parquet", "BROTLI", 1, "", 3},
-		"all-types-gzip":    {"all-types.parquet", "GZIP", 1, "", 5},
-		"all-types-zstd":    {"all-types.parquet", "ZSTD", 1, "", 5},
-		"all-types-brotli":  {"all-types.parquet", "BROTLI", 1, "", 5},
-		"empty-gzip":        {"empty.parquet", "GZIP", 1, "", 0},
-		"good-v2":           {"good.parquet", "SNAPPY", 2, "", 3},
-		"all-types-v2-zstd": {"all-types.parquet", "ZSTD", 2, "", 5},
-		"good-v2-brotli":    {"good.parquet", "BROTLI", 2, "", 3},
-		"good-stats-true":   {"good.parquet", "SNAPPY", 1, "true", 3},
-		"good-stats-false":  {"good.parquet", "SNAPPY", 1, "false", 3},
-		"good-all-options":  {"good.parquet", "ZSTD", 2, "true", 3},
+		"good-gzip": {
+			"good.parquet",
+			"GZIP",
+			1,
+			"",
+			3,
+		},
+		"good-zstd": {
+			"good.parquet",
+			"ZSTD",
+			1,
+			"",
+			3,
+		},
+		"good-uncompressed": {
+			"good.parquet",
+			"UNCOMPRESSED",
+			1,
+			"",
+			3,
+		},
+		"good-lz4": {
+			"good.parquet",
+			"LZ4",
+			1,
+			"",
+			3,
+		},
+		"good-brotli": {
+			"good.parquet",
+			"BROTLI",
+			1,
+			"",
+			3,
+		},
+		"all-types-gzip": {
+			"all-types.parquet",
+			"GZIP",
+			1,
+			"",
+			5,
+		},
+		"all-types-zstd": {
+			"all-types.parquet",
+			"ZSTD",
+			1,
+			"",
+			5,
+		},
+		"all-types-brotli": {
+			"all-types.parquet",
+			"BROTLI",
+			1,
+			"",
+			5,
+		},
+		"empty-gzip": {
+			"empty.parquet",
+			"GZIP",
+			1,
+			"",
+			0,
+		},
+		"good-v2": {
+			"good.parquet",
+			"SNAPPY",
+			2,
+			"",
+			3,
+		},
+		"all-types-v2-zstd": {
+			"all-types.parquet",
+			"ZSTD",
+			2,
+			"",
+			5,
+		},
+		"good-v2-brotli": {
+			"good.parquet",
+			"BROTLI",
+			2,
+			"",
+			3,
+		},
+		"good-stats-true": {
+			"good.parquet",
+			"SNAPPY",
+			1,
+			"true",
+			3,
+		},
+		"good-stats-false": {
+			"good.parquet",
+			"SNAPPY",
+			1,
+			"false",
+			3,
+		},
+		"good-all-options": {
+			"good.parquet",
+			"ZSTD",
+			2,
+			"true",
+			3,
+		},
 	}
 	tempDir := t.TempDir()
 

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -14,14 +14,38 @@ func TestCmd(t *testing.T) {
 		cmd    Cmd
 		stdout string
 	}{
-		"plain":             {cmd: Cmd{JSON: false, All: false, BuildTime: false, Source: false}, stdout: "v1.2.3\n"},
-		"plain-with-build":  {cmd: Cmd{JSON: false, All: false, BuildTime: true, Source: false}, stdout: "v1.2.3\ntoday\n"},
-		"plain-with-source": {cmd: Cmd{JSON: false, All: false, BuildTime: false, Source: true}, stdout: "v1.2.3\nUT\n"},
-		"plain-with-all":    {cmd: Cmd{JSON: false, All: true, BuildTime: false, Source: false}, stdout: "v1.2.3\ntoday\nUT\n"},
-		"json":              {cmd: Cmd{JSON: true, All: false, BuildTime: false, Source: false}, stdout: `{"Version":"v1.2.3"}` + "\n"},
-		"json-with-build":   {cmd: Cmd{JSON: true, All: false, BuildTime: true, Source: false}, stdout: `{"Version":"v1.2.3","BuildTime":"today"}` + "\n"},
-		"json-with-source":  {cmd: Cmd{JSON: true, All: false, BuildTime: false, Source: true}, stdout: `{"Version":"v1.2.3","Source":"UT"}` + "\n"},
-		"json-with-all":     {cmd: Cmd{JSON: true, All: true, BuildTime: false, Source: false}, stdout: `{"Version":"v1.2.3","BuildTime":"today","Source":"UT"}` + "\n"},
+		"plain": {
+			cmd:    Cmd{JSON: false, All: false, BuildTime: false, Source: false},
+			stdout: "v1.2.3\n",
+		},
+		"plain-with-build": {
+			cmd:    Cmd{JSON: false, All: false, BuildTime: true, Source: false},
+			stdout: "v1.2.3\ntoday\n",
+		},
+		"plain-with-source": {
+			cmd:    Cmd{JSON: false, All: false, BuildTime: false, Source: true},
+			stdout: "v1.2.3\nUT\n",
+		},
+		"plain-with-all": {
+			cmd:    Cmd{JSON: false, All: true, BuildTime: false, Source: false},
+			stdout: "v1.2.3\ntoday\nUT\n",
+		},
+		"json": {
+			cmd:    Cmd{JSON: true, All: false, BuildTime: false, Source: false},
+			stdout: `{"Version":"v1.2.3"}` + "\n",
+		},
+		"json-with-build": {
+			cmd:    Cmd{JSON: true, All: false, BuildTime: true, Source: false},
+			stdout: `{"Version":"v1.2.3","BuildTime":"today"}` + "\n",
+		},
+		"json-with-source": {
+			cmd:    Cmd{JSON: true, All: false, BuildTime: false, Source: true},
+			stdout: `{"Version":"v1.2.3","Source":"UT"}` + "\n",
+		},
+		"json-with-all": {
+			cmd:    Cmd{JSON: true, All: true, BuildTime: false, Source: false},
+			stdout: `{"Version":"v1.2.3","BuildTime":"today","Source":"UT"}` + "\n",
+		},
 	}
 
 	version = "v1.2.3"

--- a/io/compression_level_test.go
+++ b/io/compression_level_test.go
@@ -13,38 +13,93 @@ func TestParseCompressionLevels(t *testing.T) {
 		errMsg      string
 	}{
 		// Valid cases
-		"single-gzip":       {input: []string{"GZIP=1"}, expectedLen: 1},
-		"single-zstd":       {input: []string{"ZSTD=22"}, expectedLen: 1},
-		"single-brotli":     {input: []string{"BROTLI=0"}, expectedLen: 1},
-		"mixed-case":        {input: []string{"gzip=9"}, expectedLen: 1},
-		"comma-separated":   {input: []string{"GZIP=9,ZSTD=3"}, expectedLen: 2},
-		"whitespace":        {input: []string{" gzip = 9 "}, expectedLen: 1},
-		"whitespace-commas": {input: []string{" GZIP = 6 , ZSTD= 5 "}, expectedLen: 2},
-		"empty-input":       {input: []string{}},
-		"nil-input":         {},
-		"empty-string":      {input: []string{""}},
+		"single-gzip": {
+			input:       []string{"GZIP=1"},
+			expectedLen: 1,
+		},
+		"single-zstd": {
+			input:       []string{"ZSTD=22"},
+			expectedLen: 1,
+		},
+		"single-brotli": {
+			input:       []string{"BROTLI=0"},
+			expectedLen: 1,
+		},
+		"mixed-case": {
+			input:       []string{"gzip=9"},
+			expectedLen: 1,
+		},
+		"comma-separated": {
+			input:       []string{"GZIP=9,ZSTD=3"},
+			expectedLen: 2,
+		},
+		"whitespace": {
+			input:       []string{" gzip = 9 "},
+			expectedLen: 1,
+		},
+		"whitespace-commas": {
+			input:       []string{" GZIP = 6 , ZSTD= 5 "},
+			expectedLen: 2,
+		},
+		"empty-input": {
+			input: []string{},
+		},
+		"nil-input": {},
+		"empty-string": {
+			input: []string{""},
+		},
 
 		// Duplicate ordering: left-to-right, last wins
-		"duplicate-across-flags": {input: []string{"GZIP=3", "ZSTD=2,GZIP=9"}, expectedLen: 2},
+		"duplicate-across-flags": {
+			input:       []string{"GZIP=3", "ZSTD=2,GZIP=9"},
+			expectedLen: 2,
+		},
 
 		// Invalid format
-		"no-equals":       {input: []string{"GZIP9"}, errMsg: "invalid compression level format"},
-		"equals-no-codec": {input: []string{"=9"}, errMsg: "empty codec"},
-		"equals-no-level": {input: []string{"GZIP="}, errMsg: "empty level"},
-		"just-equals":     {input: []string{"="}, errMsg: "empty codec"},
+		"no-equals": {
+			input:  []string{"GZIP9"},
+			errMsg: "invalid compression level format",
+		},
+		"equals-no-codec": {
+			input:  []string{"=9"},
+			errMsg: "empty codec",
+		},
+		"equals-no-level": {
+			input:  []string{"GZIP="},
+			errMsg: "empty level",
+		},
+		"just-equals": {
+			input:  []string{"="},
+			errMsg: "empty codec",
+		},
 
 		// Invalid level
-		"non-integer": {input: []string{"GZIP=abc"}, errMsg: "must be an integer"},
+		"non-integer": {
+			input:  []string{"GZIP=abc"},
+			errMsg: "must be an integer",
+		},
 
 		// Unsupported codecs
-		"snappy":       {input: []string{"SNAPPY=1"}, errMsg: "does not support compression levels"},
-		"uncompressed": {input: []string{"UNCOMPRESSED=3"}, errMsg: "does not support compression levels"},
+		"snappy": {
+			input:  []string{"SNAPPY=1"},
+			errMsg: "does not support compression levels",
+		},
+		"uncompressed": {
+			input:  []string{"UNCOMPRESSED=3"},
+			errMsg: "does not support compression levels",
+		},
 
 		// Unknown codec
-		"unknown-codec": {input: []string{"FOO=1"}, errMsg: "unknown codec"},
+		"unknown-codec": {
+			input:  []string{"FOO=1"},
+			errMsg: "unknown codec",
+		},
 
 		// Range error
-		"gzip-out-of-range": {input: []string{"GZIP=99"}, errMsg: "out of range"},
+		"gzip-out-of-range": {
+			input:  []string{"GZIP=99"},
+			errMsg: "out of range",
+		},
 	}
 
 	for name, tc := range testCases {

--- a/io/io_test.go
+++ b/io/io_test.go
@@ -124,13 +124,55 @@ func TestGetBucketRegion(t *testing.T) {
 		ignoreTLS bool
 		errMsg    string
 	}{
-		"non-existent-bucket":            {"", uuid.New().String(), true, false, "not found"},
-		"unable-to-get-region":           {"", "localhost/something/does/not/matter", true, false, "unable to get region for S3 bucket"},
-		"bucket-name-with-dot":           {"", "xiehang.com", false, true, ""},
-		"bucket-name-with-dot-no-ignore": {"", "xiehang.com", false, false, "unable to get region for S3 bucket"},
-		"private-bucket":                 {"", "doc-example-bucket", true, false, "S3 bucket doc-example-bucket is not public"},
-		"aws-error":                      {"", "00", true, false, "unrecognized StatusCode from AWS: 400"},
-		"missing-credential":             {uuid.New().String(), "daylight-openstreetmap", false, false, "failed to get shared config profile"},
+		"non-existent-bucket": {
+			"",
+			uuid.New().String(),
+			true,
+			false,
+			"not found",
+		},
+		"unable-to-get-region": {
+			"",
+			"localhost/something/does/not/matter",
+			true,
+			false,
+			"unable to get region for S3 bucket",
+		},
+		"bucket-name-with-dot": {
+			"",
+			"xiehang.com",
+			false,
+			true,
+			"",
+		},
+		"bucket-name-with-dot-no-ignore": {
+			"",
+			"xiehang.com",
+			false,
+			false,
+			"unable to get region for S3 bucket",
+		},
+		"private-bucket": {
+			"",
+			"doc-example-bucket",
+			true,
+			false,
+			"S3 bucket doc-example-bucket is not public",
+		},
+		"aws-error": {
+			"",
+			"00",
+			true,
+			false,
+			"unrecognized StatusCode from AWS: 400",
+		},
+		"missing-credential": {
+			uuid.New().String(),
+			"daylight-openstreetmap",
+			false,
+			false,
+			"failed to get shared config profile",
+		},
 	}
 
 	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
@@ -167,11 +209,41 @@ func TestParseURI(t *testing.T) {
 		path   string
 		errMsg string
 	}{
-		"invalid-uri":    {"://uri", "", "", "", "unable to parse file location"},
-		"with-user":      {"scheme://username@path/to/file", "scheme", "path", "/to/file", ""},
-		"with-file":      {"file://path/to/file", "file", "", "path/to/file", ""},
-		"with-file-root": {"file:///path/to/file", "file", "", "/path/to/file", ""},
-		"without-file":   {"path/to/file", "file", "", "path/to/file", ""},
+		"invalid-uri": {
+			"://uri",
+			"",
+			"",
+			"",
+			"unable to parse file location",
+		},
+		"with-user": {
+			"scheme://username@path/to/file",
+			"scheme",
+			"path",
+			"/to/file",
+			"",
+		},
+		"with-file": {
+			"file://path/to/file",
+			"file",
+			"",
+			"path/to/file",
+			"",
+		},
+		"with-file-root": {
+			"file:///path/to/file",
+			"file",
+			"",
+			"/path/to/file",
+			"",
+		},
+		"without-file": {
+			"path/to/file",
+			"file",
+			"",
+			"path/to/file",
+			"",
+		},
 	}
 
 	for name, tc := range testCases {

--- a/io/reader_test.go
+++ b/io/reader_test.go
@@ -28,17 +28,47 @@ func TestBuildReaderOptions(t *testing.T) {
 		option ReadOption
 		errMsg string
 	}{
-		"empty":                    {option: ReadOption{}},
-		"invalid-footer-key":       {option: ReadOption{FooterKey: "!!!"}, errMsg: "invalid base64 footer key"},
-		"invalid-aad-prefix":       {option: ReadOption{AADPrefix: "!!!"}, errMsg: "invalid base64 AAD prefix"},
-		"column-key-missing-equal": {option: ReadOption{ColumnKeys: []string{"colpath"}}, errMsg: "invalid column key format"},
-		"column-key-empty-path":    {option: ReadOption{ColumnKeys: []string{"=YWJj"}}, errMsg: "invalid column key format"},
-		"column-key-empty-value":   {option: ReadOption{ColumnKeys: []string{"col.path="}}, errMsg: "invalid column key format"},
-		"column-key-invalid-key":   {option: ReadOption{ColumnKeys: []string{"col.path=!!!"}}, errMsg: "invalid base64 column key"},
-		"valid-footer-key-std":     {option: ReadOption{FooterKey: testFooterKey}},
-		"reject-url-safe-base64":   {option: ReadOption{FooterKey: "-_8="}, errMsg: "invalid base64 footer key"},
-		"reject-unpadded-base64":   {option: ReadOption{FooterKey: "MDEyMzQ1Njc4OTAxMjM0NQ"}, errMsg: "invalid base64 footer key"},
-		"valid-column-key":         {option: ReadOption{ColumnKeys: []string{"double_field=" + testDoubleFieldKey}}},
+		"empty": {
+			option: ReadOption{},
+		},
+		"invalid-footer-key": {
+			option: ReadOption{FooterKey: "!!!"},
+			errMsg: "invalid base64 footer key",
+		},
+		"invalid-aad-prefix": {
+			option: ReadOption{AADPrefix: "!!!"},
+			errMsg: "invalid base64 AAD prefix",
+		},
+		"column-key-missing-equal": {
+			option: ReadOption{ColumnKeys: []string{"colpath"}},
+			errMsg: "invalid column key format",
+		},
+		"column-key-empty-path": {
+			option: ReadOption{ColumnKeys: []string{"=YWJj"}},
+			errMsg: "invalid column key format",
+		},
+		"column-key-empty-value": {
+			option: ReadOption{ColumnKeys: []string{"col.path="}},
+			errMsg: "invalid column key format",
+		},
+		"column-key-invalid-key": {
+			option: ReadOption{ColumnKeys: []string{"col.path=!!!"}},
+			errMsg: "invalid base64 column key",
+		},
+		"valid-footer-key-std": {
+			option: ReadOption{FooterKey: testFooterKey},
+		},
+		"reject-url-safe-base64": {
+			option: ReadOption{FooterKey: "-_8="},
+			errMsg: "invalid base64 footer key",
+		},
+		"reject-unpadded-base64": {
+			option: ReadOption{FooterKey: "MDEyMzQ1Njc4OTAxMjM0NQ"},
+			errMsg: "invalid base64 footer key",
+		},
+		"valid-column-key": {
+			option: ReadOption{ColumnKeys: []string{"double_field=" + testDoubleFieldKey}},
+		},
 		"multiple-column-keys": {
 			option: ReadOption{ColumnKeys: []string{
 				"double_field=" + testDoubleFieldKey,
@@ -79,27 +109,111 @@ func TestNewParquetFileReader(t *testing.T) {
 		option ReadOption
 		errMsg string
 	}{
-		"invalid-uri":            {"://uri", rOpt, "unable to parse file location"},
-		"invalid-scheme":         {"invalid-scheme://something", rOpt, "unknown location scheme"},
-		"local-file-not-found":   {"file://path/to/file", rOpt, "no such file or directory"},
-		"local-file-not-parquet": {"../testdata/not-a-parquet-file", rOpt, "invalid argument"},
-		"local-file-good":        {"../testdata/good.parquet", rOpt, ""},
-		"s3-not-found":           {"s3://bucket-does-not-exist", rOpt, "not found"},
-		"s3-good":                {s3URL, ReadOption{Anonymous: true}, ""},
-		"s3-wrong-version":       {s3URL, ReadOption{ObjectVersion: "random-version-id", Anonymous: true}, "https response error StatusCode: 400"},
-		"gcs-no-permission":      {gcsURL, rOpt, "failed to create GCS client"},
-		"gcs-wrong-generation":   {gcsURL, ReadOption{Anonymous: true, ObjectVersion: "99999"}, "Error 404: No such object:"},
-		"gcs-good":               {gcsURL, ReadOption{Anonymous: true}, ""},
-		"gcs-good-with-gen":      {gcsURL, ReadOption{Anonymous: true, ObjectVersion: "-1"}, ""},
-		"azblob-no-permission":   {azblobURL, rOpt, "Server failed to authenticate the request"},
-		"azblob-bad-version":     {azblobURL, ReadOption{Anonymous: true, ObjectVersion: "foo-bar"}, "RESPONSE 400: 400"},
-		"azblob-good":            {azblobURL, ReadOption{Anonymous: true}, ""},
-		"http-bad-url":           {"https://.../", rOpt, "no such host"},
-		"http-no-range-support":  {"https://www.google.com/", rOpt, "does not support range"},
-		"http-good":              {httpURL, rOpt, ""},
-		"hdfs-failed":            {"hdfs://localhost:1/temp/good.parquet", rOpt, "connection refused"},
-		"azblob-invalid-uri1":    {"wasbs://bad/url", rOpt, "azure blob URI format:"},
-		"azblob-invalid-uri2":    {"wasbs://storageaccount.blob.core.windows.net//aa", rOpt, "azure blob URI format:"},
+		"invalid-uri": {
+			"://uri",
+			rOpt,
+			"unable to parse file location",
+		},
+		"invalid-scheme": {
+			"invalid-scheme://something",
+			rOpt,
+			"unknown location scheme",
+		},
+		"local-file-not-found": {
+			"file://path/to/file",
+			rOpt,
+			"no such file or directory",
+		},
+		"local-file-not-parquet": {
+			"../testdata/not-a-parquet-file",
+			rOpt,
+			"invalid argument",
+		},
+		"local-file-good": {
+			"../testdata/good.parquet",
+			rOpt,
+			"",
+		},
+		"s3-not-found": {
+			"s3://bucket-does-not-exist",
+			rOpt,
+			"not found",
+		},
+		"s3-good": {
+			s3URL,
+			ReadOption{Anonymous: true},
+			"",
+		},
+		"s3-wrong-version": {
+			s3URL,
+			ReadOption{ObjectVersion: "random-version-id", Anonymous: true},
+			"https response error StatusCode: 400",
+		},
+		"gcs-no-permission": {
+			gcsURL,
+			rOpt,
+			"failed to create GCS client",
+		},
+		"gcs-wrong-generation": {
+			gcsURL,
+			ReadOption{Anonymous: true, ObjectVersion: "99999"},
+			"Error 404: No such object:",
+		},
+		"gcs-good": {
+			gcsURL,
+			ReadOption{Anonymous: true},
+			"",
+		},
+		"gcs-good-with-gen": {
+			gcsURL,
+			ReadOption{Anonymous: true, ObjectVersion: "-1"},
+			"",
+		},
+		"azblob-no-permission": {
+			azblobURL,
+			rOpt,
+			"Server failed to authenticate the request",
+		},
+		"azblob-bad-version": {
+			azblobURL,
+			ReadOption{Anonymous: true, ObjectVersion: "foo-bar"},
+			"RESPONSE 400: 400",
+		},
+		"azblob-good": {
+			azblobURL,
+			ReadOption{Anonymous: true},
+			"",
+		},
+		"http-bad-url": {
+			"https://.../",
+			rOpt,
+			"no such host",
+		},
+		"http-no-range-support": {
+			"https://www.google.com/",
+			rOpt,
+			"does not support range",
+		},
+		"http-good": {
+			httpURL,
+			rOpt,
+			"",
+		},
+		"hdfs-failed": {
+			"hdfs://localhost:1/temp/good.parquet",
+			rOpt,
+			"connection refused",
+		},
+		"azblob-invalid-uri1": {
+			"wasbs://bad/url",
+			rOpt,
+			"azure blob URI format:",
+		},
+		"azblob-invalid-uri2": {
+			"wasbs://storageaccount.blob.core.windows.net//aa",
+			rOpt,
+			"azure blob URI format:",
+		},
 	}
 
 	t.Setenv("AWS_CONFIG_FILE", "/dev/null")

--- a/io/writer_test.go
+++ b/io/writer_test.go
@@ -43,20 +43,62 @@ func TestNewParquetFileWriter(t *testing.T) {
 		uri    string
 		errMsg string
 	}{
-		"invalid-uri":          {"://uri", "unable to parse file location"},
-		"invalid-scheme":       {"invalid-scheme://something", "unknown location scheme"},
-		"local-file-not-found": {"file://path/to/file", "no such file or directory"},
-		"local-not-file":       {"../testdata/", "is a directory"},
-		"local-file-good":      {tempFile, ""},
-		"s3-bucket-not-found":  {"s3://bucket-does-not-exist" + uuid.NewString(), "not found"},
-		"s3-good":              {"s3://daylight-openstreetmap/will-not-create-till-close", ""},
-		"gcs-no-permission":    {"gs://cloud-samples-data/bigquery/us-states/us-states.parquet", "failed to open GCS object"},
-		"azblob-invalid-uri1":  {"wasbs://bad/url", "azure blob URI format:"},
-		"azblob-invalid-uri2":  {"wasbs://storageaccount.blob.core.windows.net//aa", "azure blob URI format:"},
-		"azblob-good":          {"wasbs://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/will-not-create-till-close", ""},
-		"http-not-support":     {"https://domain.tld/path/to/file", "writing to [https] endpoint is not currently supported"},
-		"hdfs-failed":          {"hdfs://localhost:1/temp/good.parquet", "connection refused"},
-		"hdfs-with-user":       {"hdfs://user@localhost:1/temp/good.parquet", "connection refused"},
+		"invalid-uri": {
+			"://uri",
+			"unable to parse file location",
+		},
+		"invalid-scheme": {
+			"invalid-scheme://something",
+			"unknown location scheme",
+		},
+		"local-file-not-found": {
+			"file://path/to/file",
+			"no such file or directory",
+		},
+		"local-not-file": {
+			"../testdata/",
+			"is a directory",
+		},
+		"local-file-good": {
+			tempFile,
+			"",
+		},
+		"s3-bucket-not-found": {
+			"s3://bucket-does-not-exist" + uuid.NewString(),
+			"not found",
+		},
+		"s3-good": {
+			"s3://daylight-openstreetmap/will-not-create-till-close",
+			"",
+		},
+		"gcs-no-permission": {
+			"gs://cloud-samples-data/bigquery/us-states/us-states.parquet",
+			"failed to open GCS object",
+		},
+		"azblob-invalid-uri1": {
+			"wasbs://bad/url",
+			"azure blob URI format:",
+		},
+		"azblob-invalid-uri2": {
+			"wasbs://storageaccount.blob.core.windows.net//aa",
+			"azure blob URI format:",
+		},
+		"azblob-good": {
+			"wasbs://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/will-not-create-till-close",
+			"",
+		},
+		"http-not-support": {
+			"https://domain.tld/path/to/file",
+			"writing to [https] endpoint is not currently supported",
+		},
+		"hdfs-failed": {
+			"hdfs://localhost:1/temp/good.parquet",
+			"connection refused",
+		},
+		"hdfs-with-user": {
+			"hdfs://user@localhost:1/temp/good.parquet",
+			"connection refused",
+		},
 	}
 
 	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
@@ -193,8 +235,12 @@ func TestParseWriterColumnKeys(t *testing.T) {
 		errMsg    string
 		wantPaths []string
 	}{
-		"nil":   {raw: nil},
-		"empty": {raw: []string{}},
+		"nil": {
+			raw: nil,
+		},
+		"empty": {
+			raw: []string{},
+		},
 		"single": {
 			raw:       []string{"name=" + key16},
 			wantPaths: []string{"name"},
@@ -203,11 +249,26 @@ func TestParseWriterColumnKeys(t *testing.T) {
 			raw:       []string{"a=" + key16, "b=@footer-key"},
 			wantPaths: []string{"a", "b"},
 		},
-		"missing-equals":       {raw: []string{"name"}, errMsg: "invalid writer column key format [name]"},
-		"empty-path":           {raw: []string{"=" + key16}, errMsg: "invalid writer column key format [="},
-		"empty-value":          {raw: []string{"name="}, errMsg: "invalid writer column key format [name=]"},
-		"duplicate-exact":      {raw: []string{"name=" + key16, "name=@footer-key"}, errMsg: "duplicate writer column key path [name]"},
-		"duplicate-normalized": {raw: []string{"Parent.Child=" + key16, "Parent.Child=@footer-key"}, errMsg: "duplicate writer column key path [Parent.Child]"},
+		"missing-equals": {
+			raw:    []string{"name"},
+			errMsg: "invalid writer column key format [name]",
+		},
+		"empty-path": {
+			raw:    []string{"=" + key16},
+			errMsg: "invalid writer column key format [=",
+		},
+		"empty-value": {
+			raw:    []string{"name="},
+			errMsg: "invalid writer column key format [name=]",
+		},
+		"duplicate-exact": {
+			raw:    []string{"name=" + key16, "name=@footer-key"},
+			errMsg: "duplicate writer column key path [name]",
+		},
+		"duplicate-normalized": {
+			raw:    []string{"Parent.Child=" + key16, "Parent.Child=@footer-key"},
+			errMsg: "duplicate writer column key path [Parent.Child]",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -345,15 +406,60 @@ func TestNewCSVWriter(t *testing.T) {
 		schema []string
 		errMsg string
 	}{
-		"invalid-uri":       {wOpt, "://uri", nil, "unable to parse file location"},
-		"invalid-scheme":    {wOpt, "invalid-scheme://something", nil, "unknown location scheme"},
-		"invalid-schema1":   {wOpt, tempFile, []string{"invalid schema"}, "expect 'key=value'"},
-		"invalid-schema2":   {wOpt, tempFile, []string{"name=Id"}, "not a valid Type string"},
-		"invalid-schema3":   {wOpt, tempFile, []string{"name=Id, type=FOOBAR"}, "field [Id] with type [FOOBAR]: not a valid Type string"},
-		"invalid-codec":     {WriteOption{CompressionCodec: "FOOBAR"}, tempFile, []string{"name=Id, type=INT64"}, "not a valid CompressionCodec string"},
-		"unsupported-codec": {WriteOption{CompressionCodec: "LZO"}, tempFile, []string{"name=Id, type=INT64"}, "compression is not supported at this moment"},
-		"supported-brotli":  {WriteOption{CompressionCodec: "BROTLI"}, tempFile, []string{"name=Id, type=INT64"}, ""},
-		"compression-level": {WriteOption{CompressionCodec: "GZIP", CompressionLevel: []string{"GZIP=6"}}, tempFile, []string{"name=Id, type=INT64"}, ""},
+		"invalid-uri": {
+			wOpt,
+			"://uri",
+			nil,
+			"unable to parse file location",
+		},
+		"invalid-scheme": {
+			wOpt,
+			"invalid-scheme://something",
+			nil,
+			"unknown location scheme",
+		},
+		"invalid-schema1": {
+			wOpt,
+			tempFile,
+			[]string{"invalid schema"},
+			"expect 'key=value'",
+		},
+		"invalid-schema2": {
+			wOpt,
+			tempFile,
+			[]string{"name=Id"},
+			"not a valid Type string",
+		},
+		"invalid-schema3": {
+			wOpt,
+			tempFile,
+			[]string{"name=Id, type=FOOBAR"},
+			"field [Id] with type [FOOBAR]: not a valid Type string",
+		},
+		"invalid-codec": {
+			WriteOption{CompressionCodec: "FOOBAR"},
+			tempFile,
+			[]string{"name=Id, type=INT64"},
+			"not a valid CompressionCodec string",
+		},
+		"unsupported-codec": {
+			WriteOption{CompressionCodec: "LZO"},
+			tempFile,
+			[]string{"name=Id, type=INT64"},
+			"compression is not supported at this moment",
+		},
+		"supported-brotli": {
+			WriteOption{CompressionCodec: "BROTLI"},
+			tempFile,
+			[]string{"name=Id, type=INT64"},
+			"",
+		},
+		"compression-level": {
+			WriteOption{CompressionCodec: "GZIP", CompressionLevel: []string{"GZIP=6"}},
+			tempFile,
+			[]string{"name=Id, type=INT64"},
+			"",
+		},
 		"column-key-parse-error": {
 			WriteOption{
 				WriterFooterKey:  testWriterKeyBase64(16),
@@ -399,8 +505,18 @@ func TestNewCSVWriter(t *testing.T) {
 			[]string{"name=Id, type=INT64"},
 			"",
 		},
-		"hdfs-failed": {wOpt, "hdfs://localhost:1/temp/good.parquet", nil, "connection refused"},
-		"all-good":    {WriteOption{CompressionCodec: "SNAPPY"}, tempFile, []string{"name=Id, type=INT64"}, ""},
+		"hdfs-failed": {
+			wOpt,
+			"hdfs://localhost:1/temp/good.parquet",
+			nil,
+			"connection refused",
+		},
+		"all-good": {
+			WriteOption{CompressionCodec: "SNAPPY"},
+			tempFile,
+			[]string{"name=Id, type=INT64"},
+			"",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -434,11 +550,36 @@ func TestNewJSONWriter(t *testing.T) {
 		option WriteOption
 		errMsg string
 	}{
-		"invalid-uri":         {"://uri", "", WriteOption{CompressionCodec: "SNAPPY"}, "unable to parse file location"},
-		"invalid-schema1":     {tempFile, "invalid schema", WriteOption{CompressionCodec: "SNAPPY"}, "unmarshal json schema string"},
-		"invalid-schema2":     {tempFile, `{"Tag":"name=top","Fields":[{"Tag":"name=id, type=FOOBAR"}]}`, WriteOption{CompressionCodec: "SNAPPY"}, "field [Id] with type [FOOBAR]: not a valid Type string"},
-		"invalid-compression": {tempFile, validSchema, WriteOption{CompressionCodec: "INVALID"}, "not a valid CompressionCodec"},
-		"compression-level":   {tempFile, validSchema, WriteOption{CompressionCodec: "GZIP", CompressionLevel: []string{"GZIP=6"}}, ""},
+		"invalid-uri": {
+			"://uri",
+			"",
+			WriteOption{CompressionCodec: "SNAPPY"},
+			"unable to parse file location",
+		},
+		"invalid-schema1": {
+			tempFile,
+			"invalid schema",
+			WriteOption{CompressionCodec: "SNAPPY"},
+			"unmarshal json schema string",
+		},
+		"invalid-schema2": {
+			tempFile,
+			`{"Tag":"name=top","Fields":[{"Tag":"name=id, type=FOOBAR"}]}`,
+			WriteOption{CompressionCodec: "SNAPPY"},
+			"field [Id] with type [FOOBAR]: not a valid Type string",
+		},
+		"invalid-compression": {
+			tempFile,
+			validSchema,
+			WriteOption{CompressionCodec: "INVALID"},
+			"not a valid CompressionCodec",
+		},
+		"compression-level": {
+			tempFile,
+			validSchema,
+			WriteOption{CompressionCodec: "GZIP", CompressionLevel: []string{"GZIP=6"}},
+			"",
+		},
 		"column-key-parse-error": {
 			tempFile,
 			validSchema,
@@ -484,7 +625,12 @@ func TestNewJSONWriter(t *testing.T) {
 			},
 			"",
 		},
-		"all-good": {tempFile, validSchema, WriteOption{CompressionCodec: "SNAPPY"}, ""},
+		"all-good": {
+			tempFile,
+			validSchema,
+			WriteOption{CompressionCodec: "SNAPPY"},
+			"",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -518,21 +664,96 @@ func TestNewGenericWriter(t *testing.T) {
 		schema string
 		errMsg string
 	}{
-		"invalid-uri":                      {"://uri", WriteOption{}, "", "unable to parse file location"},
-		"schema-not-json":                  {tempFile, WriteOption{}, "invalid schema", "unmarshal json schema string:"},
-		"schema-invalid":                   {tempFile, WriteOption{}, `{"Tag":"name=root","Fields":[{"Tag":"name=id, type=FOOBAR"}]}`, "field [Id] with type [FOOBAR]: not a valid Type string"},
-		"invalid-codec":                    {tempFile, WriteOption{CompressionCodec: "FOOBAR"}, schema, "not a valid CompressionCodec string"},
-		"unsupported-codec":                {tempFile, WriteOption{CompressionCodec: "LZO"}, schema, "compression is not supported at this moment"},
-		"supported-brotli":                 {tempFile, WriteOption{CompressionCodec: "BROTLI"}, schema, ""},
-		"all-good":                         {tempFile, WriteOption{CompressionCodec: "SNAPPY"}, schema, ""},
-		"compression-level-gzip":           {tempFile, WriteOption{CompressionCodec: "GZIP", CompressionLevel: []string{"GZIP=6"}}, schema, ""},
-		"compression-level-zstd":           {tempFile, WriteOption{CompressionCodec: "ZSTD", CompressionLevel: []string{"ZSTD=3"}}, schema, ""},
-		"compression-level-brotli":         {tempFile, WriteOption{CompressionCodec: "BROTLI", CompressionLevel: []string{"BROTLI=5"}}, schema, ""},
-		"compression-level-lz4raw":         {tempFile, WriteOption{CompressionCodec: "LZ4_RAW", CompressionLevel: []string{"LZ4_RAW=3"}}, schema, ""},
-		"compression-level-snappy-invalid": {tempFile, WriteOption{CompressionCodec: "SNAPPY", CompressionLevel: []string{"SNAPPY=3"}}, schema, "does not support compression levels"},
-		"compression-level-invalid-value":  {tempFile, WriteOption{CompressionCodec: "GZIP", CompressionLevel: []string{"GZIP=99"}}, schema, "out of range"},
-		"compression-level-multi":          {tempFile, WriteOption{CompressionCodec: "GZIP", CompressionLevel: []string{"GZIP=6,ZSTD=3"}}, schema, ""},
-		"compression-level-nil":            {tempFile, WriteOption{CompressionCodec: "GZIP"}, schema, ""},
+		"invalid-uri": {
+			"://uri",
+			WriteOption{},
+			"",
+			"unable to parse file location",
+		},
+		"schema-not-json": {
+			tempFile,
+			WriteOption{},
+			"invalid schema",
+			"unmarshal json schema string:",
+		},
+		"schema-invalid": {
+			tempFile,
+			WriteOption{},
+			`{"Tag":"name=root","Fields":[{"Tag":"name=id, type=FOOBAR"}]}`,
+			"field [Id] with type [FOOBAR]: not a valid Type string",
+		},
+		"invalid-codec": {
+			tempFile,
+			WriteOption{CompressionCodec: "FOOBAR"},
+			schema,
+			"not a valid CompressionCodec string",
+		},
+		"unsupported-codec": {
+			tempFile,
+			WriteOption{CompressionCodec: "LZO"},
+			schema,
+			"compression is not supported at this moment",
+		},
+		"supported-brotli": {
+			tempFile,
+			WriteOption{CompressionCodec: "BROTLI"},
+			schema,
+			"",
+		},
+		"all-good": {
+			tempFile,
+			WriteOption{CompressionCodec: "SNAPPY"},
+			schema,
+			"",
+		},
+		"compression-level-gzip": {
+			tempFile,
+			WriteOption{CompressionCodec: "GZIP", CompressionLevel: []string{"GZIP=6"}},
+			schema,
+			"",
+		},
+		"compression-level-zstd": {
+			tempFile,
+			WriteOption{CompressionCodec: "ZSTD", CompressionLevel: []string{"ZSTD=3"}},
+			schema,
+			"",
+		},
+		"compression-level-brotli": {
+			tempFile,
+			WriteOption{CompressionCodec: "BROTLI", CompressionLevel: []string{"BROTLI=5"}},
+			schema,
+			"",
+		},
+		"compression-level-lz4raw": {
+			tempFile,
+			WriteOption{CompressionCodec: "LZ4_RAW", CompressionLevel: []string{"LZ4_RAW=3"}},
+			schema,
+			"",
+		},
+		"compression-level-snappy-invalid": {
+			tempFile,
+			WriteOption{CompressionCodec: "SNAPPY", CompressionLevel: []string{"SNAPPY=3"}},
+			schema,
+			"does not support compression levels",
+		},
+		"compression-level-invalid-value": {
+			tempFile,
+			WriteOption{CompressionCodec: "GZIP", CompressionLevel: []string{"GZIP=99"}},
+			schema,
+			"out of range",
+		},
+		"compression-level-multi": {
+			tempFile,
+			WriteOption{CompressionCodec: "GZIP", CompressionLevel: []string{"GZIP=6,ZSTD=3"}},
+			schema,
+			"",
+		},
+		"compression-level-nil": {
+			tempFile,
+			WriteOption{CompressionCodec: "GZIP"},
+			schema,
+			"",
+		},
 		"column-key-parse-error": {
 			tempFile,
 			WriteOption{

--- a/schema/schemanode_test.go
+++ b/schema/schemanode_test.go
@@ -407,10 +407,22 @@ func TestTimeUnitToTag(t *testing.T) {
 		unit    parquet.TimeUnit
 		unitTag string
 	}{
-		"empty-unit": {parquet.TimeUnit{}, "UNKNOWN_UNIT"},
-		"nanos":      {parquet.TimeUnit{NANOS: &parquet.NanoSeconds{}}, "NANOS"},
-		"micros":     {parquet.TimeUnit{MICROS: &parquet.MicroSeconds{}}, "MICROS"},
-		"millis":     {parquet.TimeUnit{MILLIS: &parquet.MilliSeconds{}}, "MILLIS"},
+		"empty-unit": {
+			parquet.TimeUnit{},
+			"UNKNOWN_UNIT",
+		},
+		"nanos": {
+			parquet.TimeUnit{NANOS: &parquet.NanoSeconds{}},
+			"NANOS",
+		},
+		"micros": {
+			parquet.TimeUnit{MICROS: &parquet.MicroSeconds{}},
+			"MICROS",
+		},
+		"millis": {
+			parquet.TimeUnit{MILLIS: &parquet.MilliSeconds{}},
+			"MILLIS",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -1757,7 +1769,10 @@ func TestPopulateLeafMetadata(t *testing.T) {
 			ExNamePath:    []string{"root"},
 		}
 		bfMap := map[string]bloomFilterInfo{
-			"col1": {Enabled: true, Size: 0},
+			"col1": {
+				Enabled: true,
+				Size:    0,
+			},
 		}
 		populateLeafMetadata(root, nil, nil, bfMap)
 		require.Equal(t, "true", node.BloomFilter)
@@ -1773,7 +1788,10 @@ func TestPopulateLeafMetadata(t *testing.T) {
 			ExNamePath:    []string{"root"},
 		}
 		bfMap := map[string]bloomFilterInfo{
-			"col1": {Enabled: true, Size: 1024},
+			"col1": {
+				Enabled: true,
+				Size:    1024,
+			},
 		}
 		populateLeafMetadata(root, nil, nil, bfMap)
 		require.Equal(t, "true", node.BloomFilter)
@@ -1789,7 +1807,9 @@ func TestPopulateLeafMetadata(t *testing.T) {
 			ExNamePath:    []string{"root"},
 		}
 		bfMap := map[string]bloomFilterInfo{
-			"col1": {Enabled: false},
+			"col1": {
+				Enabled: false,
+			},
 		}
 		populateLeafMetadata(root, nil, nil, bfMap)
 		require.Empty(t, node.BloomFilter)


### PR DESCRIPTION
## Summary

- Reformat all 391 table-driven test case map entries across 17 test files from single-line to multi-line format
- Each test case entry now has its outer struct fields on separate lines, while inner struct literals remain compact
- Run `gofmt` to ensure consistent indentation throughout

## Motivation

Single-line entries cause noisy diffs when a new field is added to the test struct — the entire line changes. Multi-line format isolates each field change to its own line.

## Test plan

- [ ] `make all` passes (pure formatting change, no logic altered)