### PR TITLE
fix(split): create requested empty output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1610,7 +1610,7 @@ $ parquet-tools size -q all -j testdata/good.parquet
 
 ### split Command
 
-`split` command distributes data in source file into multiple parquet files, number of output files is either `--file-count` parameter, or total number of rows in source file divided by `--record-count` parameter.
+`split` command distributes data in source file into multiple parquet files. `--file-count` produces exactly the requested number of output files, while `--record-count` limits the number of rows in each output file.
 
 Name of output files is determined by `--name-format` and will be used by `fmt.Sprintf`, default value is `result-%06d.parquet` which means output files will be under current directory with name `result-000000.parquet`, `result-000001.parquet`, etc., you can use any of file locations that support write operation, eg S3, or HDFS.
 
@@ -1640,6 +1640,8 @@ file-0000.parquet file-0001.parquet
 ```
 
 #### Exact number of output files
+
+When `--file-count` exceeds the source row count, the remaining outputs are valid schema-only Parquet files. This also means splitting an empty source with `--file-count N` creates `N` empty files.
 
 ```bash
 $ parquet-tools row-count testdata/all-types.parquet

--- a/cmd/split/split.go
+++ b/cmd/split/split.go
@@ -24,7 +24,7 @@ type trunkWriter struct {
 // Cmd is a kong command for split
 type Cmd struct {
 	FailOnInt96  bool   `help:"Fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
-	FileCount    int64  `xor:"RecordCount" help:"Generate this number of result files with potential empty ones"`
+	FileCount    int64  `xor:"RecordCount" help:"Generate exactly this number of result files, including empty files when needed."`
 	NameFormat   string `help:"Format to populate target file names" default:"result-%06d.parquet"`
 	ReadPageSize int    `help:"Page size to read from Parquet." default:"1000"`
 	RecordCount  int64  `xor:"FileCount" help:"Result files will have at most this number of records"`
@@ -130,6 +130,11 @@ func (c Cmd) Run() error {
 				return fmt.Errorf("failed to write data from [%s]: %w", c.current.targetFile, err)
 			}
 			c.current.recordCount++
+		}
+	}
+	for c.current.fileIndex < c.FileCount {
+		if err := c.switchWriter(); err != nil {
+			return err
 		}
 	}
 	if c.current.writer != nil {

--- a/cmd/split/split_test.go
+++ b/cmd/split/split_test.go
@@ -64,6 +64,18 @@ func TestCmd(t *testing.T) {
 			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 2, NameFormat: "ut-%d.parquet", ReadPageSize: 1000, RecordCount: 0, URI: "all-types.parquet", current: trunkWriter{}},
 			result: map[string]int64{"ut-0.parquet": 3, "ut-1.parquet": 2},
 		},
+		"file-count-exceeds-rows": {
+			cmd: Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 7, NameFormat: "ut-%d.parquet", ReadPageSize: 1000, RecordCount: 0, URI: "all-types.parquet", current: trunkWriter{}},
+			result: map[string]int64{
+				"ut-0.parquet": 1,
+				"ut-1.parquet": 1,
+				"ut-2.parquet": 1,
+				"ut-3.parquet": 1,
+				"ut-4.parquet": 1,
+				"ut-5.parquet": 0,
+				"ut-6.parquet": 0,
+			},
+		},
 		"one-result-record-count": {
 			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "ut-%d.parquet", ReadPageSize: 1000, RecordCount: 20, URI: "all-types.parquet", current: trunkWriter{}},
 			result: map[string]int64{"ut-0.parquet": 5},
@@ -78,7 +90,7 @@ func TestCmd(t *testing.T) {
 		},
 		"empty-file-count": {
 			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 3, NameFormat: "ut-%d.parquet", ReadPageSize: 1000, RecordCount: 0, URI: "empty.parquet", current: trunkWriter{}},
-			result: map[string]int64{},
+			result: map[string]int64{"ut-0.parquet": 0, "ut-1.parquet": 0, "ut-2.parquet": 0},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- make --file-count always create exactly the requested number of Parquet files
- create schema-only output files when the requested count exceeds the source row count, including empty sources
- clarify the CLI help and README contract

## Testing

- make all

Closes #1045