### PR TITLE
feat(cli): support configurable field delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ All supplied key and AAD values must be standard base64 with padding (RFC 4648 ย
 * `--column-key`: column key in `column.path=base64key` form; repeat the flag for multiple columns.
 * `--aad-prefix`: base64-encoded AAD prefix for files that require the reader to supply it.
 
+Nested paths in field and column parameters use `.` as their delimiter by default. Set `--field-delimiter` to use another non-empty string that does not contain `=` (the assignment separator). This is useful when a field name contains a literal dot: for example, `--field-delimiter=/ --column-key 'user.info/ssn=KEY'` addresses the nested field `ssn` under a field literally named `user.info`. The delimiter applies to `--column-key`, `--writer-column-key`, `--field-encoding`, `--field-compression`, `--field-bloom-filter`, and column paths in key files.
+
 For example:
 
 ```bash
@@ -576,7 +578,7 @@ All writer keys must be standard base64 with padding (RFC 4648 ยง4) and must dec
 
 `--writer-footer-key` is required for every encryption mode. It encrypts the footer; with `--plaintext-footer` it signs the footer with AES-GCM instead. It is also the key used for any column whose `--writer-column-key` directive selects the footer key, and for unlisted columns when `--encrypt-all-columns` is set.
 
-`--writer-column-key column.path=VALUE` selects per-column encryption for the listed column. `column.path` is the dotted file-schema path of a leaf column **without** the schema root (e.g. `Parent.Child`, not `parquet_go_root.Parent.Child`). `VALUE` is either a base64-encoded AES key (the column gets its own dedicated key) or the literal `@footer-key` (the column is encrypted with `--writer-footer-key`). The leading `@` is outside the base64 alphabet, so the sentinel cannot collide with a key value.
+`--writer-column-key column.path=VALUE` selects per-column encryption for the listed column. `column.path` is the file-schema path of a leaf column **without** the schema root (e.g. `Parent.Child`, not `parquet_go_root.Parent.Child`) and uses `--field-delimiter` between components. `VALUE` is either a base64-encoded AES key (the column gets its own dedicated key) or the literal `@footer-key` (the column is encrypted with `--writer-footer-key`). The leading `@` is outside the base64 alphabet, so the sentinel cannot collide with a key value.
 
 By default, columns not listed in `--writer-column-key` are written as plaintext. Set `--encrypt-all-columns` to encrypt every leaf column not otherwise listed with `--writer-footer-key`.
 
@@ -1733,7 +1735,7 @@ $ parquet-tools transcode -s legacy.parquet --data-page-version=1 compatible.par
 
 Use the `--field-encoding` parameter to apply different encodings to specific fields.
 
-The format is `--field-encoding field.path=ENCODING`, where `field.path` is the dot-separated path to the field. For nested structures, use the full path including intermediate elements like `list` for LIST types and `key_value` for MAP types.
+The format is `--field-encoding field.path=ENCODING`, where `field.path` uses `--field-delimiter` (`.` by default). For nested structures, use the full path including intermediate elements like `list` for LIST types and `key_value` for MAP types.
 
 Apply different encodings to different fields:
 
@@ -1796,7 +1798,7 @@ $ parquet-tools transcode -s input.parquet --omit-stats false output.parquet
 
 Use the `--field-compression` parameter to apply different compression codecs to specific fields. Field-specific compression takes precedence over the file-level default set by `--compression`.
 
-The format is `--field-compression field.path=CODEC`, where `field.path` is the dot-separated path to the field (same format as `--field-encoding`).
+The format is `--field-compression field.path=CODEC`, where `field.path` uses `--field-delimiter` (same format as `--field-encoding`).
 
 Apply different compression codecs to different fields:
 
@@ -1844,7 +1846,7 @@ See [Compression Codecs](#compression-codecs) for more details.
 
 Use the `--field-bloom-filter` parameter to add, remove, or configure bloom filters on specific fields.
 
-The format is `--field-bloom-filter field.path=VALUE`, where `field.path` is the dot-separated path to the field (same format as `--field-encoding`) and `VALUE` is one of:
+The format is `--field-bloom-filter field.path=VALUE`, where `field.path` uses `--field-delimiter` (same format as `--field-encoding`) and `VALUE` is one of:
 
 * `true` - Enable bloom filter with default size (1024 bytes)
 * `false` - Remove bloom filter from the field

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -18,16 +18,21 @@ import (
 
 // Cmd is a kong command for import
 type Cmd struct {
-	Format     string `help:"Source file formats (csv/json/jsonl)." short:"f" enum:"csv,json,jsonl" default:"csv"`
-	Schema     string `required:"" short:"m" predictor:"file" help:"Schema file name."`
-	SkipHeader bool   `help:"Skip first line of CSV files" default:"false"`
-	Source     string `required:"" short:"s" predictor:"file" help:"Source file name."`
-	URI        string `arg:"" predictor:"file" help:"URI of Parquet file."`
+	FieldDelimiter string `name:"field-delimiter" help:"Delimiter separating nested field path components in field and column parameters" default:"."`
+	Format         string `help:"Source file formats (csv/json/jsonl)." short:"f" enum:"csv,json,jsonl" default:"csv"`
+	Schema         string `required:"" short:"m" predictor:"file" help:"Schema file name."`
+	SkipHeader     bool   `help:"Skip first line of CSV files" default:"false"`
+	Source         string `required:"" short:"s" predictor:"file" help:"Source file name."`
+	URI            string `arg:"" predictor:"file" help:"URI of Parquet file."`
 	pio.WriteOption
 }
 
 // Run does actual import job
 func (c Cmd) Run() error {
+	if err := pio.ValidateFieldDelimiter(c.FieldDelimiter); err != nil {
+		return err
+	}
+	c.WriteOption.FieldDelimiter = c.FieldDelimiter
 	switch c.Format {
 	case "csv":
 		return c.importCSV()

--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -164,6 +164,10 @@ func TestCmd(t *testing.T) {
 				Cmd{WriteOption: wOpt, Source: "../../testdata/jsonl.source", Format: "jsonl", Schema: "../../testdata/invalid-logical-type-json.schema", SkipHeader: false, URI: filepath.Join(tempDir, "dummy")},
 				"LogicalType DECIMAL can only be used",
 			},
+			"field-delimiter": {
+				Cmd{WriteOption: wOpt, Source: "../../testdata/json.source", Format: "json", Schema: "../../testdata/json.schema", SkipHeader: false, FieldDelimiter: "::", URI: "dummy"},
+				"field delimiter must be a single character",
+			},
 		}
 
 		for name, tc := range testCases {

--- a/cmd/merge/merge.go
+++ b/cmd/merge/merge.go
@@ -14,17 +14,21 @@ import (
 
 // Cmd is a kong command for merge
 type Cmd struct {
-	Concurrent   bool     `help:"enable concurrent processing" default:"false"`
-	FailOnInt96  bool     `help:"fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
-	ReadPageSize int      `help:"Page size to read from Parquet." default:"1000"`
-	Source       []string `short:"s" help:"Files to be merged."`
-	URI          string   `arg:"" predictor:"file" help:"URI of Parquet file."`
+	Concurrent     bool     `help:"enable concurrent processing" default:"false"`
+	FailOnInt96    bool     `help:"fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
+	FieldDelimiter string   `name:"field-delimiter" help:"Delimiter separating nested field path components in field and column parameters" default:"."`
+	ReadPageSize   int      `help:"Page size to read from Parquet." default:"1000"`
+	Source         []string `short:"s" help:"Files to be merged."`
+	URI            string   `arg:"" predictor:"file" help:"URI of Parquet file."`
 	pio.ReadOption
 	pio.WriteOption
 }
 
 // Run does actual merge job
 func (c Cmd) Run() (retErr error) {
+	if err := pio.ValidateFieldDelimiter(c.FieldDelimiter); err != nil {
+		return err
+	}
 	if c.ReadPageSize < 1 {
 		return fmt.Errorf("invalid read page size %d, needs to be at least 1", c.ReadPageSize)
 	}
@@ -42,6 +46,8 @@ func (c Cmd) Run() (retErr error) {
 		}
 	}()
 
+	c.ReadOption.FieldDelimiter = c.FieldDelimiter
+	c.WriteOption.FieldDelimiter = c.FieldDelimiter
 	fileWriter, err := pio.NewGenericWriter(c.URI, c.WriteOption, schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)

--- a/cmd/merge/merge_test.go
+++ b/cmd/merge/merge_test.go
@@ -54,6 +54,10 @@ func TestCmd(t *testing.T) {
 				Cmd{ReadOption: rOpt, Concurrent: true, FailOnInt96: true, ReadPageSize: 10, Source: []string{"../../testdata/all-types.parquet", "../../testdata/all-types.parquet"}, URI: "dummy"},
 				"type INT96 which is not supported",
 			},
+			"field-delimiter": {
+				Cmd{ReadOption: rOpt, Concurrent: false, FailOnInt96: false, ReadPageSize: 10, FieldDelimiter: "::", Source: []string{"../../testdata/good.parquet", "../../testdata/good.parquet"}, URI: "dummy"},
+				"field delimiter must be a single character",
+			},
 		}
 
 		for name, tc := range testCases {

--- a/cmd/retype/retype.go
+++ b/cmd/retype/retype.go
@@ -9,23 +9,27 @@ import (
 
 // Cmd is a kong command for retype.
 type Cmd struct {
-	Int96ToTimestamp bool   `help:"Convert INT96 columns to TIMESTAMP_NANOS." name:"int96-to-timestamp" default:"false"`
 	BsonToString     bool   `help:"Convert BSON columns to plain strings (JSON encoded)." default:"false"`
-	JsonToString     bool   `help:"Remove JSON logical type from columns." default:"false"`
+	FieldDelimiter   string `name:"field-delimiter" help:"Delimiter separating nested field path components in field and column parameters" default:"."`
 	Float16ToFloat32 bool   `help:"Convert FLOAT16 columns to FLOAT32." name:"float16-to-float32" default:"false"`
-	VariantToString  bool   `help:"Convert VARIANT columns to plain strings (JSON encoded)." default:"false"`
-	UuidToString     bool   `help:"Convert UUID columns to plain strings." default:"false"`
-	RepeatedToList   bool   `help:"Convert legacy repeated primitive columns to LIST format." default:"false"`
 	GeoToBinary      bool   `help:"Remove GEOGRAPHY and GEOMETRY logical types (keep as plain BYTE_ARRAY)." default:"false"`
+	Int96ToTimestamp bool   `help:"Convert INT96 columns to TIMESTAMP_NANOS." name:"int96-to-timestamp" default:"false"`
+	JsonToString     bool   `help:"Remove JSON logical type from columns." default:"false"`
 	ReadPageSize     int    `help:"Page size to read from Parquet." default:"1000"`
+	RepeatedToList   bool   `help:"Convert legacy repeated primitive columns to LIST format." default:"false"`
 	Source           string `short:"s" help:"Source Parquet file to retype." required:"true"`
 	URI              string `arg:"" predictor:"file" help:"URI of output Parquet file."`
+	UuidToString     bool   `help:"Convert UUID columns to plain strings." default:"false"`
+	VariantToString  bool   `help:"Convert VARIANT columns to plain strings (JSON encoded)." default:"false"`
 	pio.ReadOption
 	pio.WriteOption
 }
 
 // Run does actual retype job
 func (c Cmd) Run() (retErr error) {
+	if err := pio.ValidateFieldDelimiter(c.FieldDelimiter); err != nil {
+		return err
+	}
 	if c.ReadPageSize < 1 {
 		return fmt.Errorf("invalid read page size %d, needs to be at least 1", c.ReadPageSize)
 	}
@@ -59,6 +63,8 @@ func (c Cmd) Run() (retErr error) {
 	schemaJSON := schemaTree.JSONSchema()
 
 	// Create output file with new settings
+	c.ReadOption.FieldDelimiter = c.FieldDelimiter
+	c.WriteOption.FieldDelimiter = c.FieldDelimiter
 	fileWriter, err := pio.NewGenericWriter(c.URI, c.WriteOption, schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)

--- a/cmd/retype/retype_test.go
+++ b/cmd/retype/retype_test.go
@@ -46,6 +46,10 @@ func TestCmd(t *testing.T) {
 				Cmd{ReadOption: rOpt, ReadPageSize: 10, Source: "../../testdata/ARROW-GH-41317.parquet", URI: "dummy"},
 				"failed to build encoding map",
 			},
+			"field-delimiter": {
+				Cmd{ReadOption: rOpt, ReadPageSize: 10, FieldDelimiter: "::", Source: "../../testdata/good.parquet", URI: "dummy"},
+				"field delimiter must be a single character",
+			},
 		}
 
 		for name, tc := range testCases {

--- a/cmd/split/split.go
+++ b/cmd/split/split.go
@@ -23,12 +23,13 @@ type trunkWriter struct {
 
 // Cmd is a kong command for split
 type Cmd struct {
-	FailOnInt96  bool   `help:"Fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
-	FileCount    int64  `xor:"RecordCount" help:"Generate exactly this number of result files, including empty files when needed."`
-	NameFormat   string `help:"Format to populate target file names" default:"result-%06d.parquet"`
-	ReadPageSize int    `help:"Page size to read from Parquet." default:"1000"`
-	RecordCount  int64  `xor:"FileCount" help:"Result files will have at most this number of records"`
-	URI          string `arg:"" predictor:"file" help:"URI of Parquet file."`
+	FailOnInt96    bool   `help:"Fail command if INT96 data type is present." name:"fail-on-int96" default:"false"`
+	FieldDelimiter string `name:"field-delimiter" help:"Delimiter separating nested field path components in field and column parameters" default:"."`
+	FileCount      int64  `xor:"RecordCount" help:"Generate exactly this number of result files, including empty files when needed."`
+	NameFormat     string `help:"Format to populate target file names" default:"result-%06d.parquet"`
+	ReadPageSize   int    `help:"Page size to read from Parquet." default:"1000"`
+	RecordCount    int64  `xor:"FileCount" help:"Result files will have at most this number of records"`
+	URI            string `arg:"" predictor:"file" help:"URI of Parquet file."`
 	pio.ReadOption
 	pio.WriteOption
 
@@ -71,6 +72,8 @@ func (c *Cmd) switchWriter() error {
 	}
 
 	var err error
+	c.ReadOption.FieldDelimiter = c.FieldDelimiter
+	c.WriteOption.FieldDelimiter = c.FieldDelimiter
 	c.current.targetFile = fmt.Sprintf(c.NameFormat, c.current.fileIndex)
 	c.current.writer, err = pio.NewGenericWriter(c.current.targetFile, c.WriteOption, c.current.schemaJSON)
 	if err != nil {
@@ -89,6 +92,9 @@ func (c *Cmd) switchWriter() error {
 
 // Run does actual split job
 func (c Cmd) Run() error {
+	if err := pio.ValidateFieldDelimiter(c.FieldDelimiter); err != nil {
+		return err
+	}
 	if c.ReadPageSize < 1 {
 		return fmt.Errorf("invalid read page size %d, needs to be at least 1", c.ReadPageSize)
 	}
@@ -137,15 +143,23 @@ func (c Cmd) Run() error {
 			return err
 		}
 	}
-	if c.current.writer != nil {
-		if err := c.current.writer.WriteStop(); err != nil {
-			return fmt.Errorf("failed to end write [%s]: %w", c.current.targetFile, err)
-		}
-		if err := c.current.writer.PFile.Close(); err != nil {
-			return fmt.Errorf("failed to close [%s]: %w", c.current.targetFile, err)
-		}
+	if err := c.closeWriter(); err != nil {
+		return err
 	}
 
+	return nil
+}
+
+func (c *Cmd) closeWriter() error {
+	if c.current.writer == nil {
+		return nil
+	}
+	if err := c.current.writer.WriteStop(); err != nil {
+		return fmt.Errorf("failed to end write [%s]: %w", c.current.targetFile, err)
+	}
+	if err := c.current.writer.PFile.Close(); err != nil {
+		return fmt.Errorf("failed to close [%s]: %w", c.current.targetFile, err)
+	}
 	return nil
 }
 

--- a/cmd/split/split_test.go
+++ b/cmd/split/split_test.go
@@ -23,6 +23,10 @@ func TestCmd(t *testing.T) {
 		errMsg string
 	}{
 		// error cases
+		"field-delimiter": {
+			cmd:    Cmd{FieldDelimiter: "::", ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "", ReadPageSize: 1000, RecordCount: 10, URI: "dummy", current: tw},
+			errMsg: "field delimiter must be a single character",
+		},
 		"page-size": {
 			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 0, NameFormat: "", ReadPageSize: 0, RecordCount: 0, URI: "dummy", current: tw},
 			errMsg: "invalid read page size",

--- a/cmd/transcode/transcode.go
+++ b/cmd/transcode/transcode.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/parquet"
 
 	pio "github.com/hangxie/parquet-tools/io"
@@ -19,6 +20,7 @@ type Cmd struct {
 	FailOnInt96      bool     `help:"Fail if INT96 fields are detected in the source file." name:"fail-on-int96" default:"false"`
 	FieldBloomFilter []string `help:"Field-specific bloom filter." placeholder:"field.path=true/false/<size>"`
 	FieldCompression []string `help:"Field-specific compression." placeholder:"field.path=CODEC"`
+	FieldDelimiter   string   `name:"field-delimiter" help:"Delimiter separating nested field path components in field and column parameters" default:"."`
 	FieldEncoding    []string `help:"Field-specific encoding." placeholder:"field.path=ENCODING"`
 	OmitStats        string   `help:"Control statistics (true/false). Leave empty to keep original." default:""`
 	ReadPageSize     int      `help:"Page size to read from Parquet." default:"1000"`
@@ -29,16 +31,16 @@ type Cmd struct {
 }
 
 // parseFieldEncodings parses field-specific encoding specifications from "field.path=ENCODING" format
-// and returns a map from field path to encoding. Field paths use "." as delimiter.
+// and returns a map from normalized field path to encoding.
 func (c Cmd) parseFieldEncodings() (map[string]string, error) {
 	result := make(map[string]string)
 	for _, spec := range c.FieldEncoding {
-		parts := strings.SplitN(spec, "=", 2)
-		if len(parts) != 2 {
+		rawFieldPath, rawEncoding, found := strings.Cut(spec, "=")
+		if !found {
 			return nil, fmt.Errorf("invalid field encoding format [%s], expected 'field.path=ENCODING'", spec)
 		}
-		fieldPath := strings.TrimSpace(parts[0])
-		encoding := strings.TrimSpace(parts[1])
+		fieldPath := strings.TrimSpace(rawFieldPath)
+		encoding := strings.TrimSpace(rawEncoding)
 
 		if fieldPath == "" {
 			return nil, fmt.Errorf("empty field path in [%s]", spec)
@@ -68,22 +70,22 @@ func (c Cmd) parseFieldEncodings() (map[string]string, error) {
 			return nil, fmt.Errorf("[%s] encoding is only allowed with data page version 2 for field [%s]", encoding, fieldPath)
 		}
 
-		result[fieldPath] = strings.ToUpper(encoding)
+		result[pio.NormalizeFieldPath(fieldPath, c.FieldDelimiter)] = strings.ToUpper(encoding)
 	}
 	return result, nil
 }
 
 // parseFieldCompressions parses field-specific compression specifications from "field.path=CODEC" format
-// and returns a map from field path to compression codec. Field paths use "." as delimiter.
+// and returns a map from normalized field path to compression codec.
 func (c Cmd) parseFieldCompressions() (map[string]string, error) {
 	result := make(map[string]string)
 	for _, spec := range c.FieldCompression {
-		parts := strings.SplitN(spec, "=", 2)
-		if len(parts) != 2 {
+		rawFieldPath, rawCodec, found := strings.Cut(spec, "=")
+		if !found {
 			return nil, fmt.Errorf("invalid field compression format [%s], expected 'field.path=CODEC'", spec)
 		}
-		fieldPath := strings.TrimSpace(parts[0])
-		codec := strings.TrimSpace(parts[1])
+		fieldPath := strings.TrimSpace(rawFieldPath)
+		codec := strings.TrimSpace(rawCodec)
 
 		if fieldPath == "" {
 			return nil, fmt.Errorf("empty field path in [%s]", spec)
@@ -99,7 +101,7 @@ func (c Cmd) parseFieldCompressions() (map[string]string, error) {
 			return nil, fmt.Errorf("invalid compression codec [%s] for field [%s], valid codecs: %s", codec, fieldPath, strings.Join(pio.ValidCompressionCodecs, ", "))
 		}
 
-		result[fieldPath] = codec
+		result[pio.NormalizeFieldPath(fieldPath, c.FieldDelimiter)] = codec
 	}
 	return result, nil
 }
@@ -109,12 +111,12 @@ func (c Cmd) parseFieldCompressions() (map[string]string, error) {
 func (c Cmd) parseFieldBloomFilters() (map[string]string, error) {
 	result := make(map[string]string)
 	for _, spec := range c.FieldBloomFilter {
-		parts := strings.SplitN(spec, "=", 2)
-		if len(parts) != 2 {
+		rawFieldPath, rawValue, found := strings.Cut(spec, "=")
+		if !found {
 			return nil, fmt.Errorf("invalid field bloom filter format [%s], expected 'field.path=VALUE'", spec)
 		}
-		fieldPath := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
+		fieldPath := strings.TrimSpace(rawFieldPath)
+		value := strings.TrimSpace(rawValue)
 
 		if fieldPath == "" {
 			return nil, fmt.Errorf("empty field path in [%s]", spec)
@@ -138,7 +140,7 @@ func (c Cmd) parseFieldBloomFilters() (map[string]string, error) {
 			}
 		}
 
-		result[fieldPath] = value
+		result[pio.NormalizeFieldPath(fieldPath, c.FieldDelimiter)] = value
 	}
 	return result, nil
 }
@@ -148,7 +150,7 @@ func (c Cmd) modifySchemaTree(schemaTree *pschema.SchemaNode, fieldEncodings, fi
 	// Only apply to leaf nodes (not struct/group types)
 	if schemaTree.Type != nil {
 		// Build field path from ExNamePath (skip root element)
-		fieldPath := strings.Join(schemaTree.ExNamePath[1:], ".")
+		fieldPath := common.PathToStr(schemaTree.ExNamePath[1:])
 
 		// Apply field-specific encoding if specified
 		if encoding, found := fieldEncodings[fieldPath]; found {
@@ -200,6 +202,9 @@ func (c Cmd) modifySchemaTree(schemaTree *pschema.SchemaNode, fieldEncodings, fi
 
 // Run does actual transcode job
 func (c Cmd) Run() (retErr error) {
+	if err := pio.ValidateFieldDelimiter(c.FieldDelimiter); err != nil {
+		return err
+	}
 	if c.ReadPageSize < 1 {
 		return fmt.Errorf("invalid read page size %d, needs to be at least 1", c.ReadPageSize)
 	}
@@ -247,6 +252,8 @@ func (c Cmd) Run() (retErr error) {
 	schemaJSON := schemaTree.JSONSchema()
 
 	// Create output file with new settings
+	c.ReadOption.FieldDelimiter = c.FieldDelimiter
+	c.WriteOption.FieldDelimiter = c.FieldDelimiter
 	fileWriter, err := pio.NewGenericWriter(c.URI, c.WriteOption, schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)

--- a/cmd/transcode/transcode_test.go
+++ b/cmd/transcode/transcode_test.go
@@ -96,6 +96,7 @@ func testCmdError(t *testing.T) {
 			PageSize:         1024 * 1024,
 			RowGroupSize:     128 * 1024 * 1024,
 		}, ReadPageSize: 10, Source: "../../testdata/good.parquet", URI: filepath.Join(tempDir, "dummy")}, "not a valid CompressionCode"},
+		"field-delimiter": {Cmd{ReadOption: rOpt, WriteOption: wOpt, ReadPageSize: 10, FieldDelimiter: "::", Source: "../../testdata/good.parquet", URI: "dummy"}, "field delimiter must be a single character"},
 	}
 
 	for name, tc := range testCases {
@@ -962,6 +963,7 @@ func TestCmdIsEncodingCompatible(t *testing.T) {
 func TestCmdParseFieldEncodings(t *testing.T) {
 	testCases := []struct {
 		name            string
+		fieldDelimiter  string
 		dataPageVersion int32
 		fieldEncoding   []string
 		expected        map[string]string
@@ -969,72 +971,98 @@ func TestCmdParseFieldEncodings(t *testing.T) {
 	}{
 		{
 			name:            "empty input",
+			fieldDelimiter:  "|",
 			dataPageVersion: 1,
 			fieldEncoding:   []string{},
 			expected:        map[string]string{},
 		},
 		{
-			name:            "single field encoding",
+			name:            "single field encoding with = delimiter",
+			fieldDelimiter:  "=",
 			dataPageVersion: 1,
 			fieldEncoding:   []string{"shoe_brand=PLAIN"},
 			expected:        map[string]string{"shoe_brand": "PLAIN"},
 		},
 		{
-			name:            "multiple field encodings",
+			name:            "multiple field encodings with \\a delimiter",
+			fieldDelimiter:  "\a",
 			dataPageVersion: 1,
 			fieldEncoding:   []string{"shoe_brand=PLAIN", "shoe_name=PLAIN"},
 			expected:        map[string]string{"shoe_brand": "PLAIN", "shoe_name": "PLAIN"},
 		},
 		{
-			name:            "nested field path",
+			name:            "nested field path with tab delimiter",
+			fieldDelimiter:  "\t",
 			dataPageVersion: 1,
-			fieldEncoding:   []string{"parent.child.leaf=RLE"},
-			expected:        map[string]string{"parent.child.leaf": "RLE"},
+			fieldEncoding:   []string{"parent\tchild\tleaf=RLE"},
+			expected:        map[string]string{"parent\x01child\x01leaf": "RLE"},
 		},
 		{
-			name:            "case insensitive encoding",
+			name:            "case insensitive encoding with . delimiter",
+			fieldDelimiter:  ".",
 			dataPageVersion: 1,
 			fieldEncoding:   []string{"field=plain"},
 			expected:        map[string]string{"field": "PLAIN"},
 		},
 		{
-			name:            "encoding with whitespace",
+			name:            "encoding with whitespace and | delimiter",
+			fieldDelimiter:  "|",
 			dataPageVersion: 1,
 			fieldEncoding:   []string{"  field  =  RLE  "},
 			expected:        map[string]string{"field": "RLE"},
 		},
 		{
+			name:            "multi-char delimiter 12",
+			fieldDelimiter:  "12",
+			dataPageVersion: 1,
+			fieldEncoding:   []string{"field=PLAIN"},
+			expected:        map[string]string{"field": "PLAIN"},
+		},
+		{
+			name:            "empty delimiter defaults to dot",
+			fieldDelimiter:  "",
+			dataPageVersion: 1,
+			fieldEncoding:   []string{"field=PLAIN"},
+			expected:        map[string]string{"field": "PLAIN"},
+		},
+		{
 			name:            "missing equals sign",
+			fieldDelimiter:  "|",
 			dataPageVersion: 1,
 			fieldEncoding:   []string{"fieldPLAIN"},
 			errMsg:          "invalid field encoding format",
 		},
 		{
 			name:            "empty field path",
+			fieldDelimiter:  "|",
 			dataPageVersion: 1,
 			fieldEncoding:   []string{"=PLAIN"},
 			errMsg:          "empty field path",
 		},
 		{
 			name:            "empty encoding",
+			fieldDelimiter:  "|",
 			dataPageVersion: 1,
 			fieldEncoding:   []string{"field="},
 			errMsg:          "empty encoding",
 		},
 		{
 			name:            "invalid encoding",
+			fieldDelimiter:  "|",
 			dataPageVersion: 1,
 			fieldEncoding:   []string{"field=INVALID_ENCODING"},
 			errMsg:          "invalid encoding",
 		},
 		{
 			name:            "plain_dictionary allowed in v1",
+			fieldDelimiter:  "|",
 			dataPageVersion: 1,
 			fieldEncoding:   []string{"field=PLAIN_DICTIONARY"},
 			expected:        map[string]string{"field": "PLAIN_DICTIONARY"},
 		},
 		{
 			name:            "plain_dictionary not allowed in v2",
+			fieldDelimiter:  "|",
 			dataPageVersion: 2,
 			fieldEncoding:   []string{"field=PLAIN_DICTIONARY"},
 			errMsg:          "PLAIN_DICTIONARY encoding is only allowed with data page version 1",
@@ -1044,7 +1072,9 @@ func TestCmdParseFieldEncodings(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := Cmd{
-				FieldEncoding: tc.fieldEncoding,
+				FieldDelimiter: tc.fieldDelimiter,
+				FieldEncoding:  tc.fieldEncoding,
+				ReadOption:     pio.ReadOption{},
 				WriteOption: pio.WriteOption{
 					CompressionCodec: "SNAPPY",
 					DataPageVersion:  tc.dataPageVersion,
@@ -1147,72 +1177,104 @@ func TestCmd_getAllowedEncodings(t *testing.T) {
 func TestCmdParseFieldBloomFilters(t *testing.T) {
 	testCases := []struct {
 		name             string
+		fieldDelimiter   string
 		fieldBloomFilter []string
 		expected         map[string]string
 		errMsg           string
 	}{
 		{
 			name:             "empty input",
+			fieldDelimiter:   "|",
 			fieldBloomFilter: []string{},
 			expected:         map[string]string{},
 		},
 		{
-			name:             "enable bloom filter",
+			name:             "enable bloom filter with = delimiter",
+			fieldDelimiter:   "=",
 			fieldBloomFilter: []string{"ID=true"},
 			expected:         map[string]string{"ID": "true"},
 		},
 		{
-			name:             "disable bloom filter",
+			name:             "disable bloom filter with \\a delimiter",
+			fieldDelimiter:   "\a",
 			fieldBloomFilter: []string{"ID=false"},
 			expected:         map[string]string{"ID": "false"},
 		},
 		{
-			name:             "enable with size",
+			name:             "enable with size and tab delimiter",
+			fieldDelimiter:   "\t",
 			fieldBloomFilter: []string{"ID=2048"},
 			expected:         map[string]string{"ID": "2048"},
 		},
 		{
-			name:             "multiple fields",
+			name:             "multiple fields with . delimiter",
+			fieldDelimiter:   ".",
 			fieldBloomFilter: []string{"ID=true", "Name=4096", "Age=false"},
 			expected:         map[string]string{"ID": "true", "Name": "4096", "Age": "false"},
 		},
 		{
+			name:             "nested field with | delimiter",
+			fieldDelimiter:   "|",
+			fieldBloomFilter: []string{"parent|child=true"},
+			expected:         map[string]string{"parent\x01child": "true"},
+		},
+		{
+			name:             "multi-char delimiter 12",
+			fieldDelimiter:   "12",
+			fieldBloomFilter: []string{"ID=true"},
+			expected:         map[string]string{"ID": "true"},
+		},
+		{
+			name:             "empty delimiter defaults to dot",
+			fieldDelimiter:   "",
+			fieldBloomFilter: []string{"ID=true"},
+			expected:         map[string]string{"ID": "true"},
+		},
+		{
 			name:             "missing equals sign",
+			fieldDelimiter:   "|",
 			fieldBloomFilter: []string{"IDtrue"},
 			errMsg:           "invalid field bloom filter format",
 		},
 		{
 			name:             "empty field path",
+			fieldDelimiter:   "|",
 			fieldBloomFilter: []string{"=true"},
 			errMsg:           "empty field path",
 		},
 		{
 			name:             "empty value",
+			fieldDelimiter:   "|",
 			fieldBloomFilter: []string{"ID="},
 			errMsg:           "empty value",
 		},
 		{
 			name:             "invalid value",
+			fieldDelimiter:   "|",
 			fieldBloomFilter: []string{"ID=maybe"},
 			errMsg:           "invalid bloom filter size [maybe] for field [ID]: not a number",
 		},
 		{
 			name:             "not power of 2",
+			fieldDelimiter:   "|",
 			fieldBloomFilter: []string{"ID=3000"},
 			errMsg:           "must be a power of 2",
 		},
 		{
 			name:             "zero size",
+			fieldDelimiter:   "|",
 			fieldBloomFilter: []string{"ID=0"},
 			errMsg:           "invalid bloom filter value",
 		},
 		{
 			name:             "negative size",
+			fieldDelimiter:   "|",
 			fieldBloomFilter: []string{"ID=-1"},
 			errMsg:           "invalid bloom filter value",
 		},
 		{
 			name:             "below minimum size",
+			fieldDelimiter:   "|",
 			fieldBloomFilter: []string{"ID=16"},
 			errMsg:           "invalid bloom filter value",
 		},
@@ -1220,7 +1282,11 @@ func TestCmdParseFieldBloomFilters(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := Cmd{FieldBloomFilter: tc.fieldBloomFilter}
+			cmd := Cmd{
+				FieldDelimiter:   tc.fieldDelimiter,
+				FieldBloomFilter: tc.fieldBloomFilter,
+				ReadOption:       pio.ReadOption{},
+			}
 			result, err := cmd.parseFieldBloomFilters()
 
 			if tc.errMsg != "" {
@@ -1342,42 +1408,50 @@ func testCmdFieldBloomFilter(t *testing.T) {
 func TestCmdParseFieldCompressions(t *testing.T) {
 	testCases := []struct {
 		name             string
+		fieldDelimiter   string
 		fieldCompression []string
 		expected         map[string]string
 		errMsg           string
 	}{
 		{
 			name:             "empty input",
+			fieldDelimiter:   "|",
 			fieldCompression: []string{},
 			expected:         map[string]string{},
 		},
 		{
-			name:             "single field compression",
+			name:             "single field compression with \\a delimiter",
+			fieldDelimiter:   "\a",
 			fieldCompression: []string{"shoe_brand=SNAPPY"},
 			expected:         map[string]string{"shoe_brand": "SNAPPY"},
 		},
 		{
-			name:             "multiple field compressions",
+			name:             "multiple field compressions with = delimiter",
+			fieldDelimiter:   "=",
 			fieldCompression: []string{"shoe_brand=SNAPPY", "shoe_name=ZSTD"},
 			expected:         map[string]string{"shoe_brand": "SNAPPY", "shoe_name": "ZSTD"},
 		},
 		{
-			name:             "nested field path",
-			fieldCompression: []string{"parent.child.leaf=GZIP"},
-			expected:         map[string]string{"parent.child.leaf": "GZIP"},
+			name:             "nested field path with | delimiter",
+			fieldDelimiter:   "|",
+			fieldCompression: []string{"parent|child|leaf=GZIP"},
+			expected:         map[string]string{"parent\x01child\x01leaf": "GZIP"},
 		},
 		{
-			name:             "case insensitive codec",
+			name:             "case insensitive codec with . delimiter",
+			fieldDelimiter:   ".",
 			fieldCompression: []string{"field=snappy"},
 			expected:         map[string]string{"field": "SNAPPY"},
 		},
 		{
-			name:             "codec with whitespace",
+			name:             "codec with whitespace and tab delimiter",
+			fieldDelimiter:   "\t",
 			fieldCompression: []string{"  field  =  ZSTD  "},
 			expected:         map[string]string{"field": "ZSTD"},
 		},
 		{
-			name:             "all valid codecs",
+			name:             "all valid codecs with | delimiter",
+			fieldDelimiter:   "|",
 			fieldCompression: []string{"f1=UNCOMPRESSED", "f2=SNAPPY", "f3=GZIP", "f4=LZ4", "f5=LZ4_RAW", "f6=ZSTD", "f7=BROTLI"},
 			expected: map[string]string{
 				"f1": "UNCOMPRESSED",
@@ -1390,27 +1464,44 @@ func TestCmdParseFieldCompressions(t *testing.T) {
 			},
 		},
 		{
+			name:             "multi-char delimiter 12",
+			fieldDelimiter:   "12",
+			fieldCompression: []string{"field=SNAPPY"},
+			expected:         map[string]string{"field": "SNAPPY"},
+		},
+		{
+			name:             "empty delimiter defaults to dot",
+			fieldDelimiter:   "",
+			fieldCompression: []string{"field=SNAPPY"},
+			expected:         map[string]string{"field": "SNAPPY"},
+		},
+		{
 			name:             "missing equals sign",
+			fieldDelimiter:   "|",
 			fieldCompression: []string{"fieldSNAPPY"},
 			errMsg:           "invalid field compression format",
 		},
 		{
 			name:             "empty field path",
+			fieldDelimiter:   "|",
 			fieldCompression: []string{"=SNAPPY"},
 			errMsg:           "empty field path",
 		},
 		{
 			name:             "empty compression codec",
+			fieldDelimiter:   "|",
 			fieldCompression: []string{"field="},
 			errMsg:           "empty compression codec",
 		},
 		{
 			name:             "invalid compression codec",
+			fieldDelimiter:   "|",
 			fieldCompression: []string{"field=INVALID_CODEC"},
 			errMsg:           "invalid compression codec",
 		},
 		{
 			name:             "LZO not supported",
+			fieldDelimiter:   "|",
 			fieldCompression: []string{"field=LZO"},
 			errMsg:           "invalid compression codec",
 		},
@@ -1419,7 +1510,9 @@ func TestCmdParseFieldCompressions(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := Cmd{
+				FieldDelimiter:   tc.fieldDelimiter,
 				FieldCompression: tc.fieldCompression,
+				ReadOption:       pio.ReadOption{},
 			}
 			result, err := cmd.parseFieldCompressions()
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.31
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.0
 	github.com/google/uuid v1.6.0
-	github.com/hangxie/parquet-go/v3 v3.4.2
+	github.com/hangxie/parquet-go/v3 v3.4.3
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.11.1
 	github.com/willabides/kongplete v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyC
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
-github.com/hangxie/parquet-go/v3 v3.4.2 h1:MqHlZKsTcR+/+zps6VsEJi0hGD6W2A7KS5qqjrJ2Lis=
-github.com/hangxie/parquet-go/v3 v3.4.2/go.mod h1:yzDf7xEK3eX1iubBqTadQRbVAzKbq2Cz2xuvFoNaY1c=
+github.com/hangxie/parquet-go/v3 v3.4.3 h1:VuoNMvfB9JfUMYF/7J8YuSjvU3BgTHwZJulJcJe5oIk=
+github.com/hangxie/parquet-go/v3 v3.4.3/go.mod h1:yzDf7xEK3eX1iubBqTadQRbVAzKbq2Cz2xuvFoNaY1c=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/io/compression_level.go
+++ b/io/compression_level.go
@@ -28,13 +28,13 @@ var codecsWithoutLevels = map[string]bool{
 // normalized codec name and level. Returns an error for invalid format,
 // unknown/unsupported codecs, or non-integer levels.
 func parseCompressionLevel(item string) (string, int, error) {
-	parts := strings.SplitN(item, "=", 2)
-	if len(parts) != 2 {
+	codec, levelStr, ok := strings.Cut(item, "=")
+	if !ok {
 		return "", 0, fmt.Errorf("invalid compression level format [%s], expected 'CODEC=LEVEL'", item)
 	}
 
-	codec := strings.TrimSpace(parts[0])
-	levelStr := strings.TrimSpace(parts[1])
+	codec = strings.TrimSpace(codec)
+	levelStr = strings.TrimSpace(levelStr)
 
 	if codec == "" {
 		return "", 0, fmt.Errorf("empty codec in [%s]", item)

--- a/io/io.go
+++ b/io/io.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/parquet"
 )
 
@@ -26,6 +27,26 @@ const (
 	schemeAWSS3              string = "s3"
 	schemeAzureStorageBlob   string = "wasbs"
 )
+
+// ValidateFieldDelimiter rejects values that conflict with field assignments.
+func ValidateFieldDelimiter(delimiter string) error {
+	if delimiter == "" {
+		return nil
+	}
+	if len(delimiter) != 1 {
+		return fmt.Errorf("field delimiter must be a single character")
+	}
+	return nil
+}
+
+// NormalizeFieldPath splits path by delimiter (defaulting to "." when delimiter is empty)
+// and joins the segments with the internal ParGoPathDelimiter.
+func NormalizeFieldPath(path, delimiter string) string {
+	if delimiter == "" {
+		delimiter = "."
+	}
+	return common.PathToStr(strings.Split(path, delimiter))
+}
 
 func parseURI(uri string) (*url.URL, error) {
 	u, err := url.Parse(uri)

--- a/io/io_test.go
+++ b/io/io_test.go
@@ -117,6 +117,87 @@ func TestAzureAccessDetail(t *testing.T) {
 	})
 }
 
+func TestNormalizeFieldPath(t *testing.T) {
+	testCases := []struct {
+		name      string
+		path      string
+		delimiter string
+		expected  string
+	}{
+		{
+			name:      "default-dot-delimiter",
+			path:      "parent.child",
+			delimiter: "",
+			expected:  "parent\x01child",
+		},
+		{
+			name:      "custom-slash-delimiter",
+			path:      "parent/child",
+			delimiter: "/",
+			expected:  "parent\x01child",
+		},
+		{
+			name:      "dot-is-literal-with-custom-delimiter",
+			path:      "parent.child/leaf.name",
+			delimiter: "/",
+			expected:  "parent.child\x01leaf.name",
+		},
+		{
+			name:      "multi-character-delimiter",
+			path:      "parent::child",
+			delimiter: "::",
+			expected:  "parent\x01child",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, NormalizeFieldPath(tc.path, tc.delimiter))
+		})
+	}
+}
+
+func TestValidateFieldDelimiter(t *testing.T) {
+	testCases := []struct {
+		name      string
+		delimiter string
+		wantErr   bool
+	}{
+		{
+			name:      "valid-dot-delimiter",
+			delimiter: ".",
+			wantErr:   false,
+		},
+		{
+			name:      "valid-slash-delimiter",
+			delimiter: "/",
+			wantErr:   false,
+		},
+		{
+			name:      "valid-empty-delimiter-defaults-to-dot",
+			delimiter: "",
+			wantErr:   false,
+		},
+		{
+			name:      "invalid-multi-char-delimiter",
+			delimiter: "::",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateFieldDelimiter(tc.delimiter)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "field delimiter must be a single character")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestGetBucketRegion(t *testing.T) {
 	testCases := map[string]struct {
 		profile   string

--- a/io/reader.go
+++ b/io/reader.go
@@ -13,7 +13,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
-	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/reader"
 	"github.com/hangxie/parquet-go/v3/source"
 	pqazblob "github.com/hangxie/parquet-go/v3/source/azblob"
@@ -27,14 +26,15 @@ import (
 
 // ReadOption includes options for read operation
 type ReadOption struct {
+	AADPrefix              *string           `name:"aad-prefix" group:"Encryption" help:"(encrypted files only) base64-encoded AAD prefix (if not stored in file)."`
 	Anonymous              bool              `help:"(S3, GCS, and Azure only) object is publicly accessible." default:"false"`
+	ColumnKeys             []string          `name:"column-key" group:"Encryption" help:"(encrypted files only) column decryption key as 'column.path=base64key'; repeatable. KMS is not directly supported; retrieve the key manually first." placeholder:"column.path=base64key"`
+	FieldDelimiter         string            `kong:"-"`
+	FooterKey              *string           `name:"footer-key" group:"Encryption" help:"(encrypted files only) base64-encoded AES-128/192/256 key to decrypt the footer. KMS is not directly supported; retrieve the key manually first."`
 	HTTPExtraHeaders       map[string]string `mapsep:"," help:"(HTTP URI only) extra HTTP headers." default:""`
 	HTTPIgnoreTLSError     bool              `help:"(HTTP and S3 URI) ignore TLS error." default:"false"`
 	HTTPMultipleConnection bool              `help:"(HTTP URI only) use multiple HTTP connection." default:"false"`
 	ObjectVersion          *string           `help:"(S3, GCS, and Azure only) object version."`
-	FooterKey              *string           `name:"footer-key" group:"Encryption" help:"(encrypted files only) base64-encoded AES-128/192/256 key to decrypt the footer. KMS is not directly supported; retrieve the key manually first."`
-	ColumnKeys             []string          `name:"column-key" group:"Encryption" help:"(encrypted files only) column decryption key as 'column.path=base64key'; repeatable. KMS is not directly supported; retrieve the key manually first." placeholder:"column.path=base64key"`
-	AADPrefix              *string           `name:"aad-prefix" group:"Encryption" help:"(encrypted files only) base64-encoded AAD prefix (if not stored in file)."`
 	KeyFile                *string           `name:"key-file" group:"Encryption" help:"path to a JSON file containing decryption keys ({footer_key, aad_prefix, column_keys}); CLI flags override file values."`
 }
 
@@ -50,35 +50,35 @@ func decodeBase64(s string) ([]byte, error) {
 	return b, nil
 }
 
-func buildReaderOptions(option ReadOption) ([]reader.ReaderOption, error) {
+func buildReaderOptions(opt ReadOption) ([]reader.ReaderOption, error) {
 	var opts []reader.ReaderOption
 
-	if option.FooterKey != nil {
-		key, err := decodeBase64(*option.FooterKey)
+	if opt.FooterKey != nil {
+		key, err := decodeBase64(*opt.FooterKey)
 		if err != nil {
 			return nil, fmt.Errorf("invalid base64 footer key: %w", err)
 		}
 		opts = append(opts, reader.WithFooterKey(key))
 	}
 
-	if option.AADPrefix != nil {
-		prefix, err := decodeBase64(*option.AADPrefix)
+	if opt.AADPrefix != nil {
+		prefix, err := decodeBase64(*opt.AADPrefix)
 		if err != nil {
 			return nil, fmt.Errorf("invalid base64 AAD prefix: %w", err)
 		}
 		opts = append(opts, reader.WithAADPrefix(prefix))
 	}
 
-	for _, ck := range option.ColumnKeys {
-		parts := strings.SplitN(ck, "=", 2)
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	for _, ck := range opt.ColumnKeys {
+		path, encodedKey, found := strings.Cut(ck, "=")
+		if !found || path == "" || encodedKey == "" {
 			return nil, fmt.Errorf("invalid column key format [%s], expected 'column.path=base64key'", ck)
 		}
-		key, err := decodeBase64(parts[1])
+		key, err := decodeBase64(encodedKey)
 		if err != nil {
-			return nil, fmt.Errorf("invalid base64 column key for [%s]: %w", parts[0], err)
+			return nil, fmt.Errorf("invalid base64 column key for [%s]: %w", path, err)
 		}
-		opts = append(opts, reader.WithColumnKey(parts[0], key))
+		opts = append(opts, reader.WithColumnKey(NormalizeFieldPath(path, opt.FieldDelimiter), key))
 	}
 
 	return opts, nil
@@ -93,8 +93,8 @@ func applyKeyFile(kf keyFileSchema, opt *ReadOption) {
 	}
 	existing := make(map[string]struct{}, len(opt.ColumnKeys))
 	for _, ck := range opt.ColumnKeys {
-		if i := strings.IndexByte(ck, '='); i > 0 {
-			existing[common.ReformPathStr(ck[:i])] = struct{}{}
+		if path, _, found := strings.Cut(ck, "="); found && path != "" {
+			existing[NormalizeFieldPath(path, opt.FieldDelimiter)] = struct{}{}
 		}
 	}
 	paths := make([]string, 0, len(kf.ColumnKeys))
@@ -103,7 +103,7 @@ func applyKeyFile(kf keyFileSchema, opt *ReadOption) {
 	}
 	sort.Strings(paths)
 	for _, p := range paths {
-		if _, ok := existing[common.ReformPathStr(p)]; !ok {
+		if _, ok := existing[NormalizeFieldPath(p, opt.FieldDelimiter)]; !ok {
 			opt.ColumnKeys = append(opt.ColumnKeys, p+"="+kf.ColumnKeys[p])
 		}
 	}

--- a/io/reader_test.go
+++ b/io/reader_test.go
@@ -492,7 +492,7 @@ func TestApplyKeyFile(t *testing.T) {
 		},
 		"column-keys-cross-form-cli-wins": {
 			// CLI uses dot form "a.b"; file uses the same logical path.
-			// ReformPathStr normalizes both to the same key so the file
+			// NormalizeFieldPath normalizes both to the same key so the file
 			// entry must be suppressed and CLI value must survive.
 			kf: keyFileSchema{
 				ColumnKeys: map[string]string{"a.b": "ZmlsZQ=="},

--- a/io/writer.go
+++ b/io/writer.go
@@ -39,13 +39,14 @@ type WriteOption struct {
 	CompressionCodec    string   `short:"z" name:"compression" help:"compression codec (UNCOMPRESSED/SNAPPY/GZIP/LZ4/LZ4_RAW/ZSTD/BROTLI)" default:"SNAPPY"`
 	CompressionLevel    []string `help:"Compression level setting." placeholder:"CODEC=LEVEL"`
 	DataPageVersion     int32    `help:"Data page version (1 or 2). Use 1 for legacy DATA_PAGE format." enum:"1,2" default:"2"`
+	EncryptAllColumns   bool     `name:"encrypt-all-columns" group:"Encryption" help:"encrypt every leaf column. Columns not listed in --writer-column-key use --writer-footer-key. Default: false (only columns listed in --writer-column-key are encrypted)." default:"false"`
+	EncryptionAlgorithm string   `name:"encryption-algorithm" group:"Encryption" help:"encryption algorithm used when --writer-footer-key is set. AES-GCM-V1 authenticates every module; AES-GCM-CTR-V1 uses AES-CTR for page bodies (lower overhead, page body tampering not detected). Has no effect without --writer-footer-key." enum:"${writer_encryption_algorithms}" default:"AES-GCM-V1"`
+	FieldDelimiter      string   `kong:"-"`
 	PageSize            int64    `help:"Page size in bytes." default:"1048576"`
+	PlaintextFooter     bool     `name:"plaintext-footer" group:"Encryption" help:"write a PAR1 file with a plaintext footer signed by --writer-footer-key instead of an encrypted PARE footer. Without --encrypt-all-columns or --writer-column-key the footer is signed for integrity only (columns remain plaintext)." default:"false"`
 	RowGroupSize        int64    `help:"Row group size in bytes." default:"134217728"`
 	WriterFooterKey     *string  `name:"writer-footer-key" group:"Encryption" help:"base64-encoded AES-128/192/256 key. Encrypts the footer; also used for columns marked '=@footer-key' and for unlisted columns when --encrypt-all-columns is set. With --plaintext-footer the key signs the footer instead of encrypting it."`
-	WriterColumnKeys    []string `name:"writer-column-key" group:"Encryption" help:"per-column encryption directive 'column.path=VALUE'; repeatable. column.path is the dotted file-schema path of a leaf column without the schema root (e.g. Parent.Child, not parquet_go_root.Parent.Child). VALUE is a base64-encoded AES key, or the literal '@footer-key' to encrypt the column with --writer-footer-key. Columns not listed are plaintext unless --encrypt-all-columns is set." placeholder:"column.path=base64key"`
-	EncryptAllColumns   bool     `name:"encrypt-all-columns" group:"Encryption" help:"encrypt every leaf column. Columns not listed in --writer-column-key use --writer-footer-key. Default: false (only columns listed in --writer-column-key are encrypted)." default:"false"`
-	PlaintextFooter     bool     `name:"plaintext-footer" group:"Encryption" help:"write a PAR1 file with a plaintext footer signed by --writer-footer-key instead of an encrypted PARE footer. Without --encrypt-all-columns or --writer-column-key the footer is signed for integrity only (columns remain plaintext)." default:"false"`
-	EncryptionAlgorithm string   `name:"encryption-algorithm" group:"Encryption" help:"encryption algorithm used when --writer-footer-key is set. AES-GCM-V1 authenticates every module; AES-GCM-CTR-V1 uses AES-CTR for page bodies (lower overhead, page body tampering not detected). Has no effect without --writer-footer-key." enum:"${writer_encryption_algorithms}" default:"AES-GCM-V1"`
+	WriterColumnKeys    []string `name:"writer-column-key" group:"Encryption" help:"per-column encryption directive 'column.path=VALUE'; repeatable. column.path is the file-schema path of a leaf column without the schema root (e.g. Parent.Child, not parquet_go_root.Parent.Child), separated by --field-delimiter. VALUE is a base64-encoded AES key, or the literal '@footer-key' to encrypt the column with --writer-footer-key. Columns not listed are plaintext unless --encrypt-all-columns is set." placeholder:"column.path=base64key"`
 	WriterKeyFile       *string  `name:"writer-key-file" group:"Encryption" help:"path to a JSON file containing encryption keys ({footer_key, column_keys}); CLI flags override file values; --writer-column-key flags merge with file column_keys, CLI wins per path. Recommend chmod 600 on the file."`
 }
 
@@ -166,8 +167,8 @@ func writerOpts(option WriteOption, columnKeys []writerColumnKey) ([]writer.Writ
 	return opts, nil
 }
 
-func NewCSVWriter(uri string, option WriteOption, schema []string) (*writer.CSVWriter, error) {
-	option, err := applyWriterKeyFileOption(option)
+func NewCSVWriter(uri string, opt WriteOption, schema []string) (*writer.CSVWriter, error) {
+	opt, err := applyWriterKeyFileOption(opt)
 	if err != nil {
 		return nil, err
 	}
@@ -177,17 +178,17 @@ func NewCSVWriter(uri string, option WriteOption, schema []string) (*writer.CSVW
 		return nil, err
 	}
 
-	columnKeys, err := parseWriterColumnKeys(option.WriterColumnKeys)
+	columnKeys, err := parseWriterColumnKeys(opt.WriterColumnKeys, opt.FieldDelimiter)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err
 	}
-	opts, err := writerOpts(option, columnKeys)
+	opts, err := writerOpts(opt, columnKeys)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err
 	}
-	encOpts, err := writerColumnEncryptionSchemaOpts(option, columnKeys, func() (*parquetschema.SchemaHandler, error) {
+	encOpts, err := writerColumnEncryptionSchemaOpts(opt, columnKeys, func() (*parquetschema.SchemaHandler, error) {
 		return parquetschema.NewSchemaHandlerFromMetadata(schema)
 	}, "create schema from metadata")
 	if err != nil {
@@ -203,8 +204,8 @@ func NewCSVWriter(uri string, option WriteOption, schema []string) (*writer.CSVW
 	return pw, nil
 }
 
-func NewJSONWriter(uri string, option WriteOption, schema string) (*writer.JSONWriter, error) {
-	option, err := applyWriterKeyFileOption(option)
+func NewJSONWriter(uri string, opt WriteOption, schema string) (*writer.JSONWriter, error) {
+	opt, err := applyWriterKeyFileOption(opt)
 	if err != nil {
 		return nil, err
 	}
@@ -214,17 +215,17 @@ func NewJSONWriter(uri string, option WriteOption, schema string) (*writer.JSONW
 		return nil, err
 	}
 
-	columnKeys, err := parseWriterColumnKeys(option.WriterColumnKeys)
+	columnKeys, err := parseWriterColumnKeys(opt.WriterColumnKeys, opt.FieldDelimiter)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err
 	}
-	opts, err := writerOpts(option, columnKeys)
+	opts, err := writerOpts(opt, columnKeys)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err
 	}
-	encOpts, err := writerColumnEncryptionSchemaOpts(option, columnKeys, func() (*parquetschema.SchemaHandler, error) {
+	encOpts, err := writerColumnEncryptionSchemaOpts(opt, columnKeys, func() (*parquetschema.SchemaHandler, error) {
 		return parquetschema.NewSchemaHandlerFromJSON(schema)
 	}, "create schema from JSON")
 	if err != nil {
@@ -240,8 +241,8 @@ func NewJSONWriter(uri string, option WriteOption, schema string) (*writer.JSONW
 	return pw, nil
 }
 
-func NewGenericWriter(uri string, option WriteOption, schema string) (*writer.ParquetWriter, error) {
-	option, err := applyWriterKeyFileOption(option)
+func NewGenericWriter(uri string, opt WriteOption, schema string) (*writer.ParquetWriter, error) {
+	opt, err := applyWriterKeyFileOption(opt)
 	if err != nil {
 		return nil, err
 	}
@@ -251,17 +252,17 @@ func NewGenericWriter(uri string, option WriteOption, schema string) (*writer.Pa
 		return nil, err
 	}
 
-	columnKeys, err := parseWriterColumnKeys(option.WriterColumnKeys)
+	columnKeys, err := parseWriterColumnKeys(opt.WriterColumnKeys, opt.FieldDelimiter)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err
 	}
-	opts, err := writerOpts(option, columnKeys)
+	opts, err := writerOpts(opt, columnKeys)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err
 	}
-	encOpts, err := writerColumnEncryptionSchemaOpts(option, columnKeys, func() (*parquetschema.SchemaHandler, error) {
+	encOpts, err := writerColumnEncryptionSchemaOpts(opt, columnKeys, func() (*parquetschema.SchemaHandler, error) {
 		return parquetschema.NewSchemaHandlerFromJSON(schema)
 	}, "create schema from JSON")
 	if err != nil {

--- a/io/writer_encryption.go
+++ b/io/writer_encryption.go
@@ -36,8 +36,8 @@ func applyWriterKeyFile(kf keyFileSchema, opt *WriteOption) {
 	}
 	existing := make(map[string]struct{}, len(opt.WriterColumnKeys))
 	for _, ck := range opt.WriterColumnKeys {
-		if i := strings.IndexByte(ck, '='); i > 0 {
-			existing[common.ReformPathStr(ck[:i])] = struct{}{}
+		if path, _, found := strings.Cut(ck, "="); found && path != "" {
+			existing[NormalizeFieldPath(path, opt.FieldDelimiter)] = struct{}{}
 		}
 	}
 	paths := make([]string, 0, len(kf.ColumnKeys))
@@ -46,7 +46,7 @@ func applyWriterKeyFile(kf keyFileSchema, opt *WriteOption) {
 	}
 	sort.Strings(paths)
 	for _, p := range paths {
-		if _, ok := existing[common.ReformPathStr(p)]; !ok {
+		if _, ok := existing[NormalizeFieldPath(p, opt.FieldDelimiter)]; !ok {
 			opt.WriterColumnKeys = append(opt.WriterColumnKeys, p+"="+kf.ColumnKeys[p])
 		}
 	}
@@ -65,11 +65,11 @@ func applyWriterKeyFileOption(option WriteOption) (WriteOption, error) {
 }
 
 // writerColumnKey is one parsed --writer-column-key directive. Path is the
-// user-supplied path verbatim (used in error messages and as the argument
-// to writer.WithColumnEncrypted); it must be the dotted file-schema path
-// of a leaf column without the schema root (e.g. "Parent.Child", not
-// "parquet_go_root.Parent.Child"). NormalizedPath is the ReformPathStr
-// form used for schema lookup and duplicate detection. Value is the RHS
+// user-supplied path verbatim (used in error messages). It must be the
+// file-schema path of a leaf column without the schema root (e.g. "Parent.Child", not
+// "parquet_go_root.Parent.Child"). NormalizedPath uses parquet-go's internal
+// delimiter and is passed to writer.WithColumnEncrypted as well as used for
+// schema lookup and duplicate detection. Value is the RHS
 // — either the "@footer-key" sentinel or a base64-encoded AES key —
 // interpreted by downstream callers.
 type writerColumnKey struct {
@@ -82,26 +82,26 @@ type writerColumnKey struct {
 // strings into a single slice. Format validation and duplicate-path rejection
 // happen here exactly once; downstream helpers consume the result without
 // re-parsing or re-checking.
-func parseWriterColumnKeys(rawKeys []string) ([]writerColumnKey, error) {
+func parseWriterColumnKeys(rawKeys []string, fieldDelimiter string) ([]writerColumnKey, error) {
 	if len(rawKeys) == 0 {
 		return nil, nil
 	}
 	parsed := make([]writerColumnKey, 0, len(rawKeys))
 	seen := make(map[string]struct{}, len(rawKeys))
 	for _, raw := range rawKeys {
-		parts := strings.SplitN(raw, "=", 2)
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		path, value, found := strings.Cut(raw, "=")
+		if !found || path == "" || value == "" {
 			return nil, fmt.Errorf("invalid writer column key format [%s], expected 'column.path=base64key'", raw)
 		}
-		normalized := common.ReformPathStr(parts[0])
+		normalized := NormalizeFieldPath(path, fieldDelimiter)
 		if _, ok := seen[normalized]; ok {
-			return nil, fmt.Errorf("duplicate writer column key path [%s]", parts[0])
+			return nil, fmt.Errorf("duplicate writer column key path [%s]", path)
 		}
 		seen[normalized] = struct{}{}
 		parsed = append(parsed, writerColumnKey{
-			Path:           parts[0],
+			Path:           path,
 			NormalizedPath: normalized,
-			Value:          parts[1],
+			Value:          value,
 		})
 	}
 	return parsed, nil
@@ -137,7 +137,7 @@ func writerEncryptionOpts(option WriteOption, columnKeys []writerColumnKey) ([]w
 	opts := []writer.WriterOption{writer.WithFooterKey(footerKey)}
 	for _, ck := range columnKeys {
 		if ck.Value == writerColumnKeyFooterSentinel {
-			opts = append(opts, writer.WithColumnEncrypted(ck.Path, writer.ColumnFooterKey()))
+			opts = append(opts, writer.WithColumnEncrypted(ck.NormalizedPath, writer.ColumnFooterKey()))
 			continue
 		}
 
@@ -149,7 +149,7 @@ func writerEncryptionOpts(option WriteOption, columnKeys []writerColumnKey) ([]w
 			return nil, err
 		}
 
-		opts = append(opts, writer.WithColumnEncrypted(ck.Path, writer.ColumnKey(key)))
+		opts = append(opts, writer.WithColumnEncrypted(ck.NormalizedPath, writer.ColumnKey(key)))
 	}
 
 	if option.PlaintextFooter {
@@ -177,11 +177,8 @@ func validateWriterColumnKeySchemaPaths(columnKeys []writerColumnKey, pathToLeaf
 // writerSchemaPathToLeaf maps the canonical user-facing form of a leaf
 // column path — the external (Tag-name) path with the schema root
 // stripped, in parquet-go's ParGoPathDelimiter-separated form — to the
-// in-path used in schemaHandler.ValueColumns. That delimiter-separated
-// form is what ReformPathStr produces from the dotted path the user
-// supplies, which is why callers look up entries with
-// ReformPathStr(userInput). Only one form is accepted on purpose:
-// allowing multiple forms lets the same logical column appear twice
+// in-path used in schemaHandler.ValueColumns. Only one form is accepted on
+// purpose: allowing multiple forms lets the same logical column appear twice
 // in a --writer-column-key list under different spellings, which would
 // produce two WithColumnEncrypted calls for the same leaf with
 // conflicting keys.
@@ -196,22 +193,21 @@ func writerSchemaPathToLeaf(schemaHandler *parquetschema.SchemaHandler) map[stri
 		if stripped == "" {
 			continue
 		}
-		m[common.ReformPathStr(stripped)] = inPathStr
+		m[stripped] = inPathStr
 	}
 	return m
 }
 
 // stripWriterSchemaRoot returns the leaf path with the schema root removed,
-// in dot-separated form — matching both --writer-column-key syntax and
-// parquet-go's documented WithColumnEncrypted("rootless, dot-separated")
-// input contract. The empty return signals a path with no children below
+// in parquet-go's internal delimiter-separated form. The empty return signals
+// a path with no children below
 // the root (i.e., nothing to encrypt).
 func stripWriterSchemaRoot(path string) string {
 	parts := common.StrToPath(path)
 	if len(parts) <= 1 {
 		return ""
 	}
-	return strings.Join(parts[1:], ".")
+	return common.PathToStr(parts[1:])
 }
 
 // writerEncryptAllColumnsOpts returns one WithColumnEncrypted(path,

--- a/io/writer_encryption_test.go
+++ b/io/writer_encryption_test.go
@@ -68,7 +68,7 @@ func TestValidateWriterColumnKeySchemaPaths(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			columnKeys, parseErr := parseWriterColumnKeys(tc.option.WriterColumnKeys)
+			columnKeys, parseErr := parseWriterColumnKeys(tc.option.WriterColumnKeys, tc.option.FieldDelimiter)
 			require.NoError(t, parseErr)
 			var pathToLeaf map[string]string
 			if tc.schema != nil {
@@ -88,7 +88,7 @@ func TestValidateWriterColumnKeySchemaPaths(t *testing.T) {
 // TestValidateWriterColumnKeySchemaPathsCrossFormDuplicate covers the
 // case where the user lists two --writer-column-key directives whose
 // paths refer to the same leaf via different forms. The
-// ReformPathStr-keyed dedup in parseWriterColumnKeys does not strip
+// Normalized-path dedup in parseWriterColumnKeys does not strip
 // the schema root, so this used to slip through and produce two
 // WithColumnEncrypted calls for the same leaf with conflicting keys.
 // Restricting the accepted form to stripped-external rejects the
@@ -104,7 +104,7 @@ func TestValidateWriterColumnKeySchemaPathsCrossFormDuplicate(t *testing.T) {
 	columnKeys, err := parseWriterColumnKeys([]string{
 		stripped + "=" + columnKey,
 		nestedExPath + "=@footer-key",
-	})
+	}, "")
 	require.NoError(t, err)
 	require.Len(t, columnKeys, 2)
 
@@ -117,9 +117,11 @@ func TestParseWriterColumnKeys(t *testing.T) {
 	key16 := *testWriterKeyBase64(16)
 
 	testCases := map[string]struct {
-		raw       []string
-		errMsg    string
-		wantPaths []string
+		raw                 []string
+		delimiter           string
+		errMsg              string
+		wantPaths           []string
+		wantNormalizedPaths []string
 	}{
 		"nil": {
 			raw: nil,
@@ -134,6 +136,12 @@ func TestParseWriterColumnKeys(t *testing.T) {
 		"multiple": {
 			raw:       []string{"a=" + key16, "b=@footer-key"},
 			wantPaths: []string{"a", "b"},
+		},
+		"custom-delimiter-preserves-dots-in-field-names": {
+			raw:                 []string{"Parent.With.Dot/Child.Name=" + key16},
+			delimiter:           "/",
+			wantPaths:           []string{"Parent.With.Dot/Child.Name"},
+			wantNormalizedPaths: []string{"Parent.With.Dot\x01Child.Name"},
 		},
 		"missing-equals": {
 			raw:    []string{"name"},
@@ -160,7 +168,7 @@ func TestParseWriterColumnKeys(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			parsed, err := parseWriterColumnKeys(tc.raw)
+			parsed, err := parseWriterColumnKeys(tc.raw, tc.delimiter)
 			if tc.errMsg != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
@@ -171,6 +179,9 @@ func TestParseWriterColumnKeys(t *testing.T) {
 			require.Len(t, parsed, len(tc.wantPaths))
 			for i, p := range tc.wantPaths {
 				require.Equal(t, p, parsed[i].Path)
+				if len(tc.wantNormalizedPaths) > 0 {
+					require.Equal(t, tc.wantNormalizedPaths[i], parsed[i].NormalizedPath)
+				}
 			}
 		})
 	}
@@ -185,8 +196,8 @@ func TestWriterSchemaPathToLeaf(t *testing.T) {
 
 	// Only the stripped-external (file-schema) form is registered. Map keys
 	// are normalized to the ParGoPathDelimiter form, matching how callers look
-	// up entries via ReformPathStr(userInput).
-	require.Equal(t, nestedLeaf, pathToLeaf[common.ReformPathStr(strippedEx)])
+	// up entries via NormalizeFieldPath(userInput, delimiter).
+	require.Equal(t, nestedLeaf, pathToLeaf[strippedEx])
 	// The unstripped forms must NOT be registered, so that users cannot
 	// smuggle the same leaf in under two different paths.
 	_, ok := pathToLeaf[nestedLeaf]
@@ -214,9 +225,9 @@ func TestWriterSchemaPathToLeafDefensive(t *testing.T) {
 
 	pathToLeaf := writerSchemaPathToLeaf(schemaHandler)
 	// The !ok branch falls back to the in-path; stripping leaves "Field".
-	require.Equal(t, missingMapping, pathToLeaf[common.ReformPathStr("Field")])
+	require.Equal(t, missingMapping, pathToLeaf[NormalizeFieldPath("Field", "")])
 	// rootOnly has no children below the root and must be skipped entirely.
-	require.NotContains(t, pathToLeaf, common.ReformPathStr(rootOnly))
+	require.NotContains(t, pathToLeaf, NormalizeFieldPath(rootOnly, ""))
 	require.Len(t, pathToLeaf, 1)
 
 	opts := writerEncryptAllColumnsOpts(
@@ -270,7 +281,7 @@ func TestWriterEncryptAllColumnsOpts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			columnKeys, parseErr := parseWriterColumnKeys(tc.option.WriterColumnKeys)
+			columnKeys, parseErr := parseWriterColumnKeys(tc.option.WriterColumnKeys, tc.option.FieldDelimiter)
 			require.NoError(t, parseErr)
 			var pathToLeaf map[string]string
 			if tc.schema != nil {
@@ -376,7 +387,7 @@ func TestApplyWriterKeyFile(t *testing.T) {
 		},
 		"column-keys-cross-form-cli-wins": {
 			// CLI uses dot form "a.b"; file uses the same logical path.
-			// ReformPathStr normalizes both to the same key so the file
+			// NormalizeFieldPath normalizes both to the same key so the file
 			// entry must be suppressed and CLI value must survive.
 			kf:      keyFileSchema{ColumnKeys: map[string]string{"a.b": "ZmlsZQ=="}},
 			initial: WriteOption{WriterColumnKeys: []string{"a.b=Y2xp"}},
@@ -586,7 +597,7 @@ func TestWriterOpts(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			columnKeys, parseErr := parseWriterColumnKeys(tc.option.WriterColumnKeys)
+			columnKeys, parseErr := parseWriterColumnKeys(tc.option.WriterColumnKeys, tc.option.FieldDelimiter)
 			if parseErr != nil {
 				require.NotEmpty(t, tc.errMsg, "unexpected parse error: %v", parseErr)
 				require.Contains(t, parseErr.Error(), tc.errMsg)


### PR DESCRIPTION
## Summary

- adapt nested column paths to the parquet-go PathToStr contract
- add --field-delimiter with a default of . for field and column parameters
- preserve literal dots in field names when a custom delimiter is selected
- document and test column keys plus transcode field encoding, compression, and bloom filter paths

## Testing

- make all