### PR TITLE
fix(io): recognize existing local paths with colons

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,29 @@ $ parquet-tools row-count file://./testdata/good.parquet
 3
 ```
 
+An existing local path containing a colon, such as `foo:bar.parquet`, is also
+recognized as a file when the prefix is not a supported location scheme. To
+make the location explicit, prefix a relative path with `file://./`:
+
+```bash
+$ cp testdata/good.parquet foo:bar.parquet
+$ parquet-tools row-count foo:bar.parquet
+3
+$ parquet-tools row-count file://./foo:bar.parquet
+3
+$ rm foo:bar.parquet
+```
+
+When writing a new file whose path contains a colon, use the explicit
+`file://./` form because the output path does not exist yet.
+
+Supported location schemes always take precedence over identically named local
+paths. This also applies to malformed URLs: for example,
+`s3://somewhere/%zz` reports an invalid URL escape instead of reading a local
+file at that path. To address that path explicitly as a local file, use the
+`file://./` form and URL-escape special characters, such as
+`file://./s3://somewhere/%25zz`.
+
 #### S3 Bucket
 
 Use full S3 URL to indicate S3 object location, it starts with `s3://`. You need to make sure you have permission to read or write the S3 object, the easiest way to verify that is using [AWS cli](https://aws.amazon.com/cli/):

--- a/io/io.go
+++ b/io/io.go
@@ -30,7 +30,19 @@ const (
 func parseURI(uri string) (*url.URL, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
+		scheme, _, hasScheme := strings.Cut(uri, ":")
+		if !hasScheme || !knownLocationScheme(strings.ToLower(scheme)) {
+			if localURI, found := existingLocalURI(uri); found {
+				return localURI, nil
+			}
+		}
 		return nil, fmt.Errorf("unable to parse file location [%s]: %w", uri, err)
+	}
+
+	if u.Scheme != "" && !knownLocationScheme(u.Scheme) {
+		if localURI, found := existingLocalURI(uri); found {
+			u = localURI
+		}
 	}
 
 	if u.Scheme == "" {
@@ -43,6 +55,28 @@ func parseURI(uri string) (*url.URL, error) {
 	}
 
 	return u, nil
+}
+
+func existingLocalURI(uri string) (*url.URL, bool) {
+	if _, err := os.Stat(uri); err != nil {
+		return nil, false
+	}
+	return &url.URL{Scheme: schemeLocal, Path: uri}, true
+}
+
+func knownLocationScheme(scheme string) bool {
+	switch scheme {
+	case schemeLocal,
+		schemeGoogleCloudStorage,
+		schemeHDFS,
+		schemeHTTP,
+		schemeHTTPS,
+		schemeAWSS3,
+		schemeAzureStorageBlob:
+		return true
+	default:
+		return false
+	}
 }
 
 func newTLSInsecureHTTPClient() *http.Client {

--- a/io/io_test.go
+++ b/io/io_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 
@@ -202,6 +203,43 @@ func TestValidCompressionCodecs(t *testing.T) {
 }
 
 func TestParseURI(t *testing.T) {
+	colonPath := "parse-uri-" + uuid.NewString() + ":bar.parquet"
+	require.NoError(t, os.WriteFile(colonPath, nil, 0o600))
+	timestampPath := "2023-01-01T00:00-" + uuid.NewString() + ".parquet"
+	require.NoError(t, os.WriteFile(timestampPath, nil, 0o600))
+	nonOpaqueDir := "parse-uri-" + uuid.NewString() + ":"
+	nonOpaquePath := nonOpaqueDir + "/bar.parquet"
+	require.NoError(t, os.Mkdir(nonOpaqueDir, 0o700))
+	require.NoError(t, os.WriteFile(nonOpaquePath, nil, 0o600))
+	knownSchemePath := "s3:" + uuid.NewString()
+	require.NoError(t, os.WriteFile(knownSchemePath, nil, 0o600))
+	malformedS3Name := "parse-uri-" + uuid.NewString()
+	malformedS3Dir := "s3:/" + malformedS3Name
+	malformedS3URI := "s3://" + malformedS3Name + "/%zz"
+	require.NoError(t, os.MkdirAll(malformedS3Dir, 0o700))
+	require.NoError(t, os.WriteFile(malformedS3URI, nil, 0o600))
+	malformedUpperS3Name := "parse-uri-" + uuid.NewString()
+	malformedUpperS3Dir := "S3:/" + malformedUpperS3Name
+	malformedUpperS3URI := "S3://" + malformedUpperS3Name + "/%zz"
+	require.NoError(t, os.MkdirAll(malformedUpperS3Dir, 0o700))
+	require.NoError(t, os.WriteFile(malformedUpperS3URI, nil, 0o600))
+	t.Cleanup(func() {
+		require.NoError(t, os.Remove(colonPath))
+		require.NoError(t, os.Remove(timestampPath))
+		require.NoError(t, os.Remove(nonOpaquePath))
+		require.NoError(t, os.Remove(nonOpaqueDir))
+		require.NoError(t, os.Remove(knownSchemePath))
+		require.NoError(t, os.Remove(malformedS3URI))
+		require.NoError(t, os.Remove(malformedUpperS3URI))
+		require.NoError(t, os.Remove(malformedS3Dir))
+		require.NoError(t, os.Remove(malformedUpperS3Dir))
+		for _, root := range []string{"s3:", "S3:"} {
+			if err := os.Remove(root); err != nil && !os.IsNotExist(err) {
+				t.Errorf("remove test directory %q: %v", root, err)
+			}
+		}
+	})
+
 	testCases := map[string]struct {
 		uri    string
 		scheme string
@@ -243,6 +281,55 @@ func TestParseURI(t *testing.T) {
 			"",
 			"path/to/file",
 			"",
+		},
+		"existing-local-file-with-colon": {
+			colonPath,
+			"file",
+			"",
+			colonPath,
+			"",
+		},
+		"existing-timestamp-file-with-colon": {
+			timestampPath,
+			"file",
+			"",
+			timestampPath,
+			"",
+		},
+		"existing-non-opaque-path-with-colon": {
+			nonOpaquePath,
+			"file",
+			"",
+			nonOpaquePath,
+			"",
+		},
+		"nonexistent-path-with-colon": {
+			"foo:bar.parquet",
+			"foo",
+			"",
+			"",
+			"",
+		},
+		"existing-path-with-known-scheme": {
+			knownSchemePath,
+			"s3",
+			"",
+			"",
+			"",
+		},
+		"malformed-known-scheme-existing-locally": {
+			malformedS3URI,
+			"",
+			"",
+			"",
+			"invalid URL escape",
+		},
+		"malformed-uppercase-known-scheme-existing-locally": {
+			malformedUpperS3URI,
+			"",
+			"",
+			"",
+			"invalid URL escape",
 		},
 	}
 

--- a/io/reader_test.go
+++ b/io/reader_test.go
@@ -105,6 +105,14 @@ func boolToInt(v bool) int {
 
 func TestNewParquetFileReader(t *testing.T) {
 	rOpt := ReadOption{}
+	colonPath := "2023-01-01T00:00-" + uuid.NewString() + ".parquet"
+	contents, err := os.ReadFile("../testdata/good.parquet")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(colonPath, contents, 0o600))
+	t.Cleanup(func() {
+		require.NoError(t, os.Remove(colonPath))
+	})
+
 	s3URL := "s3://daylight-openstreetmap/parquet/osm_features/release=v1.58/type=way/20241112_191814_00139_grr7u_0041fe64-a5ba-4375-88bf-ef790dfedfff"
 	gcsURL := "gs://cloud-samples-data/bigquery/us-states/us-states.parquet"
 	azblobURL := "wasbs://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet"
@@ -136,6 +144,11 @@ func TestNewParquetFileReader(t *testing.T) {
 		},
 		"local-file-good": {
 			"../testdata/good.parquet",
+			rOpt,
+			"",
+		},
+		"local-file-with-colon": {
+			colonPath,
 			rOpt,
 			"",
 		},

--- a/io/writer_test.go
+++ b/io/writer_test.go
@@ -40,6 +40,15 @@ func testWriterNestedSchemaHandler(t *testing.T) *parquetschema.SchemaHandler {
 func TestNewParquetFileWriter(t *testing.T) {
 	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "unit-test.parquet")
+	explicitColonPath := "writer-" + uuid.NewString() + ":unit-test.parquet"
+	implicitColonPath := "writer-" + uuid.NewString() + ":unit-test.parquet"
+	t.Cleanup(func() {
+		for _, path := range []string{explicitColonPath, implicitColonPath} {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				t.Errorf("remove test output %q: %v", path, err)
+			}
+		}
+	})
 	testCases := map[string]struct {
 		uri    string
 		errMsg string
@@ -62,6 +71,14 @@ func TestNewParquetFileWriter(t *testing.T) {
 		},
 		"local-file-good": {
 			tempFile,
+			"",
+		},
+		"new-local-file-with-colon-requires-scheme": {
+			implicitColonPath,
+			"unknown location scheme",
+		},
+		"new-local-file-with-colon-and-scheme": {
+			"file://./" + explicitColonPath,
 			"",
 		},
 		"s3-bucket-not-found": {


### PR DESCRIPTION
## Summary

- treat existing colon-containing paths with unknown schemes as local files
- preserve supported location schemes and unknown nonexistent URI behavior
- document colon-containing paths and the explicit `file://./` form

## Testing

- `make all`

Closes #1040