### PR TITLE
fix(schema): return errors instead of panicking on malformed LIST and MAP structures

### DIFF
--- a/schema/gostruct.go
+++ b/schema/gostruct.go
@@ -52,12 +52,15 @@ func (n goStructNode) asStruct() (string, error) {
 }
 
 func (n goStructNode) asList() (string, error) {
+	if len(n.Children) == 0 {
+		return "", fmt.Errorf("invalid LIST structure in [%s]", n.Name)
+	}
 	var typeStr string
 	var err error
 	if n.Children[0].LogicalType != nil {
 		// LIST => Element (of scalar type)
 		n.Children[0].Name = "Element"
-		*n.Children[0].RepetitionType = parquet.FieldRepetitionType_REQUIRED
+		n.Children[0].RepetitionType = new(parquet.FieldRepetitionType_REQUIRED)
 		typeStr, err = goStructNode{
 			SchemaNode:     *n.Children[0],
 			ForceCamelCase: n.ForceCamelCase,
@@ -67,7 +70,7 @@ func (n goStructNode) asList() (string, error) {
 		n.Children[0].Name = "Element"
 		n.Children[0].Type = nil
 		n.Children[0].ConvertedType = nil
-		*n.Children[0].RepetitionType = parquet.FieldRepetitionType_REQUIRED
+		n.Children[0].RepetitionType = new(parquet.FieldRepetitionType_REQUIRED)
 		typeStr, err = goStructNode{
 			SchemaNode:     *n.Children[0],
 			ForceCamelCase: n.ForceCamelCase,
@@ -80,6 +83,9 @@ func (n goStructNode) asList() (string, error) {
 			SchemaNode:     *elementNode,
 			ForceCamelCase: n.ForceCamelCase,
 		}.String()
+	} else {
+		// element type cannot be determined
+		return "", fmt.Errorf("invalid LIST structure in [%s]", n.Name)
 	}
 	if err != nil {
 		return "", err

--- a/schema/gostruct_test.go
+++ b/schema/gostruct_test.go
@@ -139,6 +139,47 @@ func TestGoStructNode(t *testing.T) {
 		require.Contains(t, err.Error(), "unknown type: 999")
 	})
 
+	t.Run("list-without-children", func(t *testing.T) {
+		option := pio.ReadOption{}
+		uri := "../testdata/all-types.parquet"
+		pr, err := pio.NewParquetFileReader(uri, option)
+		require.NoError(t, err)
+		defer func() {
+			_ = pr.PFile.Close()
+		}()
+
+		schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+		require.NoError(t, err)
+		require.NotNil(t, schemaRoot)
+
+		// 46th field is "List"
+		schemaRoot.Children[46].Children = nil
+		_, err = goStructNode{SchemaNode: *schemaRoot}.String()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid LIST structure in [List]")
+	})
+
+	t.Run("list-without-element-type", func(t *testing.T) {
+		option := pio.ReadOption{}
+		uri := "../testdata/all-types.parquet"
+		pr, err := pio.NewParquetFileReader(uri, option)
+		require.NoError(t, err)
+		defer func() {
+			_ = pr.PFile.Close()
+		}()
+
+		schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+		require.NoError(t, err)
+		require.NotNil(t, schemaRoot)
+
+		// 46th field is "List", whose 1st field is the interim "List" group
+		schemaRoot.Children[46].Children[0].LogicalType = nil
+		schemaRoot.Children[46].Children[0].Children = nil
+		_, err = goStructNode{SchemaNode: *schemaRoot}.String()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid LIST structure in [List]")
+	})
+
 	t.Run("invalid-map-value", func(t *testing.T) {
 		option := pio.ReadOption{}
 		uri := "../testdata/all-types.parquet"
@@ -205,5 +246,26 @@ func TestGoStructNode(t *testing.T) {
 		// golden file has prefix of "type <root node name>"
 		prefix := fmt.Sprintf("type %s ", root.InNamePath[0])
 		require.Equal(t, string(expected), prefix+typeStr+"\n")
+	})
+
+	t.Run("as-list-nil-repetition-type", func(t *testing.T) {
+		// Element nodes coming straight off the wire can have a nil
+		// RepetitionType, asList() used to dereference it directly and panic.
+		node := SchemaNode{
+			SchemaElement: parquet.SchemaElement{Name: "List"},
+			Children: []*SchemaNode{
+				{
+					SchemaElement: parquet.SchemaElement{
+						Name:        "element",
+						LogicalType: &parquet.LogicalType{STRING: &parquet.StringType{}},
+					},
+				},
+			},
+		}
+
+		require.NotPanics(t, func() {
+			_, err := goStructNode{SchemaNode: node}.asList()
+			require.NoError(t, err)
+		})
 	})
 }

--- a/schema/schematags.go
+++ b/schema/schematags.go
@@ -82,10 +82,11 @@ func (s *SchemaNode) updateTagForList(tagMap map[string]string) {
 		return
 	}
 
+	required := parquet.FieldRepetitionType_REQUIRED
 	if s.Children[0].LogicalType != nil {
 		// LIST => Element (of scalar type)
 		s.Children[0].Name = "Element"
-		*s.Children[0].RepetitionType = parquet.FieldRepetitionType_REQUIRED
+		s.Children[0].RepetitionType = &required
 		maps.Copy(tagMap, s.Children[0].getTagMapWithPrefix("value"))
 		return
 	}
@@ -95,7 +96,7 @@ func (s *SchemaNode) updateTagForList(tagMap map[string]string) {
 		s.Children[0].Name = "Element"
 		s.Children[0].Type = nil
 		s.Children[0].ConvertedType = nil
-		*s.Children[0].RepetitionType = parquet.FieldRepetitionType_REQUIRED
+		s.Children[0].RepetitionType = &required
 		return
 	}
 
@@ -109,8 +110,8 @@ func (s *SchemaNode) updateTagForList(tagMap map[string]string) {
 }
 
 func (s *SchemaNode) updateTagForMap(tagMap map[string]string) {
-	if len(s.Children) == 0 || s.Children[0] == nil || len(s.Children[0].Children) == 0 {
-		// meaningless interim layer
+	if len(s.Children) == 0 || s.Children[0] == nil || len(s.Children[0].Children) < 2 {
+		// meaningless interim layer, or a malformed key_value group
 		return
 	}
 	if s.Children[0].ConvertedType != nil && *s.Children[0].ConvertedType != parquet.ConvertedType_MAP_KEY_VALUE {

--- a/schema/schematags_test.go
+++ b/schema/schematags_test.go
@@ -12,3 +12,41 @@ func TestTypeStrVariant(t *testing.T) {
 		t.Fatalf("typeStr() = %q, want VARIANT", got)
 	}
 }
+
+func TestUpdateTagForListNilRepetitionType(t *testing.T) {
+	listType := parquet.ConvertedType_LIST
+	node := SchemaNode{
+		SchemaElement: parquet.SchemaElement{Name: "List", ConvertedType: &listType},
+		Children: []*SchemaNode{
+			{SchemaElement: parquet.SchemaElement{Name: "Element", LogicalType: &parquet.LogicalType{STRING: &parquet.StringType{}}}},
+		},
+	}
+	tagMap := node.GetTagMap()
+	if tagMap["convertedtype"] != "LIST" {
+		t.Fatalf(`tagMap["convertedtype"] = %q, want LIST`, tagMap["convertedtype"])
+	}
+	if rt := node.Children[0].RepetitionType; rt == nil || *rt != parquet.FieldRepetitionType_REQUIRED {
+		t.Fatalf("element repetition type = %v, want REQUIRED", rt)
+	}
+}
+
+func TestUpdateTagForMapShortKeyValue(t *testing.T) {
+	mapType := parquet.ConvertedType_MAP
+	keyValueType := parquet.ConvertedType_MAP_KEY_VALUE
+	int32Type := parquet.Type_INT32
+	node := SchemaNode{
+		SchemaElement: parquet.SchemaElement{Name: "Map", ConvertedType: &mapType},
+		Children: []*SchemaNode{
+			{
+				SchemaElement: parquet.SchemaElement{Name: "Key_value", ConvertedType: &keyValueType},
+				Children: []*SchemaNode{
+					{SchemaElement: parquet.SchemaElement{Name: "Key", Type: &int32Type}},
+				},
+			},
+		},
+	}
+	tagMap := node.GetTagMap()
+	if tagMap["convertedtype"] != "MAP" {
+		t.Fatalf(`tagMap["convertedtype"] = %q, want MAP`, tagMap["convertedtype"])
+	}
+}


### PR DESCRIPTION
## Summary

- return `invalid LIST structure` errors from `goStructNode.asList` instead of panicking on a LIST with no children, and stop emitting invalid Go (`[]` with no element type) when the element type cannot be determined
- treat a MAP whose key_value group has fewer than two children as an interim layer in `updateTagForMap` instead of indexing out of range
- stop dereferencing a possibly-nil `RepetitionType` in `updateTagForList`

Fixes #1032

## Test

- new cases in `schema/schematags_test.go` and `schema/gostruct_test.go`; without the fix they panic with index-out-of-range
- `go test ./schema/` passes
