### PR TITLE
feat: add weekly star history chart to GitHub Pages

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,46 @@
+name: star-history
+
+on:
+  schedule:
+    - cron: '0 6 * * 0'   # Sunday 06:00 UTC
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - scripts/star-history.py
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate star history page
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist
+          python3 scripts/star-history.py dist/index.html
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/scripts/star-history.py
+++ b/scripts/star-history.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Fetch star history for hangxie/parquet-tools and generate an interactive HTML chart.
+
+Usage:
+    python3 scripts/star-history.py [output.html]
+
+Environment:
+    GITHUB_TOKEN  GitHub personal access token (raises rate limit from 60 to 5000/hr)
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+REPO = "hangxie/parquet-tools"
+RECENT_DAYS = 30  # daily hover tips for this many days at the trailing end of the chart
+
+
+def fetch_stars(token=None):
+    """Return sorted list of star date strings ('YYYY-MM-DD') via GitHub API."""
+    stars = []
+    page = 1
+    headers = {
+        "Accept": "application/vnd.github.v3.star+json",
+        "User-Agent": "star-history/1.0",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    while True:
+        url = f"https://api.github.com/repos/{REPO}/stargazers?per_page=100&page={page}"
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                data = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            print(f"GitHub API error (page {page}): {e}", file=sys.stderr)
+            sys.exit(1)
+
+        if not data:
+            break
+        for item in data:
+            stars.append(item["starred_at"][:10])  # "YYYY-MM-DD"
+        if len(data) < 100:
+            break
+        page += 1
+
+    return sorted(stars)
+
+
+def cumulative_by_date(star_dates):
+    """Return dict mapping date string -> cumulative star count."""
+    daily = Counter(star_dates)
+    result = {}
+    running = 0
+    for d in sorted(daily):
+        running += daily[d]
+        result[d] = running
+    return result
+
+
+def monthly_points(cumulative):
+    """Return list of (date, count) using the last day with data in each month."""
+    monthly = {}
+    for date, count in sorted(cumulative.items()):
+        monthly[date[:7]] = (date, count)
+    return [v for _, v in sorted(monthly.items())]
+
+
+def tick_step(max_val):
+    """Return a tick interval giving 2-5 gridlines from 0 to max_val."""
+    for step in [50, 100, 200, 250, 500, 1000, 2000, 5000, 10000, 25000]:
+        if 2 <= max_val // step <= 5:
+            return step
+    return max(1, max_val // 4)
+
+
+def generate_html(monthly, cumulative, output_path, recent_days=RECENT_DAYS):
+    if not monthly:
+        print("No star data to chart.", file=sys.stderr)
+        sys.exit(1)
+
+    max_count = monthly[-1][1]
+    y_max = max_count
+    y_step = tick_step(max_count)
+
+    W, H = 900, 420
+    ML, MR, MT, MB = 65, 30, 30, 50
+    cw, ch = W - ML - MR, H - MT - MB
+
+    first = datetime.strptime(monthly[0][0], "%Y-%m-%d")
+    last = datetime.strptime(monthly[-1][0], "%Y-%m-%d")
+    span = (last - first).days or 1
+
+    def xp(d):
+        return ML + (datetime.strptime(d, "%Y-%m-%d") - first).days / span * cw
+
+    def yp(c):
+        return MT + ch - c / y_max * ch
+
+    # Y gridlines and labels
+    y_els = []
+    tick = 0
+    while tick <= y_max:
+        y = yp(tick)
+        y_els.append(
+            f'<line x1="{ML}" y1="{y:.1f}" x2="{ML+cw}" y2="{y:.1f}" '
+            f'stroke="#eee" stroke-width="1"/>'
+        )
+        y_els.append(
+            f'<text x="{ML-8}" y="{y:.1f}" text-anchor="end" '
+            f'dominant-baseline="middle" font-size="12" fill="#999">{tick}</text>'
+        )
+        tick += y_step
+
+    # X gridlines (Jan 1 of each year after the first) and year labels
+    x_els = []
+    x_els.append(
+        f'<text x="{ML}" y="{MT+ch+20}" text-anchor="middle" '
+        f'font-size="12" fill="#999">{first.year}</text>'
+    )
+    year = first.year + 1
+    while True:
+        jan1 = datetime(year, 1, 1)
+        if jan1 > last:
+            break
+        x = xp(jan1.strftime("%Y-%m-%d"))
+        x_els.append(
+            f'<line x1="{x:.1f}" y1="{MT}" x2="{x:.1f}" y2="{MT+ch}" '
+            f'stroke="#eee" stroke-width="1" stroke-dasharray="3,3"/>'
+        )
+        x_els.append(
+            f'<text x="{x:.1f}" y="{MT+ch+20}" text-anchor="middle" '
+            f'font-size="12" fill="#999">{year}</text>'
+        )
+        year += 1
+
+    # SVG line and area paths (always monthly resolution)
+    pts = [(xp(d), yp(c)) for d, c in monthly]
+    line_d = "M" + " L".join(f"{x:.1f},{y:.1f}" for x, y in pts)
+    area_d = (
+        f"M{ML:.1f},{MT+ch:.1f} L"
+        + " L".join(f"{x:.1f},{y:.1f}" for x, y in pts)
+        + f" L{pts[-1][0]:.1f},{MT+ch:.1f} Z"
+    )
+
+    # Daily hit targets for the trailing recent_days period
+    cutoff = last - timedelta(days=recent_days - 1)
+    cutoff_str = cutoff.strftime("%Y-%m-%d")
+    pre = {d: c for d, c in cumulative.items() if d < cutoff_str}
+    running = cumulative[max(pre)] if pre else 0
+    daily_recent = []
+    for i in range(recent_days):
+        d = (cutoff + timedelta(days=i)).strftime("%Y-%m-%d")
+        if d in cumulative:
+            running = cumulative[d]
+        daily_recent.append((d, running))
+
+    # JS point data: monthly labels outside recent window, daily labels inside
+    js_points = []
+    for (date, count), (x, _) in zip(monthly, pts):
+        if date >= cutoff_str:
+            continue
+        label = datetime.strptime(date, "%Y-%m-%d").strftime("%b 01")
+        js_points.append(f'{{x:{x:.1f},d:"{label}",n:{count}}}')
+    for date, count in daily_recent:
+        x = xp(date)
+        label = datetime.strptime(date, "%Y-%m-%d").strftime("%b %d")
+        js_points.append(f'{{x:{x:.1f},d:"{label}",n:{count}}}')
+    js_points_str = "[" + ",".join(js_points) + "]"
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    html = f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Star History — hangxie/parquet-tools</title>
+<style>
+body {{
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  margin: 24px; background: #fff; color: #333;
+}}
+h2 {{ font-size: 16px; font-weight: 600; margin: 0 0 12px; }}
+#tip {{
+  position: fixed; background: #1e293b; color: #f8fafc;
+  padding: 5px 10px; border-radius: 5px; font-size: 13px;
+  pointer-events: none; display: none; white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0,0,0,.25);
+}}
+p.meta {{ font-size: 11px; color: #bbb; margin-top: 6px; }}
+</style>
+</head>
+<body>
+<h2>hangxie/parquet-tools — Star History</h2>
+<div id="tip"></div>
+<svg width="{W}" height="{H}">
+  <defs>
+    <linearGradient id="area-fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2563eb" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#2563eb" stop-opacity="0.02"/>
+    </linearGradient>
+  </defs>
+  {''.join(y_els)}
+  {''.join(x_els)}
+  <line x1="{ML}" y1="{MT}" x2="{ML}" y2="{MT+ch}" stroke="#ddd" stroke-width="1"/>
+  <line x1="{ML}" y1="{MT+ch}" x2="{ML+cw}" y2="{MT+ch}" stroke="#ddd" stroke-width="1"/>
+  <text x="14" y="{MT + ch//2}" text-anchor="middle" font-size="12" fill="#999"
+        transform="rotate(-90,14,{MT + ch//2})">Stars</text>
+  <path d="{area_d}" fill="url(#area-fill)"/>
+  <path d="{line_d}" fill="none" stroke="#2563eb" stroke-width="4"/>
+  <path id="hover-zone" d="{line_d}" fill="none" stroke="transparent" stroke-width="20" style="cursor:default"/>
+</svg>
+<p class="meta">Updated {today} &middot; {max_count} total stars</p>
+<script>
+const tip = document.getElementById('tip');
+const pts = {js_points_str};
+const zone = document.getElementById('hover-zone');
+zone.addEventListener('mousemove', e => {{
+  const rect = zone.closest('svg').getBoundingClientRect();
+  const mx = e.clientX - rect.left;
+  let best = null, minD = Infinity;
+  for (const p of pts) {{
+    const d = Math.abs(p.x - mx);
+    if (d < minD) {{ minD = d; best = p; }}
+  }}
+  if (best) {{
+    tip.textContent = best.d + ' — ' + best.n + ' ★';
+    tip.style.display = 'block';
+    tip.style.left = (e.clientX + 14) + 'px';
+    tip.style.top = (e.clientY - 36) + 'px';
+  }}
+}});
+zone.addEventListener('mouseleave', () => {{ tip.style.display = 'none'; }});
+</script>
+</body>
+</html>"""
+
+    with open(output_path, "w") as f:
+        f.write(html)
+    print(f"Generated {output_path} ({max_count} stars, {len(monthly)} monthly + {recent_days} daily points)")
+
+
+def main():
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    out = sys.argv[1] if len(sys.argv) > 1 else "star-history.html"
+    recent_days = int(sys.argv[2]) if len(sys.argv) > 2 else RECENT_DAYS
+    print(f"Fetching stars for {REPO}...", flush=True)
+    stars = fetch_stars(token)
+    print(f"Total: {len(stars)} stars")
+    cumulative = cumulative_by_date(stars)
+    pts = monthly_points(cumulative)
+    generate_html(pts, cumulative, out, recent_days)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `scripts/star-history.py` — fetches all star timestamps from the GitHub API (paginated, stdlib only, no dependencies) and generates a self-contained `star-history.html` with an SVG line chart and hover tooltips
- Adds `.github/workflows/star-history.yml` — runs every Sunday at 06:00 UTC (and on manual trigger), publishes `index.html` to the `gh-pages` branch

## Chart features

- Line + area fill showing cumulative stars since day 1
- One invisible hit-target per month; hover shows date and count
- Y-axis auto-scales (e.g. `[0,100,200,300]` now; `[0,1000,2000,3000]` at 2000 stars)
- X-axis year markers at Jan 1 boundaries

## After merging

1. Go to Actions → `star-history` → **Run workflow** (creates the `gh-pages` branch)
2. Settings → Pages → Source: branch `gh-pages`, folder `/` → Save
3. Chart is live at `https://hangxie.github.io/parquet-tools/`