### PR TITLE
fix(ci): install matplotlib before generating pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -34,6 +34,9 @@ jobs:
           go-version: "1.26"
           cache-dependency-path: go.sum
 
+      - name: Install Python dependencies
+        run: pip install matplotlib
+
       - name: Generate coverage pages
         run: make pages-coverage
 
@@ -54,6 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Python dependencies
+        run: pip install matplotlib
 
       - name: Generate star history page
         env:


### PR DESCRIPTION
## Summary

- Both `star-history.py` and `coverage-history.py` call `generate_png()` which imports `matplotlib`
- The `ubuntu-latest` GitHub Actions runner does not have `matplotlib` pre-installed
- Added `pip install matplotlib` step to both `coverage-history` and `star-history` jobs before the `make pages-*` calls

Fixes the failure in https://github.com/hangxie/parquet-tools/actions/runs/28346097967