### PR TITLE
chore(deps): upgrade parquet-go to v3.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.27
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.2
 	github.com/google/uuid v1.6.0
-	github.com/hangxie/parquet-go/v3 v3.4.0
+	github.com/hangxie/parquet-go/v3 v3.4.1
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.11.1
 	github.com/willabides/kongplete v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyC
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
-github.com/hangxie/parquet-go/v3 v3.4.0 h1:XibZTAkuiwtzYUo4JRmRZQQO6ss57eZfuiBXQ09VWAU=
-github.com/hangxie/parquet-go/v3 v3.4.0/go.mod h1:yzDf7xEK3eX1iubBqTadQRbVAzKbq2Cz2xuvFoNaY1c=
+github.com/hangxie/parquet-go/v3 v3.4.1 h1:ELgDydQOExpQz5vEpPzN+OwQrZENoSG5GHtPjmMLCx8=
+github.com/hangxie/parquet-go/v3 v3.4.1/go.mod h1:yzDf7xEK3eX1iubBqTadQRbVAzKbq2Cz2xuvFoNaY1c=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/io/reader.go
+++ b/io/reader.go
@@ -226,6 +226,15 @@ func NewParquetFileReader(URI string, option ReadOption) (*reader.ParquetReader,
 		_ = fileReader.Close()
 		return nil, err
 	}
+	internalFooter, err := pr.InternalFooter()
+	if err != nil {
+		_ = fileReader.Close()
+		return nil, fmt.Errorf("translate footer to internal names: %w", err)
+	}
+	if internalFooter != nil {
+		pr.Footer = internalFooter
+		pr.SchemaHandler.SchemaElements = internalFooter.Schema
+	}
 
 	hasEncryptionOptions := option.FooterKey != nil || len(option.ColumnKeys) > 0 || option.AADPrefix != nil
 	isEncrypted := pr.FileCrypto != nil || (pr.Footer != nil && pr.Footer.IsSetEncryptionAlgorithm())


### PR DESCRIPTION
## Summary

- Upgrades `github.com/hangxie/parquet-go/v3` from v3.4.0 to v3.4.1
- v3.4.1 removes the automatic `RenameSchema()` call inside `NewParquetReader`; the footer now exposes raw external Parquet names by default
- Adds `InternalFooter()` call in `NewParquetFileReader` to get a translated copy with internal Go names, then syncs `pr.SchemaHandler.SchemaElements` to the translated schema so all downstream schema tree building and column path lookups continue to work unchanged

## Test plan

- [x] `go test ./...` — all 14 packages pass
- [x] `make all` passes