### PR TITLE
ci(star-history): rename output page and upgrade GHA actions to Node.js 24

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -22,16 +22,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Generate star history page
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p dist
-          python3 scripts/star-history.py dist/index.html
+          python3 scripts/star-history.py dist/star-history.html
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: dist
 


### PR DESCRIPTION
## Summary

- Rename generated GitHub Pages output from `index.html` to `star-history.html`
- Upgrade `actions/checkout@v4` → `v5` (Node.js 24 runtime)
- Upgrade `actions/upload-pages-artifact@v3` → `v4` (eliminates internal `upload-artifact@v4` / Node.js 20 dependency)

## Test plan

- [ ] Trigger workflow via `workflow_dispatch` and verify page is generated at `star-history.html`
- [ ] Confirm no Node.js 20 deprecation warnings in GHA run logs