### PR TITLE
refactor: thread context.Context from top-level commands through entire call stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ parquet-tools: error: expected one of "cat", "import", "inspect", "merge", "meta
     - [Container Image](#container-image)
     - [Prebuilt RPM and deb Packages](#prebuilt-rpm-and-deb-packages)
   - [Usage](#usage)
+    - [Canceling a Command](#canceling-a-command)
     - [Obtain Help](#obtain-help)
     - [Parquet File Location](#parquet-file-location)
       - [File System](#file-system)
@@ -229,6 +230,10 @@ Updating / installing...
 ```
 
 ## Usage
+
+### Canceling a Command
+
+Press Ctrl+C to cancel an active command. `parquet-tools` also handles `SIGTERM`, allowing long-running reads, writes, and inspection operations to stop cleanly.
 
 ### Obtain Help
 `parquet-tools` provides help information through `-h` flag, whenever you are not sure about a parameter for a command, just add `-h` to the end of the line then it will give you all available options, for example:

--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -49,7 +49,7 @@ var delimiter = map[string]struct {
 }
 
 // Run does actual cat job
-func (c Cmd) Run() error {
+func (c Cmd) Run(ctx context.Context) error {
 	if c.ReadPageSize < 1 {
 		return fmt.Errorf("invalid read page size %d, needs to be at least 1", c.ReadPageSize)
 	}
@@ -67,7 +67,7 @@ func (c Cmd) Run() error {
 		return fmt.Errorf("unknown format: [%s]", c.Format)
 	}
 
-	fileReader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
+	fileReader, err := pio.NewParquetFileReader(ctx, c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (c Cmd) Run() error {
 		_ = fileReader.PFile.Close()
 	}()
 
-	return c.outputRows(fileReader)
+	return c.outputRows(ctx, fileReader)
 }
 
 func (c *Cmd) outputHeader(schemaRoot *pschema.SchemaNode) ([]string, error) {
@@ -109,8 +109,8 @@ func (c *Cmd) outputHeader(schemaRoot *pschema.SchemaNode) ([]string, error) {
 	return fieldList, nil
 }
 
-func (c *Cmd) retrieveFieldDef(fileReader *reader.ParquetReader) ([]string, error) {
-	schemaRoot, err := pschema.NewSchemaTree(context.Background(), fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
+func (c *Cmd) retrieveFieldDef(ctx context.Context, fileReader *reader.ParquetReader) ([]string, error) {
+	schemaRoot, err := pschema.NewSchemaTree(ctx, fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
 	if err != nil {
 		return nil, err
 	}
@@ -251,20 +251,20 @@ func (c Cmd) printer(ctx context.Context, outputChan chan string) error {
 	}
 }
 
-func (c Cmd) outputRows(fileReader *reader.ParquetReader) error {
-	fieldList, err := c.retrieveFieldDef(fileReader)
+func (c Cmd) outputRows(ctx context.Context, fileReader *reader.ParquetReader) error {
+	fieldList, err := c.retrieveFieldDef(ctx, fileReader)
 	if err != nil {
 		return err
 	}
 
-	schemaRoot, err := pschema.NewSchemaTree(context.Background(), fileReader, pschema.SchemaOption{})
+	schemaRoot, err := pschema.NewSchemaTree(ctx, fileReader, pschema.SchemaOption{})
 	if err != nil {
 		return err
 	}
 	unknownCols := unknownColumnNames(schemaRoot)
 
 	// skip rows
-	if err := fileReader.SkipRowsWithContext(context.Background(), c.Skip); err != nil {
+	if err := fileReader.SkipRowsWithContext(ctx, c.Skip); err != nil {
 		return err
 	}
 
@@ -276,9 +276,6 @@ func (c Cmd) outputRows(fileReader *reader.ParquetReader) error {
 	}
 
 	// Use a single errgroup for all goroutines
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	g, gctx := errgroup.WithContext(ctx)
 
 	// Use appropriate buffer size
@@ -313,7 +310,7 @@ func (c Cmd) outputRows(fileReader *reader.ParquetReader) error {
 			default:
 			}
 
-			rows, err := fileReader.ReadByNumberWithContext(context.Background(), c.ReadPageSize)
+			rows, err := fileReader.ReadByNumberWithContext(gctx, c.ReadPageSize)
 			if err != nil {
 				return fmt.Errorf("failed to cat: %w", err)
 			}

--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -67,7 +67,7 @@ func (c Cmd) Run() error {
 		return fmt.Errorf("unknown format: [%s]", c.Format)
 	}
 
-	fileReader, err := pio.NewParquetFileReader(c.URI, c.ReadOption)
+	fileReader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func (c *Cmd) outputHeader(schemaRoot *pschema.SchemaNode) ([]string, error) {
 }
 
 func (c *Cmd) retrieveFieldDef(fileReader *reader.ParquetReader) ([]string, error) {
-	schemaRoot, err := pschema.NewSchemaTree(fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
+	schemaRoot, err := pschema.NewSchemaTree(context.Background(), fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (c Cmd) outputRows(fileReader *reader.ParquetReader) error {
 		return err
 	}
 
-	schemaRoot, err := pschema.NewSchemaTree(fileReader, pschema.SchemaOption{})
+	schemaRoot, err := pschema.NewSchemaTree(context.Background(), fileReader, pschema.SchemaOption{})
 	if err != nil {
 		return err
 	}

--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -264,7 +264,7 @@ func (c Cmd) outputRows(fileReader *reader.ParquetReader) error {
 	unknownCols := unknownColumnNames(schemaRoot)
 
 	// skip rows
-	if err := fileReader.SkipRows(c.Skip); err != nil {
+	if err := fileReader.SkipRowsWithContext(context.Background(), c.Skip); err != nil {
 		return err
 	}
 
@@ -313,7 +313,7 @@ func (c Cmd) outputRows(fileReader *reader.ParquetReader) error {
 			default:
 			}
 
-			rows, err := fileReader.ReadByNumber(c.ReadPageSize)
+			rows, err := fileReader.ReadByNumberWithContext(context.Background(), c.ReadPageSize)
 			if err != nil {
 				return fmt.Errorf("failed to cat: %w", err)
 			}

--- a/cmd/cat/cat_test.go
+++ b/cmd/cat/cat_test.go
@@ -315,7 +315,7 @@ func TestCmdEncoder(t *testing.T) {
 				require.NoError(t, err)
 
 				// Populate rowChan with some data, then cancel context
-				rows, err := fileReader.ReadByNumber(5)
+				rows, err := fileReader.ReadByNumberWithContext(context.Background(), 5)
 				require.NoError(t, err)
 
 				// Send one row and then cancel
@@ -341,7 +341,7 @@ func TestCmdEncoder(t *testing.T) {
 				require.NoError(t, err)
 
 				// Populate rowChan with data
-				rows, err := fileReader.ReadByNumber(5)
+				rows, err := fileReader.ReadByNumberWithContext(context.Background(), 5)
 				require.NoError(t, err)
 
 				// Fill output channel to block sending

--- a/cmd/cat/cat_test.go
+++ b/cmd/cat/cat_test.go
@@ -311,7 +311,7 @@ func TestCmdEncoder(t *testing.T) {
 				outputChan := make(chan string, 10)
 
 				// Open a test parquet file
-				fileReader, err := pio.NewParquetFileReader("file://../../testdata/good.parquet", rOpt)
+				fileReader, err := pio.NewParquetFileReader(context.Background(), "file://../../testdata/good.parquet", rOpt)
 				require.NoError(t, err)
 
 				// Populate rowChan with some data, then cancel context
@@ -337,7 +337,7 @@ func TestCmdEncoder(t *testing.T) {
 				outputChan := make(chan string, 1) // Small buffer to test the send path
 
 				// Open a test parquet file
-				fileReader, err := pio.NewParquetFileReader("file://../../testdata/good.parquet", rOpt)
+				fileReader, err := pio.NewParquetFileReader(context.Background(), "file://../../testdata/good.parquet", rOpt)
 				require.NoError(t, err)
 
 				// Populate rowChan with data

--- a/cmd/cat/cat_test.go
+++ b/cmd/cat/cat_test.go
@@ -222,12 +222,12 @@ func TestCmd(t *testing.T) {
 				cmd.URI = "file://../../testdata/" + tc.cmd.URI
 			}
 			if tc.errMsg != "" {
-				err := cmd.Run()
+				err := cmd.Run(context.Background())
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
 			} else {
 				stdout, stderr := testutils.CaptureStdoutStderr(func() {
-					require.NoError(t, cmd.Run())
+					require.NoError(t, cmd.Run(context.Background()))
 				})
 				require.Equal(t, testutils.LoadExpected(t, "../../testdata/golden/"+tc.golden), stdout)
 				require.Equal(t, "", stderr)
@@ -284,7 +284,7 @@ func TestCmdEncrypted(t *testing.T) {
 			}
 
 			stdout, stderr := testutils.CaptureStdoutStderr(func() {
-				require.NoError(t, cmd.Run())
+				require.NoError(t, cmd.Run(context.Background()))
 			})
 			require.Contains(t, stdout, `"double_field"`)
 			require.Contains(t, stdout, `"float_field"`)
@@ -403,19 +403,19 @@ func BenchmarkCatCmd(b *testing.B) {
 	}
 	// Warm up the Go runtime before actual benchmark
 	for range 10 {
-		_ = cmd.Run()
+		_ = cmd.Run(context.Background())
 	}
 
 	b.Run("default", func(b *testing.B) {
 		for b.Loop() {
-			require.NoError(b, cmd.Run())
+			require.NoError(b, cmd.Run(context.Background()))
 		}
 	})
 
 	cmd.Concurrent = true
 	b.Run("concurrent", func(b *testing.B) {
 		for b.Loop() {
-			require.NoError(b, cmd.Run())
+			require.NoError(b, cmd.Run(context.Background()))
 		}
 	})
 
@@ -424,7 +424,7 @@ func BenchmarkCatCmd(b *testing.B) {
 	cmd.Concurrent = true
 	b.Run("csv", func(b *testing.B) {
 		for b.Loop() {
-			require.NoError(b, cmd.Run())
+			require.NoError(b, cmd.Run(context.Background()))
 		}
 	})
 }

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -2,6 +2,7 @@ package importcmd
 
 import (
 	"bufio"
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
@@ -102,11 +103,11 @@ func (c Cmd) importCSV() error {
 		for i := range fields {
 			parquetFields[i] = &fields[i]
 		}
-		if err = parquetWriter.WriteString(parquetFields); err != nil {
+		if err = parquetWriter.WriteStringWithContext(context.Background(), parquetFields); err != nil {
 			return fmt.Errorf("failed to write [%v] to parquet: %w", fields, err)
 		}
 	}
-	if err := parquetWriter.WriteStop(); err != nil {
+	if err := parquetWriter.WriteStopWithContext(context.Background()); err != nil {
 		return fmt.Errorf("failed to close Parquet writer [%s]: %w", c.URI, err)
 	}
 
@@ -144,12 +145,12 @@ func (c Cmd) importJSON() error {
 	}
 
 	for _, record := range records {
-		if err := parquetWriter.Write(string(record)); err != nil {
+		if err := parquetWriter.WriteWithContext(context.Background(), string(record)); err != nil {
 			return fmt.Errorf("failed to write to parquet file: %w", err)
 		}
 	}
 
-	if err := parquetWriter.WriteStop(); err != nil {
+	if err := parquetWriter.WriteStopWithContext(context.Background()); err != nil {
 		return fmt.Errorf("failed to close Parquet writer [%s]: %w", c.URI, err)
 	}
 	if err := c.closeWriter(parquetWriter.PFile); err != nil {
@@ -191,11 +192,11 @@ func (c Cmd) importJSONL() error {
 			return fmt.Errorf("invalid JSON string: %s", string(jsonData))
 		}
 
-		if err := parquetWriter.Write(string(jsonData)); err != nil {
+		if err := parquetWriter.WriteWithContext(context.Background(), string(jsonData)); err != nil {
 			return fmt.Errorf("failed to write to parquet file: %w", err)
 		}
 	}
-	if err := parquetWriter.WriteStop(); err != nil {
+	if err := parquetWriter.WriteStopWithContext(context.Background()); err != nil {
 		return fmt.Errorf("failed to close Parquet writer [%s]: %w", c.URI, err)
 	}
 	if err := c.closeWriter(parquetWriter.PFile); err != nil {

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -29,18 +29,18 @@ type Cmd struct {
 }
 
 // Run does actual import job
-func (c Cmd) Run() error {
+func (c Cmd) Run(ctx context.Context) error {
 	if err := pio.ValidateFieldDelimiter(c.FieldDelimiter); err != nil {
 		return err
 	}
 	c.WriteOption.FieldDelimiter = c.FieldDelimiter
 	switch c.Format {
 	case "csv":
-		return c.importCSV()
+		return c.importCSV(ctx)
 	case "json":
-		return c.importJSON()
+		return c.importJSON(ctx)
 	case "jsonl":
-		return c.importJSONL()
+		return c.importJSONL(ctx)
 	}
 	return fmt.Errorf("[%s] is not a recognized source format", c.Format)
 }
@@ -59,7 +59,7 @@ func (c Cmd) closeWriter(pf parquetSource.ParquetFileWriter) error {
 	return err
 }
 
-func (c Cmd) importCSV() error {
+func (c Cmd) importCSV(ctx context.Context) error {
 	schemaData, err := os.ReadFile(c.Schema)
 	if err != nil {
 		return fmt.Errorf("failed to load schema from [%s]: %w", c.Schema, err)
@@ -83,7 +83,7 @@ func (c Cmd) importCSV() error {
 	}()
 	csvReader := csv.NewReader(csvFile)
 
-	parquetWriter, err := pio.NewCSVWriter(context.Background(), c.URI, c.WriteOption, schema)
+	parquetWriter, err := pio.NewCSVWriter(ctx, c.URI, c.WriteOption, schema)
 	if err != nil {
 		return fmt.Errorf("failed to create CSV writer: %w", err)
 	}
@@ -103,11 +103,11 @@ func (c Cmd) importCSV() error {
 		for i := range fields {
 			parquetFields[i] = &fields[i]
 		}
-		if err = parquetWriter.WriteStringWithContext(context.Background(), parquetFields); err != nil {
+		if err = parquetWriter.WriteStringWithContext(ctx, parquetFields); err != nil {
 			return fmt.Errorf("failed to write [%v] to parquet: %w", fields, err)
 		}
 	}
-	if err := parquetWriter.WriteStopWithContext(context.Background()); err != nil {
+	if err := parquetWriter.WriteStopWithContext(ctx); err != nil {
 		return fmt.Errorf("failed to close Parquet writer [%s]: %w", c.URI, err)
 	}
 
@@ -118,7 +118,7 @@ func (c Cmd) importCSV() error {
 	return nil
 }
 
-func (c Cmd) importJSON() error {
+func (c Cmd) importJSON(ctx context.Context) error {
 	schemaData, err := os.ReadFile(c.Schema)
 	if err != nil {
 		return fmt.Errorf("failed to load schema from [%s]: %w", c.Schema, err)
@@ -139,18 +139,18 @@ func (c Cmd) importJSON() error {
 		return fmt.Errorf("content of [%s] is not a valid JSON array: %w", c.Source, err)
 	}
 
-	parquetWriter, err := pio.NewJSONWriter(context.Background(), c.URI, c.WriteOption, string(schemaData))
+	parquetWriter, err := pio.NewJSONWriter(ctx, c.URI, c.WriteOption, string(schemaData))
 	if err != nil {
 		return fmt.Errorf("failed to create JSON writer: %w", err)
 	}
 
 	for _, record := range records {
-		if err := parquetWriter.WriteWithContext(context.Background(), string(record)); err != nil {
+		if err := parquetWriter.WriteWithContext(ctx, string(record)); err != nil {
 			return fmt.Errorf("failed to write to parquet file: %w", err)
 		}
 	}
 
-	if err := parquetWriter.WriteStopWithContext(context.Background()); err != nil {
+	if err := parquetWriter.WriteStopWithContext(ctx); err != nil {
 		return fmt.Errorf("failed to close Parquet writer [%s]: %w", c.URI, err)
 	}
 	if err := c.closeWriter(parquetWriter.PFile); err != nil {
@@ -160,7 +160,7 @@ func (c Cmd) importJSON() error {
 	return nil
 }
 
-func (c Cmd) importJSONL() error {
+func (c Cmd) importJSONL(ctx context.Context) error {
 	schemaData, err := os.ReadFile(c.Schema)
 	if err != nil {
 		return fmt.Errorf("failed to load schema from [%s]: %w", c.Schema, err)
@@ -181,7 +181,7 @@ func (c Cmd) importJSONL() error {
 	scanner := bufio.NewScanner(jsonlFile)
 	scanner.Split(bufio.ScanLines)
 
-	parquetWriter, err := pio.NewJSONWriter(context.Background(), c.URI, c.WriteOption, string(schemaData))
+	parquetWriter, err := pio.NewJSONWriter(ctx, c.URI, c.WriteOption, string(schemaData))
 	if err != nil {
 		return fmt.Errorf("failed to create JSON writer: %w", err)
 	}
@@ -192,11 +192,11 @@ func (c Cmd) importJSONL() error {
 			return fmt.Errorf("invalid JSON string: %s", string(jsonData))
 		}
 
-		if err := parquetWriter.WriteWithContext(context.Background(), string(jsonData)); err != nil {
+		if err := parquetWriter.WriteWithContext(ctx, string(jsonData)); err != nil {
 			return fmt.Errorf("failed to write to parquet file: %w", err)
 		}
 	}
-	if err := parquetWriter.WriteStopWithContext(context.Background()); err != nil {
+	if err := parquetWriter.WriteStopWithContext(ctx); err != nil {
 		return fmt.Errorf("failed to close Parquet writer [%s]: %w", c.URI, err)
 	}
 	if err := c.closeWriter(parquetWriter.PFile); err != nil {

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -83,7 +83,7 @@ func (c Cmd) importCSV() error {
 	}()
 	csvReader := csv.NewReader(csvFile)
 
-	parquetWriter, err := pio.NewCSVWriter(c.URI, c.WriteOption, schema)
+	parquetWriter, err := pio.NewCSVWriter(context.Background(), c.URI, c.WriteOption, schema)
 	if err != nil {
 		return fmt.Errorf("failed to create CSV writer: %w", err)
 	}
@@ -139,7 +139,7 @@ func (c Cmd) importJSON() error {
 		return fmt.Errorf("content of [%s] is not a valid JSON array: %w", c.Source, err)
 	}
 
-	parquetWriter, err := pio.NewJSONWriter(c.URI, c.WriteOption, string(schemaData))
+	parquetWriter, err := pio.NewJSONWriter(context.Background(), c.URI, c.WriteOption, string(schemaData))
 	if err != nil {
 		return fmt.Errorf("failed to create JSON writer: %w", err)
 	}
@@ -181,7 +181,7 @@ func (c Cmd) importJSONL() error {
 	scanner := bufio.NewScanner(jsonlFile)
 	scanner.Split(bufio.ScanLines)
 
-	parquetWriter, err := pio.NewJSONWriter(c.URI, c.WriteOption, string(schemaData))
+	parquetWriter, err := pio.NewJSONWriter(context.Background(), c.URI, c.WriteOption, string(schemaData))
 	if err != nil {
 		return fmt.Errorf("failed to create JSON writer: %w", err)
 	}

--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -1,6 +1,7 @@
 package importcmd
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -223,7 +224,7 @@ func TestCmd(t *testing.T) {
 				err := tc.cmd.Run()
 				require.NoError(t, err)
 
-				reader, err := pio.NewParquetFileReader(tc.cmd.URI, pio.ReadOption{})
+				reader, err := pio.NewParquetFileReader(context.Background(), tc.cmd.URI, pio.ReadOption{})
 				require.NoError(t, err)
 				require.Equal(t, tc.rowCount, reader.GetNumRows())
 			})

--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -174,7 +174,7 @@ func TestCmd(t *testing.T) {
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
-				err := tc.cmd.Run()
+				err := tc.cmd.Run(context.Background())
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
 			})
@@ -221,7 +221,7 @@ func TestCmd(t *testing.T) {
 				tc.cmd.Schema = filepath.Join("../../testdata", tc.cmd.Schema)
 				tc.cmd.URI = filepath.Join(tempDir, "import-"+name+".parquet")
 
-				err := tc.cmd.Run()
+				err := tc.cmd.Run(context.Background())
 				require.NoError(t, err)
 
 				reader, err := pio.NewParquetFileReader(context.Background(), tc.cmd.URI, pio.ReadOption{})
@@ -249,7 +249,7 @@ func TestCmdEncryption(t *testing.T) {
 		Schema: schema,
 		URI:    plainURI,
 	}
-	require.NoError(t, plainCmd.Run())
+	require.NoError(t, plainCmd.Run(context.Background()))
 	wantOutput := testutils.CommandStdout(t, importTestCatCmd(plainURI, pio.ReadOption{}))
 
 	testCases := []struct {
@@ -377,7 +377,7 @@ func TestCmdEncryption(t *testing.T) {
 				Schema:      schema,
 				URI:         uri,
 			}
-			require.NoError(t, cmd.Run())
+			require.NoError(t, cmd.Run(context.Background()))
 			require.Equal(t, tc.footerMagic, testutils.ParquetFooterMagic(t, uri))
 			require.Equal(t, wantOutput, testutils.CommandStdout(t, importTestCatCmd(uri, tc.readOption)))
 		})
@@ -458,7 +458,7 @@ func TestCmdEncryptionErrors(t *testing.T) {
 				Schema:      filepath.Join("..", "..", "testdata", "csv.schema"),
 				URI:         filepath.Join(tempDir, tc.name+".parquet"),
 			}
-			err := cmd.Run()
+			err := cmd.Run(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.errMsg)
 		})
@@ -489,7 +489,7 @@ func TestCmdEncryptionEncryptAllColumns(t *testing.T) {
 			Schema:      schema,
 			URI:         uri,
 		}
-		require.NoError(t, cmd.Run())
+		require.NoError(t, cmd.Run(context.Background()))
 		return uri
 	}
 
@@ -497,7 +497,7 @@ func TestCmdEncryptionEncryptAllColumns(t *testing.T) {
 		t.Helper()
 		var err error
 		_, _ = testutils.CaptureStdoutStderr(func() {
-			err = importTestCatCmd(uri, pio.ReadOption{}).Run()
+			err = importTestCatCmd(uri, pio.ReadOption{}).Run(context.Background())
 		})
 		return err
 	}

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -45,7 +45,7 @@ type Cmd struct {
 }
 
 // Run does actual inspect job
-func (c Cmd) Run() error {
+func (c Cmd) Run(ctx context.Context) error {
 	// Validate parameter combinations
 	if c.Page != nil && (c.RowGroup == nil || c.ColumnChunk == nil) {
 		return fmt.Errorf("--page requires both --row-group and --column-chunk")
@@ -54,7 +54,7 @@ func (c Cmd) Run() error {
 		return fmt.Errorf("--column-chunk requires --row-group")
 	}
 
-	reader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
+	reader, err := pio.NewParquetFileReader(ctx, c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (c Cmd) Run() error {
 		_ = reader.PFile.Close()
 	}()
 
-	schemaRoot, err := pschema.NewSchemaTree(context.Background(), reader, pschema.SchemaOption{FailOnInt96: false})
+	schemaRoot, err := pschema.NewSchemaTree(ctx, reader, pschema.SchemaOption{FailOnInt96: false})
 	if err != nil {
 		return err
 	}
@@ -76,10 +76,10 @@ func (c Cmd) Run() error {
 	switch {
 	case c.Page != nil:
 		// Level 4: Show page details and values
-		return c.inspectPage(reader, *c.RowGroup, *c.ColumnChunk, *c.Page, pathMap)
+		return c.inspectPage(ctx, reader, *c.RowGroup, *c.ColumnChunk, *c.Page, pathMap)
 	case c.ColumnChunk != nil:
 		// Level 3: Show column chunk details and pages
-		return c.inspectColumnChunk(reader, *c.RowGroup, *c.ColumnChunk, inExNameMap, pathMap, bloomSizeMap)
+		return c.inspectColumnChunk(ctx, reader, *c.RowGroup, *c.ColumnChunk, inExNameMap, pathMap, bloomSizeMap)
 	case c.RowGroup != nil:
 		// Level 2: Show row group details and column chunks
 		return c.inspectRowGroup(reader, *c.RowGroup, inExNameMap, pathMap, bloomSizeMap)

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 
@@ -53,7 +54,7 @@ func (c Cmd) Run() error {
 		return fmt.Errorf("--column-chunk requires --row-group")
 	}
 
-	reader, err := pio.NewParquetFileReader(c.URI, c.ReadOption)
+	reader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}
@@ -61,7 +62,7 @@ func (c Cmd) Run() error {
 		_ = reader.PFile.Close()
 	}()
 
-	schemaRoot, err := pschema.NewSchemaTree(reader, pschema.SchemaOption{FailOnInt96: false})
+	schemaRoot, err := pschema.NewSchemaTree(context.Background(), reader, pschema.SchemaOption{FailOnInt96: false})
 	if err != nil {
 		return err
 	}

--- a/cmd/inspect/inspect_test.go
+++ b/cmd/inspect/inspect_test.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -653,14 +654,14 @@ func TestReadPageValuesEdgeCases(t *testing.T) {
 	})
 
 	t.Run("nil-num-values-error", func(t *testing.T) {
-		fileReader, err := pio.NewParquetFileReader("../../testdata/good.parquet", pio.ReadOption{})
+		fileReader, err := pio.NewParquetFileReader(context.Background(), "../../testdata/good.parquet", pio.ReadOption{})
 		require.NoError(t, err)
 		defer func() { _ = fileReader.PFile.Close() }()
 
 		col := fileReader.Footer.RowGroups[0].Columns[0]
 		pathKey := strings.Join(col.MetaData.PathInSchema, common.ParGoPathDelimiter)
 
-		schemaRoot, err := pschema.NewSchemaTree(fileReader, pschema.SchemaOption{})
+		schemaRoot, err := pschema.NewSchemaTree(context.Background(), fileReader, pschema.SchemaOption{})
 		require.NoError(t, err)
 		schemaNode := schemaRoot.GetPathMap()[pathKey]
 
@@ -678,11 +679,11 @@ func TestReadPagesError(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(tmpFile, data, 0o644))
 
-	pr, err := pio.NewParquetFileReader(tmpFile, pio.ReadOption{})
+	pr, err := pio.NewParquetFileReader(context.Background(), tmpFile, pio.ReadOption{})
 	require.NoError(t, err)
 	defer func() { _ = pr.PFile.Close() }()
 
-	schemaRoot, err := pschema.NewSchemaTree(pr, pschema.SchemaOption{SkipPageEncoding: true})
+	schemaRoot, err := pschema.NewSchemaTree(context.Background(), pr, pschema.SchemaOption{SkipPageEncoding: true})
 	require.NoError(t, err)
 
 	pathKey := strings.Join(pr.Footer.RowGroups[0].Columns[0].MetaData.PathInSchema, common.ParGoPathDelimiter)
@@ -711,14 +712,14 @@ func TestReadDictionaryPageValuesError(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(tmpFile, data, 0o644))
 
-	pr, err := pio.NewParquetFileReader(tmpFile, pio.ReadOption{})
+	pr, err := pio.NewParquetFileReader(context.Background(), tmpFile, pio.ReadOption{})
 	require.NoError(t, err)
 	defer func() { _ = pr.PFile.Close() }()
 
 	col := pr.Footer.RowGroups[0].Columns[0]
 	pathKey := strings.Join(col.MetaData.PathInSchema, common.ParGoPathDelimiter)
 
-	schemaRoot, err := pschema.NewSchemaTree(pr, pschema.SchemaOption{SkipPageEncoding: true})
+	schemaRoot, err := pschema.NewSchemaTree(context.Background(), pr, pschema.SchemaOption{SkipPageEncoding: true})
 	require.NoError(t, err)
 	schemaNode := schemaRoot.GetPathMap()[pathKey]
 

--- a/cmd/inspect/inspect_test.go
+++ b/cmd/inspect/inspect_test.go
@@ -253,13 +253,13 @@ func TestInspect(t *testing.T) {
 			}
 			tc.cmd.URI = "../../testdata/" + tc.cmd.URI
 			if tc.errMsg != "" {
-				err := tc.cmd.Run()
+				err := tc.cmd.Run(context.Background())
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
 			} else {
 				tc.golden = "../../testdata/golden/" + tc.golden
 				stdout, stderr := testutils.CaptureStdoutStderr(func() {
-					require.NoError(t, tc.cmd.Run())
+					require.NoError(t, tc.cmd.Run(context.Background()))
 				})
 				require.Equal(t, testutils.LoadExpected(t, tc.golden), stdout)
 				require.Equal(t, "", stderr)
@@ -300,7 +300,7 @@ func TestInspectEncrypted(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			stdout, stderr := testutils.CaptureStdoutStderr(func() {
-				require.NoError(t, cmd.Run())
+				require.NoError(t, cmd.Run(context.Background()))
 			})
 			require.Contains(t, stdout, `"totalRows":50`)
 			require.Equal(t, "", stderr)
@@ -639,7 +639,7 @@ func TestReadPageValuesEdgeCases(t *testing.T) {
 		col := &parquet.ColumnChunk{MetaData: &parquet.ColumnMetaData{}}
 		pages := []PageInfo{{Type: parquet.PageType_INDEX_PAGE}}
 
-		values, err := cmd.readPageValues(nil, 0, 0, col, nil, pages, 0)
+		values, err := cmd.readPageValues(context.Background(), nil, 0, 0, col, nil, pages, 0)
 		require.NoError(t, err)
 		require.Equal(t, []any{}, values)
 	})
@@ -648,7 +648,7 @@ func TestReadPageValuesEdgeCases(t *testing.T) {
 		col := &parquet.ColumnChunk{MetaData: &parquet.ColumnMetaData{}}
 		pages := []PageInfo{{Type: parquet.PageType_DATA_PAGE}}
 
-		_, err := cmd.readPageValues(nil, 0, 0, col, nil, pages, 5)
+		_, err := cmd.readPageValues(context.Background(), nil, 0, 0, col, nil, pages, 5)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "page index 5 out of range")
 	})
@@ -667,7 +667,7 @@ func TestReadPageValuesEdgeCases(t *testing.T) {
 
 		pages := []PageInfo{{Type: parquet.PageType_DATA_PAGE, NumValues: nil}}
 
-		_, err = cmd.readPageValues(fileReader, 0, 0, col, schemaNode, pages, 0)
+		_, err = cmd.readPageValues(context.Background(), fileReader, 0, 0, col, schemaNode, pages, 0)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unable to get numValues for page")
 	})
@@ -692,7 +692,7 @@ func TestReadPagesError(t *testing.T) {
 	// Nullify column metadata so readAllPageHeaders returns an error
 	pr.Footer.RowGroups[0].Columns[0].MetaData = nil
 
-	_, err = Cmd{}.readPages(pr, 0, 0, schemaNode)
+	_, err = Cmd{}.readPages(context.Background(), pr, 0, 0, schemaNode)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to read page headers")
 }
@@ -701,7 +701,7 @@ func TestRunCorruptFile(t *testing.T) {
 	tmpFile := t.TempDir() + "/corrupt.parquet"
 	require.NoError(t, os.WriteFile(tmpFile, []byte("not a parquet file"), 0o644))
 
-	err := Cmd{ReadOption: pio.ReadOption{}, URI: tmpFile}.Run()
+	err := Cmd{ReadOption: pio.ReadOption{}, URI: tmpFile}.Run(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "read footer")
 }
@@ -724,7 +724,7 @@ func TestReadDictionaryPageValuesError(t *testing.T) {
 	schemaNode := schemaRoot.GetPathMap()[pathKey]
 
 	// Get the dictionary page info before corrupting the file
-	pages, err := Cmd{}.readPages(pr, 0, 0, schemaNode)
+	pages, err := Cmd{}.readPages(context.Background(), pr, 0, 0, schemaNode)
 	require.NoError(t, err)
 	require.NotEmpty(t, pages)
 	require.Equal(t, parquet.PageType_DICTIONARY_PAGE, pages[0].Type)
@@ -733,7 +733,7 @@ func TestReadDictionaryPageValuesError(t *testing.T) {
 	require.NoError(t, os.Truncate(tmpFile, 4))
 
 	cmd := Cmd{}
-	_, err = cmd.readDictionaryPageValues(pr, col, schemaNode, pages[0])
+	_, err = cmd.readDictionaryPageValues(context.Background(), pr, col, schemaNode, pages[0])
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to read dictionary page values")
 }

--- a/cmd/inspect/levels.go
+++ b/cmd/inspect/levels.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -78,7 +79,7 @@ func (c Cmd) buildColumnChunkBrief(index int, col *parquet.ColumnChunk, inExName
 }
 
 // Level 3: Column chunk details and pages with brief info
-func (c Cmd) inspectColumnChunk(reader *reader.ParquetReader, rowGroupIndex, columnChunkIndex int, inExNameMap map[string][]string, pathMap map[string]*pschema.SchemaNode, bloomSizeMap map[string]int32) error {
+func (c Cmd) inspectColumnChunk(ctx context.Context, reader *reader.ParquetReader, rowGroupIndex, columnChunkIndex int, inExNameMap map[string][]string, pathMap map[string]*pschema.SchemaNode, bloomSizeMap map[string]int32) error {
 	footer := reader.Footer
 
 	if rowGroupIndex < 0 || rowGroupIndex >= len(footer.RowGroups) {
@@ -137,7 +138,7 @@ func (c Cmd) inspectColumnChunk(reader *reader.ParquetReader, rowGroupIndex, col
 	}
 
 	// Read pages - this requires reading the actual data from the file
-	pages, err := c.readPages(reader, rowGroupIndex, columnChunkIndex, schemaNode)
+	pages, err := c.readPages(ctx, reader, rowGroupIndex, columnChunkIndex, schemaNode)
 	if err != nil {
 		return fmt.Errorf("failed to read pages: %w", err)
 	}
@@ -151,7 +152,7 @@ func (c Cmd) inspectColumnChunk(reader *reader.ParquetReader, rowGroupIndex, col
 }
 
 // Level 4: Page details and values
-func (c Cmd) inspectPage(reader *reader.ParquetReader, rowGroupIndex, columnChunkIndex, pageIndex int, pathMap map[string]*pschema.SchemaNode) error {
+func (c Cmd) inspectPage(ctx context.Context, reader *reader.ParquetReader, rowGroupIndex, columnChunkIndex, pageIndex int, pathMap map[string]*pschema.SchemaNode) error {
 	footer := reader.Footer
 
 	if rowGroupIndex < 0 || rowGroupIndex >= len(footer.RowGroups) {
@@ -167,7 +168,7 @@ func (c Cmd) inspectPage(reader *reader.ParquetReader, rowGroupIndex, columnChun
 	schemaNode := pathMap[pathKey]
 
 	// Read pages
-	pages, err := c.readPages(reader, rowGroupIndex, columnChunkIndex, schemaNode)
+	pages, err := c.readPages(ctx, reader, rowGroupIndex, columnChunkIndex, schemaNode)
 	if err != nil {
 		return fmt.Errorf("failed to read pages: %w", err)
 	}
@@ -178,7 +179,7 @@ func (c Cmd) inspectPage(reader *reader.ParquetReader, rowGroupIndex, columnChun
 	page := pages[pageIndex]
 
 	// Read page values
-	values, err := c.readPageValues(reader, rowGroupIndex, columnChunkIndex, col, schemaNode, pages, pageIndex)
+	values, err := c.readPageValues(ctx, reader, rowGroupIndex, columnChunkIndex, col, schemaNode, pages, pageIndex)
 	if err != nil {
 		return fmt.Errorf("failed to read page values: %w", err)
 	}

--- a/cmd/inspect/pages.go
+++ b/cmd/inspect/pages.go
@@ -10,8 +10,8 @@ import (
 	pschema "github.com/hangxie/parquet-tools/schema"
 )
 
-func (c Cmd) readPages(pr *reader.ParquetReader, rowGroupIndex, columnChunkIndex int, schemaNode *pschema.SchemaNode) ([]PageInfo, error) {
-	pageHeaders, err := pr.GetAllPageHeadersWithContext(context.Background(), rowGroupIndex, columnChunkIndex)
+func (c Cmd) readPages(ctx context.Context, pr *reader.ParquetReader, rowGroupIndex, columnChunkIndex int, schemaNode *pschema.SchemaNode) ([]PageInfo, error) {
+	pageHeaders, err := pr.GetAllPageHeadersWithContext(ctx, rowGroupIndex, columnChunkIndex)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read page headers: %w", err)
 	}
@@ -76,7 +76,7 @@ func (c Cmd) convertPageHeaderInfo(headerInfo reader.PageHeaderInfo, schemaNode 
 	return pageInfo
 }
 
-func (c Cmd) readPageValues(pr *reader.ParquetReader, rowGroupIndex, columnChunkIndex int, col *parquet.ColumnChunk, schemaNode *pschema.SchemaNode, pages []PageInfo, pageIndex int) ([]any, error) {
+func (c Cmd) readPageValues(ctx context.Context, pr *reader.ParquetReader, rowGroupIndex, columnChunkIndex int, col *parquet.ColumnChunk, schemaNode *pschema.SchemaNode, pages []PageInfo, pageIndex int) ([]any, error) {
 	meta := col.MetaData
 
 	if pageIndex < 0 || pageIndex >= len(pages) {
@@ -88,7 +88,7 @@ func (c Cmd) readPageValues(pr *reader.ParquetReader, rowGroupIndex, columnChunk
 	// Handle different page types
 	switch pageInfo.Type {
 	case parquet.PageType_DICTIONARY_PAGE:
-		return c.readDictionaryPageValues(pr, col, schemaNode, pageInfo)
+		return c.readDictionaryPageValues(ctx, pr, col, schemaNode, pageInfo)
 	case parquet.PageType_DATA_PAGE, parquet.PageType_DATA_PAGE_V2:
 		// Continue to process data pages below
 	default:
@@ -103,11 +103,11 @@ func (c Cmd) readPageValues(pr *reader.ParquetReader, rowGroupIndex, columnChunk
 	}
 
 	// Create a fresh column reader to read the entire column
-	freshReader, err := reader.NewParquetColumnReaderWithContext(context.Background(), pr.PFile, reader.WithNP(4))
+	freshReader, err := reader.NewParquetColumnReaderWithContext(ctx, pr.PFile, reader.WithNP(4))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create fresh reader: %w", err)
 	}
-	defer func() { _ = freshReader.ReadStopWithContext(context.Background()) }()
+	defer func() { _ = freshReader.ReadStopWithContext(context.WithoutCancel(ctx)) }()
 
 	// Calculate total number of rows in the file
 	totalRows := int64(0)
@@ -116,7 +116,7 @@ func (c Cmd) readPageValues(pr *reader.ParquetReader, rowGroupIndex, columnChunk
 	}
 
 	// Read ALL values from the entire file for this column
-	allValuesInFile, _, _, err := freshReader.ReadColumnByIndexWithContext(context.Background(), int64(columnChunkIndex), totalRows)
+	allValuesInFile, _, _, err := freshReader.ReadColumnByIndexWithContext(ctx, int64(columnChunkIndex), totalRows)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read column values: %w", err)
 	}
@@ -155,10 +155,10 @@ func (c Cmd) readPageValues(pr *reader.ParquetReader, rowGroupIndex, columnChunk
 	return c.convertValuesToJSON(pageValues, schemaNode), nil
 }
 
-func (c Cmd) readDictionaryPageValues(pr *reader.ParquetReader, col *parquet.ColumnChunk, schemaNode *pschema.SchemaNode, pageInfo PageInfo) ([]any, error) {
+func (c Cmd) readDictionaryPageValues(ctx context.Context, pr *reader.ParquetReader, col *parquet.ColumnChunk, schemaNode *pschema.SchemaNode, pageInfo PageInfo) ([]any, error) {
 	meta := col.MetaData
 
-	values, err := pr.ReadDictionaryPageValuesWithContext(context.Background(), pageInfo.Offset, meta.Codec, meta.Type)
+	values, err := pr.ReadDictionaryPageValuesWithContext(ctx, pageInfo.Offset, meta.Codec, meta.Type)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read dictionary page values: %w", err)
 	}

--- a/cmd/inspect/pages.go
+++ b/cmd/inspect/pages.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -10,7 +11,7 @@ import (
 )
 
 func (c Cmd) readPages(pr *reader.ParquetReader, rowGroupIndex, columnChunkIndex int, schemaNode *pschema.SchemaNode) ([]PageInfo, error) {
-	pageHeaders, err := pr.GetAllPageHeaders(rowGroupIndex, columnChunkIndex)
+	pageHeaders, err := pr.GetAllPageHeadersWithContext(context.Background(), rowGroupIndex, columnChunkIndex)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read page headers: %w", err)
 	}
@@ -102,11 +103,11 @@ func (c Cmd) readPageValues(pr *reader.ParquetReader, rowGroupIndex, columnChunk
 	}
 
 	// Create a fresh column reader to read the entire column
-	freshReader, err := reader.NewParquetColumnReader(pr.PFile, reader.WithNP(4))
+	freshReader, err := reader.NewParquetColumnReaderWithContext(context.Background(), pr.PFile, reader.WithNP(4))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create fresh reader: %w", err)
 	}
-	defer func() { _ = freshReader.ReadStop() }()
+	defer func() { _ = freshReader.ReadStopWithContext(context.Background()) }()
 
 	// Calculate total number of rows in the file
 	totalRows := int64(0)
@@ -115,7 +116,7 @@ func (c Cmd) readPageValues(pr *reader.ParquetReader, rowGroupIndex, columnChunk
 	}
 
 	// Read ALL values from the entire file for this column
-	allValuesInFile, _, _, err := freshReader.ReadColumnByIndex(int64(columnChunkIndex), totalRows)
+	allValuesInFile, _, _, err := freshReader.ReadColumnByIndexWithContext(context.Background(), int64(columnChunkIndex), totalRows)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read column values: %w", err)
 	}
@@ -157,7 +158,7 @@ func (c Cmd) readPageValues(pr *reader.ParquetReader, rowGroupIndex, columnChunk
 func (c Cmd) readDictionaryPageValues(pr *reader.ParquetReader, col *parquet.ColumnChunk, schemaNode *pschema.SchemaNode, pageInfo PageInfo) ([]any, error) {
 	meta := col.MetaData
 
-	values, err := pr.ReadDictionaryPageValues(pageInfo.Offset, meta.Codec, meta.Type)
+	values, err := pr.ReadDictionaryPageValuesWithContext(context.Background(), pageInfo.Offset, meta.Codec, meta.Type)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read dictionary page values: %w", err)
 	}

--- a/cmd/inspect/pages_test.go
+++ b/cmd/inspect/pages_test.go
@@ -1,15 +1,73 @@
 package inspect
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/parquet"
 	"github.com/hangxie/parquet-go/v3/reader"
+	"github.com/stretchr/testify/require"
+
+	pio "github.com/hangxie/parquet-tools/io"
+	pschema "github.com/hangxie/parquet-tools/schema"
 )
 
 func TestConvertIndexPageHeader(t *testing.T) {
 	page := (Cmd{}).convertPageHeaderInfo(reader.PageHeaderInfo{PageType: parquet.PageType_INDEX_PAGE}, nil)
 	if page.Note != "Index page (column index)" {
 		t.Fatalf("convertPageHeaderInfo() note = %q", page.Note)
+	}
+}
+
+func TestPageReadsHonorCanceledContext(t *testing.T) {
+	pr, err := pio.NewParquetFileReader(context.Background(), "../../testdata/dict-page.parquet", pio.ReadOption{})
+	require.NoError(t, err)
+	defer func() { _ = pr.PFile.Close() }()
+
+	col := pr.Footer.RowGroups[0].Columns[0]
+	pathKey := strings.Join(col.MetaData.PathInSchema, common.ParGoPathDelimiter)
+	schemaRoot, err := pschema.NewSchemaTree(context.Background(), pr, pschema.SchemaOption{SkipPageEncoding: true})
+	require.NoError(t, err)
+	schemaNode := schemaRoot.GetPathMap()[pathKey]
+
+	pages, err := (Cmd{}).readPages(context.Background(), pr, 0, 0, schemaNode)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(pages), 2)
+	require.Equal(t, parquet.PageType_DICTIONARY_PAGE, pages[0].Type)
+
+	dataPageIndex := -1
+	for i, page := range pages {
+		if page.Type == parquet.PageType_DATA_PAGE || page.Type == parquet.PageType_DATA_PAGE_V2 {
+			dataPageIndex = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, dataPageIndex)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := map[string]func() error{
+		"page headers": func() error {
+			_, err := (Cmd{}).readPages(ctx, pr, 0, 0, schemaNode)
+			return err
+		},
+		"dictionary values": func() error {
+			_, err := (Cmd{}).readDictionaryPageValues(ctx, pr, col, schemaNode, pages[0])
+			return err
+		},
+		"column values": func() error {
+			_, err := (Cmd{}).readPageValues(ctx, pr, 0, 0, col, schemaNode, pages, dataPageIndex)
+			return err
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test()
+			require.ErrorIs(t, err, context.Canceled)
+		})
 	}
 }

--- a/cmd/internal/testutils/utils.go
+++ b/cmd/internal/testutils/utils.go
@@ -17,7 +17,7 @@ import (
 var stdCaptureMutex sync.Mutex
 
 type runnableCommand interface {
-	Run() error
+	Run(context.Context) error
 }
 
 // HasSameSchema compares the logical schema of two parquet files using structural
@@ -80,7 +80,7 @@ func CommandStdout(t *testing.T, cmd runnableCommand) string {
 	t.Helper()
 
 	stdout, _ := CaptureStdoutStderr(func() {
-		if err := cmd.Run(); err != nil {
+		if err := cmd.Run(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/cmd/internal/testutils/utils.go
+++ b/cmd/internal/testutils/utils.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -29,12 +30,12 @@ func HasSameSchema(file1, file2 string, opts ...pschema.CompareOption) bool {
 		option = opts[0]
 	}
 	buildTree := func(file string) *pschema.SchemaNode {
-		pr, err := pio.NewParquetFileReader(file, pio.ReadOption{})
+		pr, err := pio.NewParquetFileReader(context.Background(), file, pio.ReadOption{})
 		if err != nil {
 			return nil
 		}
 		defer func() { _ = pr.PFile.Close() }()
-		tree, err := pschema.NewSchemaTree(pr, pschema.SchemaOption{})
+		tree, err := pschema.NewSchemaTree(context.Background(), pr, pschema.SchemaOption{})
 		if err != nil {
 			return nil
 		}

--- a/cmd/internal/testutils/utils_test.go
+++ b/cmd/internal/testutils/utils_test.go
@@ -1,0 +1,28 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+type contextCommand struct {
+	ctx context.Context
+}
+
+func (c *contextCommand) Run(ctx context.Context) error {
+	c.ctx = ctx
+	fmt.Print("output")
+	return nil
+}
+
+func TestCommandStdoutPassesContext(t *testing.T) {
+	cmd := new(contextCommand)
+
+	if got := CommandStdout(t, cmd); got != "output" {
+		t.Fatalf("CommandStdout() = %q, want %q", got, "output")
+	}
+	if cmd.ctx == nil {
+		t.Fatal("CommandStdout() passed a nil context")
+	}
+}

--- a/cmd/merge/merge.go
+++ b/cmd/merge/merge.go
@@ -25,7 +25,7 @@ type Cmd struct {
 }
 
 // Run does actual merge job
-func (c Cmd) Run() (retErr error) {
+func (c Cmd) Run(ctx context.Context) (retErr error) {
 	if err := pio.ValidateFieldDelimiter(c.FieldDelimiter); err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func (c Cmd) Run() (retErr error) {
 		return fmt.Errorf("needs at least 2 source files")
 	}
 
-	fileReaders, schemaJSON, err := c.openSources()
+	fileReaders, schemaJSON, err := c.openSources(ctx)
 	if err != nil {
 		return err
 	}
@@ -48,12 +48,12 @@ func (c Cmd) Run() (retErr error) {
 
 	c.ReadOption.FieldDelimiter = c.FieldDelimiter
 	c.WriteOption.FieldDelimiter = c.FieldDelimiter
-	fileWriter, err := pio.NewGenericWriter(context.Background(), c.URI, c.WriteOption, schemaJSON)
+	fileWriter, err := pio.NewGenericWriter(ctx, c.URI, c.WriteOption, schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)
 	}
 	defer func() {
-		if err := fileWriter.WriteStopWithContext(context.Background()); err != nil && retErr == nil {
+		if err := fileWriter.WriteStopWithContext(ctx); err != nil && retErr == nil {
 			retErr = fmt.Errorf("failed to end write [%s]: %w", c.URI, err)
 		}
 		if err := fileWriter.PFile.Close(); err != nil && retErr == nil {
@@ -64,7 +64,7 @@ func (c Cmd) Run() (retErr error) {
 	// Single errgroup so all goroutines share one derived context —
 	// if either writer or any reader fails, gctx is cancelled and the other
 	// side's select on ctx.Done() fires, preventing deadlock.
-	g, gctx := errgroup.WithContext(context.Background())
+	g, gctx := errgroup.WithContext(ctx)
 	writerChan := make(chan any)
 
 	g.Go(func() error {
@@ -90,18 +90,18 @@ func (c Cmd) Run() (retErr error) {
 	return g.Wait()
 }
 
-func (c Cmd) openSources() ([]*reader.ParquetReader, string, error) {
+func (c Cmd) openSources(ctx context.Context) ([]*reader.ParquetReader, string, error) {
 	var schemaJSON string
 	var rootSchema *pschema.SchemaNode
 	var err error
 	fileReaders := make([]*reader.ParquetReader, len(c.Source))
 	for i, source := range c.Source {
-		fileReaders[i], err = pio.NewParquetFileReader(context.Background(), source, c.ReadOption)
+		fileReaders[i], err = pio.NewParquetFileReader(ctx, source, c.ReadOption)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to read from [%s]: %w", source, err)
 		}
 
-		currSchema, err := pschema.NewSchemaTree(context.Background(), fileReaders[i], pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
+		currSchema, err := pschema.NewSchemaTree(ctx, fileReaders[i], pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
 		if err != nil {
 			return nil, "", err
 		}
@@ -109,7 +109,7 @@ func (c Cmd) openSources() ([]*reader.ParquetReader, string, error) {
 		if rootSchema == nil {
 			rootSchema = currSchema
 			// Build a separate tree for JSON since JSONSchema() mutates the tree
-			jsonTree, jsonErr := pschema.NewSchemaTree(context.Background(), fileReaders[i], pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
+			jsonTree, jsonErr := pschema.NewSchemaTree(ctx, fileReaders[i], pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
 			if jsonErr != nil {
 				return nil, "", jsonErr
 			}

--- a/cmd/merge/merge.go
+++ b/cmd/merge/merge.go
@@ -48,7 +48,7 @@ func (c Cmd) Run() (retErr error) {
 
 	c.ReadOption.FieldDelimiter = c.FieldDelimiter
 	c.WriteOption.FieldDelimiter = c.FieldDelimiter
-	fileWriter, err := pio.NewGenericWriter(c.URI, c.WriteOption, schemaJSON)
+	fileWriter, err := pio.NewGenericWriter(context.Background(), c.URI, c.WriteOption, schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)
 	}
@@ -96,12 +96,12 @@ func (c Cmd) openSources() ([]*reader.ParquetReader, string, error) {
 	var err error
 	fileReaders := make([]*reader.ParquetReader, len(c.Source))
 	for i, source := range c.Source {
-		fileReaders[i], err = pio.NewParquetFileReader(source, c.ReadOption)
+		fileReaders[i], err = pio.NewParquetFileReader(context.Background(), source, c.ReadOption)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to read from [%s]: %w", source, err)
 		}
 
-		currSchema, err := pschema.NewSchemaTree(fileReaders[i], pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
+		currSchema, err := pschema.NewSchemaTree(context.Background(), fileReaders[i], pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
 		if err != nil {
 			return nil, "", err
 		}
@@ -109,7 +109,7 @@ func (c Cmd) openSources() ([]*reader.ParquetReader, string, error) {
 		if rootSchema == nil {
 			rootSchema = currSchema
 			// Build a separate tree for JSON since JSONSchema() mutates the tree
-			jsonTree, jsonErr := pschema.NewSchemaTree(fileReaders[i], pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
+			jsonTree, jsonErr := pschema.NewSchemaTree(context.Background(), fileReaders[i], pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
 			if jsonErr != nil {
 				return nil, "", jsonErr
 			}

--- a/cmd/merge/merge.go
+++ b/cmd/merge/merge.go
@@ -53,7 +53,7 @@ func (c Cmd) Run() (retErr error) {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)
 	}
 	defer func() {
-		if err := fileWriter.WriteStop(); err != nil && retErr == nil {
+		if err := fileWriter.WriteStopWithContext(context.Background()); err != nil && retErr == nil {
 			retErr = fmt.Errorf("failed to end write [%s]: %w", c.URI, err)
 		}
 		if err := fileWriter.PFile.Close(); err != nil && retErr == nil {

--- a/cmd/merge/merge_test.go
+++ b/cmd/merge/merge_test.go
@@ -103,7 +103,7 @@ func TestCmd(t *testing.T) {
 				err := tc.cmd.Run()
 				require.NoError(t, err)
 
-				reader, _ := pio.NewParquetFileReader(tc.cmd.URI, rOpt)
+				reader, _ := pio.NewParquetFileReader(context.Background(), tc.cmd.URI, rOpt)
 				rowCount := reader.GetNumRows()
 				_ = reader.PFile.Close()
 				require.Equal(t, tc.rowCount, rowCount)
@@ -122,7 +122,7 @@ func TestCmd(t *testing.T) {
 		cmd.URI = filepath.Join(tempDir, "1.parquet")
 		require.Nil(t, cmd.Run())
 
-		reader, _ := pio.NewParquetFileReader(cmd.URI, rOpt)
+		reader, _ := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 		rowCount := reader.GetNumRows()
 		_ = reader.PFile.Close()
 		require.Equal(t, int64(10), rowCount)
@@ -132,7 +132,7 @@ func TestCmd(t *testing.T) {
 		cmd.URI = filepath.Join(tempDir, "2.parquet")
 		require.Nil(t, cmd.Run())
 
-		reader, _ = pio.NewParquetFileReader(cmd.URI, rOpt)
+		reader, _ = pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 		rowCount = reader.GetNumRows()
 		_ = reader.PFile.Close()
 		require.Equal(t, int64(15), rowCount)
@@ -142,7 +142,7 @@ func TestCmd(t *testing.T) {
 		cmd.URI = filepath.Join(tempDir, "3.parquet")
 		require.Nil(t, cmd.Run())
 
-		reader, _ = pio.NewParquetFileReader(cmd.URI, rOpt)
+		reader, _ = pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 		rowCount = reader.GetNumRows()
 		_ = reader.PFile.Close()
 		require.Equal(t, int64(20), rowCount)
@@ -163,7 +163,7 @@ func TestCmd(t *testing.T) {
 		}
 		require.NoError(t, mergeCmd.Run())
 
-		reader, _ := pio.NewParquetFileReader(mergedFile, pio.ReadOption{})
+		reader, _ := pio.NewParquetFileReader(context.Background(), mergedFile, pio.ReadOption{})
 		rowCount := reader.GetNumRows()
 		_ = reader.PFile.Close()
 		require.Equal(t, int64(6), rowCount)
@@ -279,7 +279,7 @@ func TestCmdEncryption(t *testing.T) {
 			require.NoError(t, cmd.Run())
 			require.Equal(t, tc.footerMagic, testutils.ParquetFooterMagic(t, uri))
 
-			reader, err := pio.NewParquetFileReader(uri, tc.readOption)
+			reader, err := pio.NewParquetFileReader(context.Background(), uri, tc.readOption)
 			require.NoError(t, err)
 			require.Equal(t, int64(6), reader.GetNumRows())
 			_ = reader.PFile.Close()

--- a/cmd/merge/merge_test.go
+++ b/cmd/merge/merge_test.go
@@ -62,7 +62,7 @@ func TestCmd(t *testing.T) {
 
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
-				err := tc.cmd.Run()
+				err := tc.cmd.Run(context.Background())
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
 			})
@@ -100,7 +100,7 @@ func TestCmd(t *testing.T) {
 					tc.cmd.Source[i] = filepath.Join("..", "..", "testdata", tc.cmd.Source[i])
 				}
 				tc.cmd.URI = filepath.Join(tempDir, name+".parquet")
-				err := tc.cmd.Run()
+				err := tc.cmd.Run(context.Background())
 				require.NoError(t, err)
 
 				reader, _ := pio.NewParquetFileReader(context.Background(), tc.cmd.URI, rOpt)
@@ -120,7 +120,7 @@ func TestCmd(t *testing.T) {
 
 		cmd := Cmd{ReadOption: rOpt, Concurrent: true, FailOnInt96: false, ReadPageSize: 10, Source: []string{source, source}, URI: ""}
 		cmd.URI = filepath.Join(tempDir, "1.parquet")
-		require.Nil(t, cmd.Run())
+		require.Nil(t, cmd.Run(context.Background()))
 
 		reader, _ := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 		rowCount := reader.GetNumRows()
@@ -130,7 +130,7 @@ func TestCmd(t *testing.T) {
 
 		cmd.Source = []string{cmd.URI, source}
 		cmd.URI = filepath.Join(tempDir, "2.parquet")
-		require.Nil(t, cmd.Run())
+		require.Nil(t, cmd.Run(context.Background()))
 
 		reader, _ = pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 		rowCount = reader.GetNumRows()
@@ -140,7 +140,7 @@ func TestCmd(t *testing.T) {
 
 		cmd.Source = []string{cmd.URI, source}
 		cmd.URI = filepath.Join(tempDir, "3.parquet")
-		require.Nil(t, cmd.Run())
+		require.Nil(t, cmd.Run(context.Background()))
 
 		reader, _ = pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 		rowCount = reader.GetNumRows()
@@ -161,7 +161,7 @@ func TestCmd(t *testing.T) {
 			Source:       []string{sourceGZIP, sourceSnappy},
 			URI:          mergedFile,
 		}
-		require.NoError(t, mergeCmd.Run())
+		require.NoError(t, mergeCmd.Run(context.Background()))
 
 		reader, _ := pio.NewParquetFileReader(context.Background(), mergedFile, pio.ReadOption{})
 		rowCount := reader.GetNumRows()
@@ -181,7 +181,7 @@ func TestCmd(t *testing.T) {
 			URI:          resultFile,
 		}
 
-		err := mergeCmd.Run()
+		err := mergeCmd.Run(context.Background())
 		require.NoError(t, err)
 
 		require.True(t, testutils.HasSameSchema("../../testdata/optional-fields.parquet", resultFile))
@@ -195,7 +195,7 @@ func TestCmd(t *testing.T) {
 			URI:          resultFile,
 		}
 		stdout, _ := testutils.CaptureStdoutStderr(func() {
-			require.NoError(t, catCmd.Run())
+			require.NoError(t, catCmd.Run(context.Background()))
 		})
 		require.Equal(t, testutils.LoadExpected(t, "../../testdata/golden/merge-optional-fields-json.json"), stdout)
 	})
@@ -276,7 +276,7 @@ func TestCmdEncryption(t *testing.T) {
 				Source:       sources,
 				URI:          uri,
 			}
-			require.NoError(t, cmd.Run())
+			require.NoError(t, cmd.Run(context.Background()))
 			require.Equal(t, tc.footerMagic, testutils.ParquetFooterMagic(t, uri))
 
 			reader, err := pio.NewParquetFileReader(context.Background(), uri, tc.readOption)
@@ -355,7 +355,7 @@ func TestCmdEncryptionErrors(t *testing.T) {
 				Source:       sources,
 				URI:          filepath.Join(tempDir, tc.name+".parquet"),
 			}
-			err := cmd.Run()
+			err := cmd.Run(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.errMsg)
 		})
@@ -393,18 +393,18 @@ func BenchmarkMergeCmd(b *testing.B) {
 
 	// Warm up the Go runtime before actual benchmark
 	for range 10 {
-		_ = cmd.Run()
+		_ = cmd.Run(context.Background())
 	}
 
 	b.Run("default", func(b *testing.B) {
 		for b.Loop() {
-			require.NoError(b, cmd.Run())
+			require.NoError(b, cmd.Run(context.Background()))
 		}
 	})
 	cmd.Concurrent = true
 	b.Run("concurrent", func(b *testing.B) {
 		for b.Loop() {
-			require.NoError(b, cmd.Run())
+			require.NoError(b, cmd.Run(context.Background()))
 		}
 	})
 }

--- a/cmd/meta/meta.go
+++ b/cmd/meta/meta.go
@@ -57,9 +57,9 @@ type parquetMeta struct {
 }
 
 // Run does actual meta job
-func (c Cmd) Run() error {
+func (c Cmd) Run(ctx context.Context) error {
 	if c.ShowKeyMetadata {
-		hints, err := pio.ReadEncryptionKeyHints(context.Background(), c.URI, c.ReadOption)
+		hints, err := pio.ReadEncryptionKeyHints(ctx, c.URI, c.ReadOption)
 		if err != nil {
 			return err
 		}
@@ -74,12 +74,12 @@ func (c Cmd) Run() error {
 		return nil
 	}
 
-	reader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
+	reader, err := pio.NewParquetFileReader(ctx, c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}
 
-	schemaRoot, err := pschema.NewSchemaTree(context.Background(), reader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96, SkipPageEncoding: true})
+	schemaRoot, err := pschema.NewSchemaTree(ctx, reader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96, SkipPageEncoding: true})
 	if err != nil {
 		return err
 	}

--- a/cmd/meta/meta.go
+++ b/cmd/meta/meta.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -58,7 +59,7 @@ type parquetMeta struct {
 // Run does actual meta job
 func (c Cmd) Run() error {
 	if c.ShowKeyMetadata {
-		hints, err := pio.ReadEncryptionKeyHints(c.URI, c.ReadOption)
+		hints, err := pio.ReadEncryptionKeyHints(context.Background(), c.URI, c.ReadOption)
 		if err != nil {
 			return err
 		}
@@ -73,12 +74,12 @@ func (c Cmd) Run() error {
 		return nil
 	}
 
-	reader, err := pio.NewParquetFileReader(c.URI, c.ReadOption)
+	reader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}
 
-	schemaRoot, err := pschema.NewSchemaTree(reader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96, SkipPageEncoding: true})
+	schemaRoot, err := pschema.NewSchemaTree(context.Background(), reader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96, SkipPageEncoding: true})
 	if err != nil {
 		return err
 	}

--- a/cmd/meta/meta_test.go
+++ b/cmd/meta/meta_test.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -243,12 +244,12 @@ func TestCmd(t *testing.T) {
 				cmd.URI = "../../testdata/" + tc.cmd.URI
 			}
 			if tc.errMsg != "" {
-				err := cmd.Run()
+				err := cmd.Run(context.Background())
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
 			} else {
 				stdout, stderr := testutils.CaptureStdoutStderr(func() {
-					require.NoError(t, cmd.Run())
+					require.NoError(t, cmd.Run(context.Background()))
 				})
 				require.Equal(t, testutils.LoadExpected(t, "../../testdata/golden/"+tc.golden), stdout)
 				require.Equal(t, "", stderr)
@@ -276,12 +277,12 @@ func BenchmarkMetaCmd(b *testing.B) {
 
 	// Warm up the Go runtime before actual benchmark
 	for range 10 {
-		_ = cmd.Run()
+		_ = cmd.Run(context.Background())
 	}
 
 	b.Run("default", func(b *testing.B) {
 		for b.Loop() {
-			require.NoError(b, cmd.Run())
+			require.NoError(b, cmd.Run(context.Background()))
 		}
 	})
 }

--- a/cmd/retype/retype.go
+++ b/cmd/retype/retype.go
@@ -1,6 +1,7 @@
 package retype
 
 import (
+	"context"
 	"fmt"
 
 	pio "github.com/hangxie/parquet-tools/io"
@@ -70,7 +71,7 @@ func (c Cmd) Run() (retErr error) {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)
 	}
 	defer func() {
-		if err := fileWriter.WriteStop(); err != nil && retErr == nil {
+		if err := fileWriter.WriteStopWithContext(context.Background()); err != nil && retErr == nil {
 			retErr = fmt.Errorf("failed to end write [%s]: %w", c.URI, err)
 		}
 		if err := fileWriter.PFile.Close(); err != nil && retErr == nil {

--- a/cmd/retype/retype.go
+++ b/cmd/retype/retype.go
@@ -36,7 +36,7 @@ func (c Cmd) Run() (retErr error) {
 	}
 
 	// Open source file
-	fileReader, err := pio.NewParquetFileReader(c.Source, c.ReadOption)
+	fileReader, err := pio.NewParquetFileReader(context.Background(), c.Source, c.ReadOption)
 	if err != nil {
 		return fmt.Errorf("failed to read from [%s]: %w", c.Source, err)
 	}
@@ -45,7 +45,7 @@ func (c Cmd) Run() (retErr error) {
 	}()
 
 	// Get schema from source
-	schemaTree, err := pschema.NewSchemaTree(fileReader, pschema.SchemaOption{})
+	schemaTree, err := pschema.NewSchemaTree(context.Background(), fileReader, pschema.SchemaOption{})
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (c Cmd) Run() (retErr error) {
 	// Create output file with new settings
 	c.ReadOption.FieldDelimiter = c.FieldDelimiter
 	c.WriteOption.FieldDelimiter = c.FieldDelimiter
-	fileWriter, err := pio.NewGenericWriter(c.URI, c.WriteOption, schemaJSON)
+	fileWriter, err := pio.NewGenericWriter(context.Background(), c.URI, c.WriteOption, schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)
 	}
@@ -79,5 +79,5 @@ func (c Cmd) Run() (retErr error) {
 		}
 	}()
 
-	return pio.RunPipeline(fileReader, fileWriter, c.Source, c.URI, c.ReadPageSize, converter.Convert)
+	return pio.RunPipeline(context.Background(), fileReader, fileWriter, c.Source, c.URI, c.ReadPageSize, converter.Convert)
 }

--- a/cmd/retype/retype.go
+++ b/cmd/retype/retype.go
@@ -27,7 +27,7 @@ type Cmd struct {
 }
 
 // Run does actual retype job
-func (c Cmd) Run() (retErr error) {
+func (c Cmd) Run(ctx context.Context) (retErr error) {
 	if err := pio.ValidateFieldDelimiter(c.FieldDelimiter); err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func (c Cmd) Run() (retErr error) {
 	}
 
 	// Open source file
-	fileReader, err := pio.NewParquetFileReader(context.Background(), c.Source, c.ReadOption)
+	fileReader, err := pio.NewParquetFileReader(ctx, c.Source, c.ReadOption)
 	if err != nil {
 		return fmt.Errorf("failed to read from [%s]: %w", c.Source, err)
 	}
@@ -45,7 +45,7 @@ func (c Cmd) Run() (retErr error) {
 	}()
 
 	// Get schema from source
-	schemaTree, err := pschema.NewSchemaTree(context.Background(), fileReader, pschema.SchemaOption{})
+	schemaTree, err := pschema.NewSchemaTree(ctx, fileReader, pschema.SchemaOption{})
 	if err != nil {
 		return err
 	}
@@ -66,12 +66,12 @@ func (c Cmd) Run() (retErr error) {
 	// Create output file with new settings
 	c.ReadOption.FieldDelimiter = c.FieldDelimiter
 	c.WriteOption.FieldDelimiter = c.FieldDelimiter
-	fileWriter, err := pio.NewGenericWriter(context.Background(), c.URI, c.WriteOption, schemaJSON)
+	fileWriter, err := pio.NewGenericWriter(ctx, c.URI, c.WriteOption, schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)
 	}
 	defer func() {
-		if err := fileWriter.WriteStopWithContext(context.Background()); err != nil && retErr == nil {
+		if err := fileWriter.WriteStopWithContext(ctx); err != nil && retErr == nil {
 			retErr = fmt.Errorf("failed to end write [%s]: %w", c.URI, err)
 		}
 		if err := fileWriter.PFile.Close(); err != nil && retErr == nil {
@@ -79,5 +79,5 @@ func (c Cmd) Run() (retErr error) {
 		}
 	}()
 
-	return pio.RunPipeline(context.Background(), fileReader, fileWriter, c.Source, c.URI, c.ReadPageSize, converter.Convert)
+	return pio.RunPipeline(ctx, fileReader, fileWriter, c.Source, c.URI, c.ReadPageSize, converter.Convert)
 }

--- a/cmd/retype/retype_test.go
+++ b/cmd/retype/retype_test.go
@@ -54,7 +54,7 @@ func TestCmd(t *testing.T) {
 
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
-				err := tc.cmd.Run()
+				err := tc.cmd.Run(context.Background())
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
 			})
@@ -173,7 +173,7 @@ func TestCmd(t *testing.T) {
 
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
-				err := tc.cmd.Run()
+				err := tc.cmd.Run(context.Background())
 				require.NoError(t, err)
 
 				stdout, stderr := testutils.CaptureStdoutStderr(func() {
@@ -184,7 +184,7 @@ func TestCmd(t *testing.T) {
 						Format:       "json",
 						URI:          resultFile,
 					}
-					require.NoError(t, cmd.Run())
+					require.NoError(t, cmd.Run(context.Background()))
 				})
 				require.Equal(t, testutils.LoadExpected(t, tc.goldenData), stdout)
 				require.Equal(t, "", stderr)
@@ -195,7 +195,7 @@ func TestCmd(t *testing.T) {
 						Format:     "json",
 						URI:        resultFile,
 					}
-					require.NoError(t, cmd.Run())
+					require.NoError(t, cmd.Run(context.Background()))
 				})
 				require.Equal(t, testutils.LoadExpected(t, tc.goldenSchema), stdout)
 				require.Equal(t, "", stderr)
@@ -276,7 +276,7 @@ func TestCmdEncryption(t *testing.T) {
 				Source:       source,
 				URI:          uri,
 			}
-			require.NoError(t, cmd.Run())
+			require.NoError(t, cmd.Run(context.Background()))
 			require.Equal(t, tc.footerMagic, testutils.ParquetFooterMagic(t, uri))
 
 			reader, err := pio.NewParquetFileReader(context.Background(), uri, tc.readOption)
@@ -352,7 +352,7 @@ func TestCmdEncryptionErrors(t *testing.T) {
 				Source:       source,
 				URI:          filepath.Join(tempDir, tc.name+".parquet"),
 			}
-			err := cmd.Run()
+			err := cmd.Run(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.errMsg)
 		})

--- a/cmd/retype/retype_test.go
+++ b/cmd/retype/retype_test.go
@@ -279,7 +279,7 @@ func TestCmdEncryption(t *testing.T) {
 			require.NoError(t, cmd.Run())
 			require.Equal(t, tc.footerMagic, testutils.ParquetFooterMagic(t, uri))
 
-			reader, err := pio.NewParquetFileReader(uri, tc.readOption)
+			reader, err := pio.NewParquetFileReader(context.Background(), uri, tc.readOption)
 			require.NoError(t, err)
 			require.Equal(t, int64(3), reader.GetNumRows())
 			_ = reader.PFile.Close()
@@ -958,7 +958,7 @@ func TestWriterContextCancellation(t *testing.T) {
 }
 
 func TestReaderContextCancellation(t *testing.T) {
-	fileReader, err := pio.NewParquetFileReader("../../testdata/good.parquet", pio.ReadOption{})
+	fileReader, err := pio.NewParquetFileReader(context.Background(), "../../testdata/good.parquet", pio.ReadOption{})
 	require.NoError(t, err)
 	defer func() { _ = fileReader.PFile.Close() }()
 

--- a/cmd/rowcount/rowcount.go
+++ b/cmd/rowcount/rowcount.go
@@ -1,6 +1,7 @@
 package rowcount
 
 import (
+	"context"
 	"fmt"
 
 	pio "github.com/hangxie/parquet-tools/io"
@@ -14,7 +15,7 @@ type Cmd struct {
 
 // Run does actual rowcount job
 func (c Cmd) Run() error {
-	reader, err := pio.NewParquetFileReader(c.URI, c.ReadOption)
+	reader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}

--- a/cmd/rowcount/rowcount.go
+++ b/cmd/rowcount/rowcount.go
@@ -14,8 +14,8 @@ type Cmd struct {
 }
 
 // Run does actual rowcount job
-func (c Cmd) Run() error {
-	reader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
+func (c Cmd) Run(ctx context.Context) error {
+	reader, err := pio.NewParquetFileReader(ctx, c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}

--- a/cmd/rowcount/rowcount_test.go
+++ b/cmd/rowcount/rowcount_test.go
@@ -1,6 +1,7 @@
 package rowcount
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestCmd(t *testing.T) {
 		cmd := &Cmd{}
 		cmd.URI = "file/does/not/exist"
 
-		err := cmd.Run()
+		err := cmd.Run(context.Background())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no such file or directory")
 	})
@@ -34,7 +35,7 @@ func TestCmd(t *testing.T) {
 		cmd.URI = "../../testdata/good.parquet"
 
 		stdout, stderr := testutils.CaptureStdoutStderr(func() {
-			require.Nil(t, cmd.Run())
+			require.Nil(t, cmd.Run(context.Background()))
 		})
 		require.Equal(t, "3\n", stdout)
 		require.Equal(t, "", stderr)
@@ -94,13 +95,13 @@ func TestCmdEncrypted(t *testing.T) {
 				t.Parallel()
 			}
 			if tc.errMsg != "" {
-				err := tc.cmd.Run()
+				err := tc.cmd.Run(context.Background())
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
 				return
 			}
 			stdout, stderr := testutils.CaptureStdoutStderr(func() {
-				require.NoError(t, tc.cmd.Run())
+				require.NoError(t, tc.cmd.Run(context.Background()))
 			})
 			require.Equal(t, tc.stdout, stdout)
 			require.Equal(t, "", stderr)
@@ -127,12 +128,12 @@ func BenchmarkRowCountCmd(b *testing.B) {
 
 	// Warm up the Go runtime before actual benchmark
 	for range 10 {
-		_ = cmd.Run()
+		_ = cmd.Run(context.Background())
 	}
 
 	b.Run("default", func(b *testing.B) {
 		for b.Loop() {
-			require.NoError(b, cmd.Run())
+			require.NoError(b, cmd.Run(context.Background()))
 		}
 	})
 }

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -28,8 +28,8 @@ type Cmd struct {
 }
 
 // Run does actual schema job
-func (c Cmd) Run() error {
-	reader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
+func (c Cmd) Run(ctx context.Context) error {
+	reader, err := pio.NewParquetFileReader(ctx, c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func (c Cmd) Run() error {
 		_ = reader.PFile.Close()
 	}()
 
-	schemaRoot, err := pschema.NewSchemaTree(context.Background(), reader, pschema.SchemaOption{FailOnInt96: false, SkipPageEncoding: c.SkipPageEncoding})
+	schemaRoot, err := pschema.NewSchemaTree(ctx, reader, pschema.SchemaOption{FailOnInt96: false, SkipPageEncoding: c.SkipPageEncoding})
 	if err != nil {
 		return err
 	}

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"go/format"
@@ -28,7 +29,7 @@ type Cmd struct {
 
 // Run does actual schema job
 func (c Cmd) Run() error {
-	reader, err := pio.NewParquetFileReader(c.URI, c.ReadOption)
+	reader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}
@@ -36,7 +37,7 @@ func (c Cmd) Run() error {
 		_ = reader.PFile.Close()
 	}()
 
-	schemaRoot, err := pschema.NewSchemaTree(reader, pschema.SchemaOption{FailOnInt96: false, SkipPageEncoding: c.SkipPageEncoding})
+	schemaRoot, err := pschema.NewSchemaTree(context.Background(), reader, pschema.SchemaOption{FailOnInt96: false, SkipPageEncoding: c.SkipPageEncoding})
 	if err != nil {
 		return err
 	}

--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -1,6 +1,7 @@
 package schema_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -175,12 +176,12 @@ func TestCmd(t *testing.T) {
 				cmd.URI = "../../testdata/" + tc.cmd.URI
 			}
 			if tc.errMsg != "" {
-				err := cmd.Run()
+				err := cmd.Run(context.Background())
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
 			} else {
 				stdout, stderr := testutils.CaptureStdoutStderr(func() {
-					require.NoError(t, cmd.Run())
+					require.NoError(t, cmd.Run(context.Background()))
 				})
 				require.Equal(t, testutils.LoadExpected(t, "../../testdata/golden/"+tc.golden), stdout)
 				require.Equal(t, "", stderr)
@@ -225,7 +226,7 @@ func TestCmdEncrypted(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			stdout, stderr := testutils.CaptureStdoutStderr(func() {
-				require.NoError(t, cmd.Run())
+				require.NoError(t, cmd.Run(context.Background()))
 			})
 			require.Contains(t, stdout, "double_field")
 			require.Contains(t, stdout, "float_field")
@@ -254,12 +255,12 @@ func BenchmarkSchemaCmd(b *testing.B) {
 
 	// Warm up the Go runtime before actual benchmark
 	for range 10 {
-		_ = cmd.Run()
+		_ = cmd.Run(context.Background())
 	}
 
 	b.Run("default", func(b *testing.B) {
 		for b.Loop() {
-			require.NoError(b, cmd.Run())
+			require.NoError(b, cmd.Run(context.Background()))
 		}
 	})
 }

--- a/cmd/size/size.go
+++ b/cmd/size/size.go
@@ -25,7 +25,7 @@ type Cmd struct {
 
 // Run does actual size job
 func (c Cmd) Run() error {
-	reader, err := pio.NewParquetFileReader(c.URI, c.ReadOption)
+	reader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}

--- a/cmd/size/size.go
+++ b/cmd/size/size.go
@@ -24,8 +24,8 @@ type Cmd struct {
 }
 
 // Run does actual size job
-func (c Cmd) Run() error {
-	reader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
+func (c Cmd) Run(ctx context.Context) error {
+	reader, err := pio.NewParquetFileReader(ctx, c.URI, c.ReadOption)
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func (c Cmd) Run() error {
 		_ = reader.PFile.Close()
 	}()
 
-	footerSize, err := reader.GetFooterSizeWithContext(context.Background())
+	footerSize, err := reader.GetFooterSizeWithContext(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/size/size.go
+++ b/cmd/size/size.go
@@ -1,6 +1,7 @@
 package size
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -32,7 +33,7 @@ func (c Cmd) Run() error {
 		_ = reader.PFile.Close()
 	}()
 
-	footerSize, err := reader.GetFooterSize()
+	footerSize, err := reader.GetFooterSizeWithContext(context.Background())
 	if err != nil {
 		return err
 	}

--- a/cmd/size/size_test.go
+++ b/cmd/size/size_test.go
@@ -1,6 +1,7 @@
 package size
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -94,12 +95,12 @@ func TestCmd(t *testing.T) {
 				t.Parallel()
 			}
 			if tc.errMsg != "" {
-				err := tc.cmd.Run()
+				err := tc.cmd.Run(context.Background())
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
 			} else {
 				stdout, stderr := testutils.CaptureStdoutStderr(func() {
-					require.NoError(t, tc.cmd.Run())
+					require.NoError(t, tc.cmd.Run(context.Background()))
 				})
 				require.Equal(t, tc.stdout, stdout)
 				require.Equal(t, "", stderr)
@@ -144,7 +145,7 @@ func TestCmdEncrypted(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			stdout, stderr := testutils.CaptureStdoutStderr(func() {
-				require.NoError(t, cmd.Run())
+				require.NoError(t, cmd.Run(context.Background()))
 			})
 			require.NotEmpty(t, stdout)
 			require.Equal(t, "", stderr)
@@ -172,12 +173,12 @@ func BenchmarkSizeCmd(b *testing.B) {
 
 	// Warm up the Go runtime before actual benchmark
 	for range 10 {
-		_ = cmd.Run()
+		_ = cmd.Run(context.Background())
 	}
 
 	b.Run("default", func(b *testing.B) {
 		for b.Loop() {
-			require.NoError(b, cmd.Run())
+			require.NoError(b, cmd.Run(context.Background()))
 		}
 	})
 }

--- a/cmd/split/split.go
+++ b/cmd/split/split.go
@@ -1,6 +1,7 @@
 package split
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
@@ -62,7 +63,7 @@ func (c *Cmd) openReader() (*reader.ParquetReader, error) {
 
 func (c *Cmd) switchWriter() error {
 	if c.current.writer != nil {
-		if err := c.current.writer.WriteStop(); err != nil {
+		if err := c.current.writer.WriteStopWithContext(context.Background()); err != nil {
 			return fmt.Errorf("failed to end write [%s]: %w", c.current.targetFile, err)
 		}
 		if err := c.current.writer.PFile.Close(); err != nil {
@@ -119,7 +120,7 @@ func (c Cmd) Run() error {
 	c.current.recordCount = c.RecordCount
 
 	for {
-		rows, err := parquetReader.ReadByNumber(c.ReadPageSize)
+		rows, err := parquetReader.ReadByNumberWithContext(context.Background(), c.ReadPageSize)
 		if err != nil {
 			return fmt.Errorf("failed to read from [%s]: %w", c.URI, err)
 		}
@@ -132,7 +133,7 @@ func (c Cmd) Run() error {
 					return err
 				}
 			}
-			if err := c.current.writer.Write(row); err != nil {
+			if err := c.current.writer.WriteWithContext(context.Background(), row); err != nil {
 				return fmt.Errorf("failed to write data from [%s]: %w", c.current.targetFile, err)
 			}
 			c.current.recordCount++
@@ -154,7 +155,7 @@ func (c *Cmd) closeWriter() error {
 	if c.current.writer == nil {
 		return nil
 	}
-	if err := c.current.writer.WriteStop(); err != nil {
+	if err := c.current.writer.WriteStopWithContext(context.Background()); err != nil {
 		return fmt.Errorf("failed to end write [%s]: %w", c.current.targetFile, err)
 	}
 	if err := c.current.writer.PFile.Close(); err != nil {

--- a/cmd/split/split.go
+++ b/cmd/split/split.go
@@ -37,12 +37,12 @@ type Cmd struct {
 	current trunkWriter
 }
 
-func (c *Cmd) openReader() (*reader.ParquetReader, error) {
-	parquetReader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
+func (c *Cmd) openReader(ctx context.Context) (*reader.ParquetReader, error) {
+	parquetReader, err := pio.NewParquetFileReader(ctx, c.URI, c.ReadOption)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open [%s]: %w", c.URI, err)
 	}
-	schemaRoot, err := pschema.NewSchemaTree(context.Background(), parquetReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
+	schemaRoot, err := pschema.NewSchemaTree(ctx, parquetReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
 	if err != nil {
 		_ = parquetReader.PFile.Close()
 		return nil, fmt.Errorf("failed to load schema for [%s]: %w", c.URI, err)
@@ -61,9 +61,9 @@ func (c *Cmd) openReader() (*reader.ParquetReader, error) {
 	return parquetReader, nil
 }
 
-func (c *Cmd) switchWriter() error {
+func (c *Cmd) switchWriter(ctx context.Context) error {
 	if c.current.writer != nil {
-		if err := c.current.writer.WriteStopWithContext(context.Background()); err != nil {
+		if err := c.current.writer.WriteStopWithContext(ctx); err != nil {
 			return fmt.Errorf("failed to end write [%s]: %w", c.current.targetFile, err)
 		}
 		if err := c.current.writer.PFile.Close(); err != nil {
@@ -76,7 +76,7 @@ func (c *Cmd) switchWriter() error {
 	c.ReadOption.FieldDelimiter = c.FieldDelimiter
 	c.WriteOption.FieldDelimiter = c.FieldDelimiter
 	c.current.targetFile = fmt.Sprintf(c.NameFormat, c.current.fileIndex)
-	c.current.writer, err = pio.NewGenericWriter(context.Background(), c.current.targetFile, c.WriteOption, c.current.schemaJSON)
+	c.current.writer, err = pio.NewGenericWriter(ctx, c.current.targetFile, c.WriteOption, c.current.schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to write to [%s]: %w", c.current.targetFile, err)
 	}
@@ -92,7 +92,7 @@ func (c *Cmd) switchWriter() error {
 }
 
 // Run does actual split job
-func (c Cmd) Run() error {
+func (c Cmd) Run(ctx context.Context) error {
 	if err := pio.ValidateFieldDelimiter(c.FieldDelimiter); err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func (c Cmd) Run() error {
 		return fmt.Errorf("invalid name format [%s]: %w", c.NameFormat, err)
 	}
 
-	parquetReader, err := c.openReader()
+	parquetReader, err := c.openReader(ctx)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (c Cmd) Run() error {
 	c.current.recordCount = c.RecordCount
 
 	for {
-		rows, err := parquetReader.ReadByNumberWithContext(context.Background(), c.ReadPageSize)
+		rows, err := parquetReader.ReadByNumberWithContext(ctx, c.ReadPageSize)
 		if err != nil {
 			return fmt.Errorf("failed to read from [%s]: %w", c.URI, err)
 		}
@@ -129,33 +129,33 @@ func (c Cmd) Run() error {
 		}
 		for _, row := range rows {
 			if c.current.recordCount == c.RecordCount {
-				if err := c.switchWriter(); err != nil {
+				if err := c.switchWriter(ctx); err != nil {
 					return err
 				}
 			}
-			if err := c.current.writer.WriteWithContext(context.Background(), row); err != nil {
+			if err := c.current.writer.WriteWithContext(ctx, row); err != nil {
 				return fmt.Errorf("failed to write data from [%s]: %w", c.current.targetFile, err)
 			}
 			c.current.recordCount++
 		}
 	}
 	for c.current.fileIndex < c.FileCount {
-		if err := c.switchWriter(); err != nil {
+		if err := c.switchWriter(ctx); err != nil {
 			return err
 		}
 	}
-	if err := c.closeWriter(); err != nil {
+	if err := c.closeWriter(ctx); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (c *Cmd) closeWriter() error {
+func (c *Cmd) closeWriter(ctx context.Context) error {
 	if c.current.writer == nil {
 		return nil
 	}
-	if err := c.current.writer.WriteStopWithContext(context.Background()); err != nil {
+	if err := c.current.writer.WriteStopWithContext(ctx); err != nil {
 		return fmt.Errorf("failed to end write [%s]: %w", c.current.targetFile, err)
 	}
 	if err := c.current.writer.PFile.Close(); err != nil {

--- a/cmd/split/split.go
+++ b/cmd/split/split.go
@@ -38,11 +38,11 @@ type Cmd struct {
 }
 
 func (c *Cmd) openReader() (*reader.ParquetReader, error) {
-	parquetReader, err := pio.NewParquetFileReader(c.URI, c.ReadOption)
+	parquetReader, err := pio.NewParquetFileReader(context.Background(), c.URI, c.ReadOption)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open [%s]: %w", c.URI, err)
 	}
-	schemaRoot, err := pschema.NewSchemaTree(parquetReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
+	schemaRoot, err := pschema.NewSchemaTree(context.Background(), parquetReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
 	if err != nil {
 		_ = parquetReader.PFile.Close()
 		return nil, fmt.Errorf("failed to load schema for [%s]: %w", c.URI, err)
@@ -76,7 +76,7 @@ func (c *Cmd) switchWriter() error {
 	c.ReadOption.FieldDelimiter = c.FieldDelimiter
 	c.WriteOption.FieldDelimiter = c.FieldDelimiter
 	c.current.targetFile = fmt.Sprintf(c.NameFormat, c.current.fileIndex)
-	c.current.writer, err = pio.NewGenericWriter(c.current.targetFile, c.WriteOption, c.current.schemaJSON)
+	c.current.writer, err = pio.NewGenericWriter(context.Background(), c.current.targetFile, c.WriteOption, c.current.schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to write to [%s]: %w", c.current.targetFile, err)
 	}

--- a/cmd/split/split_test.go
+++ b/cmd/split/split_test.go
@@ -103,7 +103,7 @@ func TestCmd(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cmd := tc.cmd
 			if tc.errMsg != "" {
-				err := cmd.Run()
+				err := cmd.Run(context.Background())
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
 			} else {
@@ -111,7 +111,7 @@ func TestCmd(t *testing.T) {
 				tempDir := t.TempDir()
 				cmd.URI = filepath.Join("../../testdata", cmd.URI)
 				cmd.NameFormat = filepath.Join(tempDir, cmd.NameFormat)
-				err := cmd.Run()
+				err := cmd.Run(context.Background())
 				require.NoError(t, err)
 				files, _ := os.ReadDir(tempDir)
 				require.Equal(t, len(files), len(tc.result))
@@ -141,7 +141,7 @@ func TestCmd(t *testing.T) {
 			NameFormat:   filepath.Join(tempDir, "ut-%d.parquet"),
 		}
 
-		err := splitCmd.Run()
+		err := splitCmd.Run(context.Background())
 		require.NoError(t, err)
 		files, _ := os.ReadDir(tempDir)
 		require.Equal(t, 1, len(files))
@@ -154,7 +154,7 @@ func TestCmd(t *testing.T) {
 			URI:          filepath.Join(tempDir, files[0].Name()),
 		}
 		stdout, _ := testutils.CaptureStdoutStderr(func() {
-			require.NoError(t, catCmd.Run())
+			require.NoError(t, catCmd.Run(context.Background()))
 		})
 		require.Equal(t, testutils.LoadExpected(t, "../../testdata/golden/split-optional-fields-json.json"), stdout)
 	})
@@ -232,7 +232,7 @@ func TestCmdEncryption(t *testing.T) {
 				NameFormat:   filepath.Join(tempDir, "part-%d.parquet"),
 				URI:          source,
 			}
-			require.NoError(t, cmd.Run())
+			require.NoError(t, cmd.Run(context.Background()))
 
 			files, err := os.ReadDir(tempDir)
 			require.NoError(t, err)
@@ -318,7 +318,7 @@ func TestCmdEncryptionErrors(t *testing.T) {
 				NameFormat:   filepath.Join(tempDir, "part-%d.parquet"),
 				URI:          source,
 			}
-			err := cmd.Run()
+			err := cmd.Run(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.errMsg)
 		})

--- a/cmd/split/split_test.go
+++ b/cmd/split/split_test.go
@@ -1,6 +1,7 @@
 package split
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -118,7 +119,7 @@ func TestCmd(t *testing.T) {
 				for _, file := range files {
 					rowCount, ok := tc.result[file.Name()]
 					require.True(t, ok)
-					reader, err := pio.NewParquetFileReader(filepath.Join(tempDir, file.Name()), rOpt)
+					reader, err := pio.NewParquetFileReader(context.Background(), filepath.Join(tempDir, file.Name()), rOpt)
 					require.NoError(t, err)
 					require.NotNil(t, reader)
 					require.Equal(t, reader.GetNumRows(), rowCount)
@@ -241,7 +242,7 @@ func TestCmdEncryption(t *testing.T) {
 			for _, file := range files {
 				path := filepath.Join(tempDir, file.Name())
 				require.Equal(t, tc.footerMagic, testutils.ParquetFooterMagic(t, path))
-				reader, err := pio.NewParquetFileReader(path, tc.readOption)
+				reader, err := pio.NewParquetFileReader(context.Background(), path, tc.readOption)
 				require.NoError(t, err)
 				totalRows += reader.GetNumRows()
 				_ = reader.PFile.Close()

--- a/cmd/transcode/transcode.go
+++ b/cmd/transcode/transcode.go
@@ -202,7 +202,7 @@ func (c Cmd) modifySchemaTree(schemaTree *pschema.SchemaNode, fieldEncodings, fi
 }
 
 // Run does actual transcode job
-func (c Cmd) Run() (retErr error) {
+func (c Cmd) Run(ctx context.Context) (retErr error) {
 	if err := pio.ValidateFieldDelimiter(c.FieldDelimiter); err != nil {
 		return err
 	}
@@ -229,7 +229,7 @@ func (c Cmd) Run() (retErr error) {
 	}
 
 	// Open source file
-	fileReader, err := pio.NewParquetFileReader(context.Background(), c.Source, c.ReadOption)
+	fileReader, err := pio.NewParquetFileReader(ctx, c.Source, c.ReadOption)
 	if err != nil {
 		return fmt.Errorf("failed to read from [%s]: %w", c.Source, err)
 	}
@@ -238,7 +238,7 @@ func (c Cmd) Run() (retErr error) {
 	}()
 
 	// Get schema from source
-	schemaTree, err := pschema.NewSchemaTree(context.Background(), fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
+	schemaTree, err := pschema.NewSchemaTree(ctx, fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
 	if err != nil {
 		return err
 	}
@@ -255,12 +255,12 @@ func (c Cmd) Run() (retErr error) {
 	// Create output file with new settings
 	c.ReadOption.FieldDelimiter = c.FieldDelimiter
 	c.WriteOption.FieldDelimiter = c.FieldDelimiter
-	fileWriter, err := pio.NewGenericWriter(context.Background(), c.URI, c.WriteOption, schemaJSON)
+	fileWriter, err := pio.NewGenericWriter(ctx, c.URI, c.WriteOption, schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)
 	}
 	defer func() {
-		if err := fileWriter.WriteStopWithContext(context.Background()); err != nil && retErr == nil {
+		if err := fileWriter.WriteStopWithContext(ctx); err != nil && retErr == nil {
 			retErr = fmt.Errorf("failed to end write [%s]: %w", c.URI, err)
 		}
 		if err := fileWriter.PFile.Close(); err != nil && retErr == nil {
@@ -268,5 +268,5 @@ func (c Cmd) Run() (retErr error) {
 		}
 	}()
 
-	return pio.RunPipeline(context.Background(), fileReader, fileWriter, c.Source, c.URI, c.ReadPageSize, nil)
+	return pio.RunPipeline(ctx, fileReader, fileWriter, c.Source, c.URI, c.ReadPageSize, nil)
 }

--- a/cmd/transcode/transcode.go
+++ b/cmd/transcode/transcode.go
@@ -1,6 +1,7 @@
 package transcode
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strconv"
@@ -259,7 +260,7 @@ func (c Cmd) Run() (retErr error) {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)
 	}
 	defer func() {
-		if err := fileWriter.WriteStop(); err != nil && retErr == nil {
+		if err := fileWriter.WriteStopWithContext(context.Background()); err != nil && retErr == nil {
 			retErr = fmt.Errorf("failed to end write [%s]: %w", c.URI, err)
 		}
 		if err := fileWriter.PFile.Close(); err != nil && retErr == nil {

--- a/cmd/transcode/transcode.go
+++ b/cmd/transcode/transcode.go
@@ -229,7 +229,7 @@ func (c Cmd) Run() (retErr error) {
 	}
 
 	// Open source file
-	fileReader, err := pio.NewParquetFileReader(c.Source, c.ReadOption)
+	fileReader, err := pio.NewParquetFileReader(context.Background(), c.Source, c.ReadOption)
 	if err != nil {
 		return fmt.Errorf("failed to read from [%s]: %w", c.Source, err)
 	}
@@ -238,7 +238,7 @@ func (c Cmd) Run() (retErr error) {
 	}()
 
 	// Get schema from source
-	schemaTree, err := pschema.NewSchemaTree(fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
+	schemaTree, err := pschema.NewSchemaTree(context.Background(), fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (c Cmd) Run() (retErr error) {
 	// Create output file with new settings
 	c.ReadOption.FieldDelimiter = c.FieldDelimiter
 	c.WriteOption.FieldDelimiter = c.FieldDelimiter
-	fileWriter, err := pio.NewGenericWriter(c.URI, c.WriteOption, schemaJSON)
+	fileWriter, err := pio.NewGenericWriter(context.Background(), c.URI, c.WriteOption, schemaJSON)
 	if err != nil {
 		return fmt.Errorf("failed to write to [%s]: %w", c.URI, err)
 	}
@@ -268,5 +268,5 @@ func (c Cmd) Run() (retErr error) {
 		}
 	}()
 
-	return pio.RunPipeline(fileReader, fileWriter, c.Source, c.URI, c.ReadPageSize, nil)
+	return pio.RunPipeline(context.Background(), fileReader, fileWriter, c.Source, c.URI, c.ReadPageSize, nil)
 }

--- a/cmd/transcode/transcode_test.go
+++ b/cmd/transcode/transcode_test.go
@@ -245,7 +245,7 @@ func testCmdGood(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify the output file exists and has the correct row count
-			reader, err := pio.NewParquetFileReader(cmd.URI, rOpt)
+			reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 			require.NoError(t, err)
 			rowCount := reader.GetNumRows()
 			_ = reader.PFile.Close()
@@ -334,7 +334,7 @@ func testCmdSchemaModification(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify output file
-	reader, err := pio.NewParquetFileReader(cmd.URI, rOpt)
+	reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 	require.NoError(t, err)
 	defer func() {
 		_ = reader.PFile.Close()
@@ -367,7 +367,7 @@ func testCmdPageSizes(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify the data is correct
-			reader, err := pio.NewParquetFileReader(cmd.URI, rOpt)
+			reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 			require.NoError(t, err)
 			require.Equal(t, int64(5), reader.GetNumRows())
 			_ = reader.PFile.Close()
@@ -535,7 +535,7 @@ func testCmdFieldEncoding(t *testing.T) {
 				require.NoError(t, err)
 
 				// Verify output file exists and has correct row count
-				reader, err := pio.NewParquetFileReader(cmd.URI, rOpt)
+				reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 				require.NoError(t, err)
 				require.Equal(t, int64(3), reader.GetNumRows())
 				_ = reader.PFile.Close()
@@ -626,7 +626,7 @@ func testCmdFieldCompression(t *testing.T) {
 				require.NoError(t, err)
 
 				// Verify output file exists and has correct row count
-				reader, err := pio.NewParquetFileReader(cmd.URI, rOpt)
+				reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 				require.NoError(t, err)
 				require.Equal(t, int64(3), reader.GetNumRows())
 				_ = reader.PFile.Close()
@@ -661,7 +661,7 @@ func testCmdFieldEncodingAndCompression(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify output file exists and has correct row count
-	reader, err := pio.NewParquetFileReader(cmd.URI, rOpt)
+	reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 	require.NoError(t, err)
 	require.Equal(t, int64(3), reader.GetNumRows())
 	_ = reader.PFile.Close()
@@ -762,7 +762,7 @@ func testCmdOverridesEncodingWhenSpecified(t *testing.T) {
 	require.Contains(t, transcodedSchema, "encoding=DELTA_BYTE_ARRAY")
 
 	// Verify data integrity by checking row count and basic data
-	reader, err := pio.NewParquetFileReader(transcodedFile, rOpt)
+	reader, err := pio.NewParquetFileReader(context.Background(), transcodedFile, rOpt)
 	require.NoError(t, err)
 	require.Equal(t, int64(3), reader.GetNumRows())
 	_ = reader.PFile.Close()
@@ -845,7 +845,7 @@ func testCmdPreservesEncodingsWithDataPageVersionChange(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify file was created and data is correct
-	reader, err := pio.NewParquetFileReader(transcodedFile, rOpt)
+	reader, err := pio.NewParquetFileReader(context.Background(), transcodedFile, rOpt)
 	require.NoError(t, err)
 	require.Equal(t, int64(5), reader.GetNumRows())
 	_ = reader.PFile.Close()
@@ -1323,7 +1323,7 @@ func testCmdFieldBloomFilter(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify bloom filter was added
-		reader, err := pio.NewParquetFileReader(cmd.URI, rOpt)
+		reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 		require.NoError(t, err)
 		defer func() { _ = reader.PFile.Close() }()
 		require.Equal(t, int64(3), reader.GetNumRows())
@@ -1346,7 +1346,7 @@ func testCmdFieldBloomFilter(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify bloom filter was removed for ID but preserved for Name and Score
-		reader, err := pio.NewParquetFileReader(cmd.URI, rOpt)
+		reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 		require.NoError(t, err)
 		defer func() { _ = reader.PFile.Close() }()
 		require.Equal(t, int64(10), reader.GetNumRows())
@@ -1372,7 +1372,7 @@ func testCmdFieldBloomFilter(t *testing.T) {
 		err := cmd.Run()
 		require.NoError(t, err)
 
-		reader, err := pio.NewParquetFileReader(cmd.URI, rOpt)
+		reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 		require.NoError(t, err)
 		defer func() { _ = reader.PFile.Close() }()
 
@@ -1391,7 +1391,7 @@ func testCmdFieldBloomFilter(t *testing.T) {
 		err := cmd.Run()
 		require.NoError(t, err)
 
-		reader, err := pio.NewParquetFileReader(cmd.URI, rOpt)
+		reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
 		require.NoError(t, err)
 		defer func() { _ = reader.PFile.Close() }()
 
@@ -1610,7 +1610,7 @@ func testCmdDecryptEncrypted(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			plainReader, err := pio.NewParquetFileReader(cmd.URI, pio.ReadOption{})
+			plainReader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, pio.ReadOption{})
 			require.NoError(t, err)
 			require.Equal(t, int64(50), plainReader.GetNumRows())
 			_ = plainReader.PFile.Close()

--- a/cmd/transcode/transcode_test.go
+++ b/cmd/transcode/transcode_test.go
@@ -101,7 +101,7 @@ func testCmdError(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			err := tc.cmd.Run()
+			err := tc.cmd.Run(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.errMsg)
 		})
@@ -241,7 +241,7 @@ func testCmdGood(t *testing.T) {
 				Source:       filepath.Join("..", "..", "testdata", tc.source),
 				URI:          filepath.Join(tempDir, name+".parquet"),
 			}
-			err := cmd.Run()
+			err := cmd.Run(context.Background())
 			require.NoError(t, err)
 
 			// Verify the output file exists and has the correct row count
@@ -280,7 +280,7 @@ func testCmdVerifyData(t *testing.T) {
 		Source:       "../../testdata/good.parquet",
 		URI:          filepath.Join(tempDir, "transcoded.parquet"),
 	}
-	err := cmd.Run()
+	err := cmd.Run(context.Background())
 	require.NoError(t, err)
 
 	// Verify the data is the same by using cat command
@@ -302,10 +302,10 @@ func testCmdVerifyData(t *testing.T) {
 	}
 
 	originalOutput, _ := testutils.CaptureStdoutStderr(func() {
-		require.NoError(t, catOriginal.Run())
+		require.NoError(t, catOriginal.Run(context.Background()))
 	})
 	transcodedOutput, _ := testutils.CaptureStdoutStderr(func() {
-		require.NoError(t, catTranscoded.Run())
+		require.NoError(t, catTranscoded.Run(context.Background()))
 	})
 
 	require.Equal(t, originalOutput, transcodedOutput)
@@ -330,7 +330,7 @@ func testCmdSchemaModification(t *testing.T) {
 		URI:          filepath.Join(tempDir, "no-mods.parquet"),
 	}
 
-	err := cmd.Run()
+	err := cmd.Run(context.Background())
 	require.NoError(t, err)
 
 	// Verify output file
@@ -363,7 +363,7 @@ func testCmdPageSizes(t *testing.T) {
 				Source:       "../../testdata/all-types.parquet",
 				URI:          filepath.Join(tempDir, fmt.Sprintf("pagesize-%d.parquet", pageSize)),
 			}
-			err := cmd.Run()
+			err := cmd.Run(context.Background())
 			require.NoError(t, err)
 
 			// Verify the data is correct
@@ -445,7 +445,7 @@ func testCmdEdgeCases(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.cmd.Run()
+			err := tc.cmd.Run(context.Background())
 			if tc.errMsg != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
@@ -526,7 +526,7 @@ func testCmdFieldEncoding(t *testing.T) {
 				URI:           filepath.Join(tempDir, tc.name+".parquet"),
 			}
 
-			err := cmd.Run()
+			err := cmd.Run(context.Background())
 
 			if tc.errMsg != "" {
 				require.Error(t, err)
@@ -617,7 +617,7 @@ func testCmdFieldCompression(t *testing.T) {
 				URI:              filepath.Join(tempDir, tc.name+".parquet"),
 			}
 
-			err := cmd.Run()
+			err := cmd.Run(context.Background())
 
 			if tc.errMsg != "" {
 				require.Error(t, err)
@@ -657,7 +657,7 @@ func testCmdFieldEncodingAndCompression(t *testing.T) {
 		URI:              filepath.Join(tempDir, "combined.parquet"),
 	}
 
-	err := cmd.Run()
+	err := cmd.Run(context.Background())
 	require.NoError(t, err)
 
 	// Verify output file exists and has correct row count
@@ -687,7 +687,7 @@ func testCmdPreservesEncodingsOverride(t *testing.T) {
 		Source:       testFile,
 		URI:          transcodedFile,
 	}
-	err := cmd.Run()
+	err := cmd.Run(context.Background())
 	require.NoError(t, err)
 
 	// Encodings should be preserved (compare with encoding but not compression)
@@ -714,10 +714,10 @@ func testCmdPreservesEncodingsOverride(t *testing.T) {
 	}
 
 	originalOutput, _ := testutils.CaptureStdoutStderr(func() {
-		require.NoError(t, catOriginal.Run())
+		require.NoError(t, catOriginal.Run(context.Background()))
 	})
 	transcodedOutput, _ := testutils.CaptureStdoutStderr(func() {
-		require.NoError(t, catTranscoded.Run())
+		require.NoError(t, catTranscoded.Run(context.Background()))
 	})
 
 	require.Equal(t, originalOutput, transcodedOutput)
@@ -745,7 +745,7 @@ func testCmdOverridesEncodingWhenSpecified(t *testing.T) {
 		Source:       "../../testdata/good.parquet",
 		URI:          transcodedFile,
 	}
-	err := cmd.Run()
+	err := cmd.Run(context.Background())
 	require.NoError(t, err)
 
 	// Get schema from transcoded file
@@ -755,7 +755,7 @@ func testCmdOverridesEncodingWhenSpecified(t *testing.T) {
 		URI:        transcodedFile,
 	}
 	transcodedSchema, _ := testutils.CaptureStdoutStderr(func() {
-		require.NoError(t, schemaCmd.Run())
+		require.NoError(t, schemaCmd.Run(context.Background()))
 	})
 
 	// Verify the encoding was overridden for shoe_name
@@ -786,10 +786,10 @@ func testCmdOverridesEncodingWhenSpecified(t *testing.T) {
 	}
 
 	transcodedOutput, _ := testutils.CaptureStdoutStderr(func() {
-		require.NoError(t, catTranscoded.Run())
+		require.NoError(t, catTranscoded.Run(context.Background()))
 	})
 	originalOutput, _ := testutils.CaptureStdoutStderr(func() {
-		require.NoError(t, catOriginal.Run())
+		require.NoError(t, catOriginal.Run(context.Background()))
 	})
 
 	require.Equal(t, originalOutput, transcodedOutput)
@@ -815,7 +815,7 @@ func testCmdPreservesEncodingsWithCompressionChange(t *testing.T) {
 		Source:       testFile,
 		URI:          transcodedFile,
 	}
-	err := cmd.Run()
+	err := cmd.Run(context.Background())
 	require.NoError(t, err)
 
 	// Encodings should be preserved even with different compression
@@ -841,7 +841,7 @@ func testCmdPreservesEncodingsWithDataPageVersionChange(t *testing.T) {
 		Source:       "../../testdata/all-types.parquet",
 		URI:          transcodedFile,
 	}
-	err := cmd.Run()
+	err := cmd.Run(context.Background())
 	require.NoError(t, err)
 
 	// Verify file was created and data is correct
@@ -857,7 +857,7 @@ func testCmdPreservesEncodingsWithDataPageVersionChange(t *testing.T) {
 		URI:        transcodedFile,
 	}
 	transcodedSchema, _ := testutils.CaptureStdoutStderr(func() {
-		require.NoError(t, schemaCmd.Run())
+		require.NoError(t, schemaCmd.Run(context.Background()))
 	})
 
 	// Should not contain PLAIN_DICTIONARY in v2
@@ -1319,7 +1319,7 @@ func testCmdFieldBloomFilter(t *testing.T) {
 			Source:           filepath.Join("..", "..", "testdata", "good.parquet"),
 			URI:              filepath.Join(tempDir, "add-bloom.parquet"),
 		}
-		err := cmd.Run()
+		err := cmd.Run(context.Background())
 		require.NoError(t, err)
 
 		// Verify bloom filter was added
@@ -1342,7 +1342,7 @@ func testCmdFieldBloomFilter(t *testing.T) {
 			Source:           filepath.Join("..", "..", "testdata", "bloom-filter.parquet"),
 			URI:              filepath.Join(tempDir, "remove-bloom.parquet"),
 		}
-		err := cmd.Run()
+		err := cmd.Run(context.Background())
 		require.NoError(t, err)
 
 		// Verify bloom filter was removed for ID but preserved for Name and Score
@@ -1369,7 +1369,7 @@ func testCmdFieldBloomFilter(t *testing.T) {
 			Source:           filepath.Join("..", "..", "testdata", "good.parquet"),
 			URI:              filepath.Join(tempDir, "add-bloom-size.parquet"),
 		}
-		err := cmd.Run()
+		err := cmd.Run(context.Background())
 		require.NoError(t, err)
 
 		reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
@@ -1388,7 +1388,7 @@ func testCmdFieldBloomFilter(t *testing.T) {
 			Source:       filepath.Join("..", "..", "testdata", "bloom-filter.parquet"),
 			URI:          filepath.Join(tempDir, "preserve-bloom.parquet"),
 		}
-		err := cmd.Run()
+		err := cmd.Run(context.Background())
 		require.NoError(t, err)
 
 		reader, err := pio.NewParquetFileReader(context.Background(), cmd.URI, rOpt)
@@ -1602,7 +1602,7 @@ func testCmdDecryptEncrypted(t *testing.T) {
 				Source:       tc.source,
 				URI:          filepath.Join(tempDir, tc.name+".parquet"),
 			}
-			err := cmd.Run()
+			err := cmd.Run(context.Background())
 			if tc.errMsg != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
@@ -1636,7 +1636,7 @@ func testCmdEncryptWriter(t *testing.T) {
 		ReadPageSize: 10,
 		Source:       plainSource,
 		URI:          encryptedSource,
-	}.Run())
+	}.Run(context.Background()))
 
 	testCases := []struct {
 		name        string
@@ -1723,7 +1723,7 @@ func testCmdEncryptWriter(t *testing.T) {
 				Source:       tc.source,
 				URI:          uri,
 			}
-			require.NoError(t, cmd.Run())
+			require.NoError(t, cmd.Run(context.Background()))
 			require.Equal(t, tc.footerMagic, testutils.ParquetFooterMagic(t, uri))
 			require.Equal(t, wantOutput, testutils.CommandStdout(t, transcodeTestCatCmd(uri, tc.outputRead)))
 		})
@@ -1809,7 +1809,7 @@ func testCmdEncryptWriterErrors(t *testing.T) {
 				Source:       filepath.Join("..", "..", "testdata", "good.parquet"),
 				URI:          filepath.Join(tempDir, tc.name+".parquet"),
 			}
-			err := cmd.Run()
+			err := cmd.Run(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.errMsg)
 		})
@@ -1844,12 +1844,12 @@ func BenchmarkTranscodeCmd(b *testing.B) {
 
 	// Warm up the Go runtime before actual benchmark
 	for range 10 {
-		_ = cmd.Run()
+		_ = cmd.Run(context.Background())
 	}
 
 	b.Run("default", func(b *testing.B) {
 		for b.Loop() {
-			require.NoError(b, cmd.Run())
+			require.NoError(b, cmd.Run(context.Background()))
 		}
 	})
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -26,7 +27,7 @@ type Cmd struct {
 }
 
 // Run does actual version job
-func (c Cmd) Run() error {
+func (c Cmd) Run(_ context.Context) error {
 	if c.All {
 		c.BuildTime = true
 		c.Source = true

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -56,7 +57,7 @@ func TestCmd(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			stdout, stderr := testutils.CaptureStdoutStderr(func() {
-				require.Nil(t, tc.cmd.Run())
+				require.Nil(t, tc.cmd.Run(context.Background()))
 			})
 			require.Equal(t, tc.stdout, stdout)
 			require.Equal(t, "", stderr)
@@ -81,7 +82,7 @@ func BenchmarkVersionCmd(b *testing.B) {
 	}
 	b.Run("default", func(b *testing.B) {
 		for b.Loop() {
-			require.NoError(b, cmd.Run())
+			require.NoError(b, cmd.Run(context.Background()))
 		}
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.31
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.0
 	github.com/google/uuid v1.6.0
-	github.com/hangxie/parquet-go/v3 v3.4.3
+	github.com/hangxie/parquet-go/v3 v3.5.0
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.11.1
 	github.com/willabides/kongplete v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyC
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
-github.com/hangxie/parquet-go/v3 v3.4.3 h1:VuoNMvfB9JfUMYF/7J8YuSjvU3BgTHwZJulJcJe5oIk=
-github.com/hangxie/parquet-go/v3 v3.4.3/go.mod h1:yzDf7xEK3eX1iubBqTadQRbVAzKbq2Cz2xuvFoNaY1c=
+github.com/hangxie/parquet-go/v3 v3.5.0 h1:XLvQbURcgn3MhNtJI40YEyNYNjVx9IpfawiZu/wqxQs=
+github.com/hangxie/parquet-go/v3 v3.5.0/go.mod h1:yzDf7xEK3eX1iubBqTadQRbVAzKbq2Cz2xuvFoNaY1c=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/io/encryption_peek.go
+++ b/io/encryption_peek.go
@@ -38,8 +38,8 @@ type EncryptionKeyHints struct {
 // ReadEncryptionKeyHints reads key_metadata fields from a parquet file by
 // parsing raw bytes, requiring no decryption keys. Returns nil if the file is
 // not encrypted or carries no key_metadata.
-func ReadEncryptionKeyHints(URI string, option ReadOption) (*EncryptionKeyHints, error) {
-	src, err := newSourceReader(URI, option)
+func ReadEncryptionKeyHints(ctx context.Context, URI string, option ReadOption) (*EncryptionKeyHints, error) {
+	src, err := newSourceReader(ctx, URI, option)
 	if err != nil {
 		return nil, err
 	}

--- a/io/encryption_peek_test.go
+++ b/io/encryption_peek_test.go
@@ -142,7 +142,7 @@ func TestReadEncryptionKeyHints(t *testing.T) {
 			if tc.setup != nil {
 				uri = tc.setup(t)
 			}
-			hints, err := ReadEncryptionKeyHints(uri, ReadOption{})
+			hints, err := ReadEncryptionKeyHints(context.Background(), uri, ReadOption{})
 			if tc.errMsg != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)

--- a/io/pipeline.go
+++ b/io/pipeline.go
@@ -19,7 +19,7 @@ func PipelineWriter(ctx context.Context, fileWriter *writer.ParquetWriter, write
 			if !more {
 				return nil
 			}
-			if err := fileWriter.WriteWithContext(context.Background(), row); err != nil {
+			if err := fileWriter.WriteWithContext(ctx, row); err != nil {
 				return fmt.Errorf("failed to write data to [%s]: %w", target, err)
 			}
 		}
@@ -29,8 +29,8 @@ func PipelineWriter(ctx context.Context, fileWriter *writer.ParquetWriter, write
 // RunPipeline runs a reader and writer in parallel using errgroup. The reader sends rows
 // through an internal channel to the writer. If either side fails, the shared context is
 // cancelled so the other side exits promptly.
-func RunPipeline(fileReader *reader.ParquetReader, fileWriter *writer.ParquetWriter, source, target string, pageSize int, transform func(any) (any, error)) error {
-	g, gctx := errgroup.WithContext(context.Background())
+func RunPipeline(ctx context.Context, fileReader *reader.ParquetReader, fileWriter *writer.ParquetWriter, source, target string, pageSize int, transform func(any) (any, error)) error {
+	g, gctx := errgroup.WithContext(ctx)
 	writerChan := make(chan any)
 
 	g.Go(func() error {
@@ -49,7 +49,7 @@ func RunPipeline(fileReader *reader.ParquetReader, fileWriter *writer.ParquetWri
 // and sends them to writerChan. Pass nil for transform to skip transformation.
 func PipelineReader(ctx context.Context, fileReader *reader.ParquetReader, writerChan chan any, source string, pageSize int, transform func(any) (any, error)) error {
 	for {
-		rows, err := fileReader.ReadByNumberWithContext(context.Background(), pageSize)
+		rows, err := fileReader.ReadByNumberWithContext(ctx, pageSize)
 		if err != nil {
 			return fmt.Errorf("failed to read from [%s]: %w", source, err)
 		}

--- a/io/pipeline.go
+++ b/io/pipeline.go
@@ -19,7 +19,7 @@ func PipelineWriter(ctx context.Context, fileWriter *writer.ParquetWriter, write
 			if !more {
 				return nil
 			}
-			if err := fileWriter.Write(row); err != nil {
+			if err := fileWriter.WriteWithContext(context.Background(), row); err != nil {
 				return fmt.Errorf("failed to write data to [%s]: %w", target, err)
 			}
 		}
@@ -49,7 +49,7 @@ func RunPipeline(fileReader *reader.ParquetReader, fileWriter *writer.ParquetWri
 // and sends them to writerChan. Pass nil for transform to skip transformation.
 func PipelineReader(ctx context.Context, fileReader *reader.ParquetReader, writerChan chan any, source string, pageSize int, transform func(any) (any, error)) error {
 	for {
-		rows, err := fileReader.ReadByNumber(pageSize)
+		rows, err := fileReader.ReadByNumberWithContext(context.Background(), pageSize)
 		if err != nil {
 			return fmt.Errorf("failed to read from [%s]: %w", source, err)
 		}

--- a/io/pipeline_test.go
+++ b/io/pipeline_test.go
@@ -161,7 +161,7 @@ func TestRunPipeline(t *testing.T) {
 		// Stop the writer so writes fail immediately.
 		_ = pw.WriteStopWithContext(context.Background())
 
-		err := RunPipeline(pr, pw, "good.parquet", "test-target", 1, nil)
+		err := RunPipeline(context.Background(), pr, pw, "good.parquet", "test-target", 1, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to write data to [test-target]")
 	})
@@ -171,7 +171,7 @@ func TestRunPipeline(t *testing.T) {
 		tempDir := t.TempDir()
 		pw := newTestWriter(t, filepath.Join(tempDir, "out.parquet"), schema)
 
-		err := RunPipeline(pr, pw, "good.parquet", "test-target", 1, func(any) (any, error) {
+		err := RunPipeline(context.Background(), pr, pw, "good.parquet", "test-target", 1, func(any) (any, error) {
 			return nil, fmt.Errorf("injected reader failure")
 		})
 		require.Error(t, err)

--- a/io/pipeline_test.go
+++ b/io/pipeline_test.go
@@ -17,7 +17,7 @@ func newTestReader(t *testing.T, path string) *reader.ParquetReader {
 	t.Helper()
 	fr, err := local.NewLocalFileReader(path)
 	require.NoError(t, err)
-	pr, err := reader.NewParquetReader(fr, nil, reader.WithNP(int64(runtime.NumCPU())))
+	pr, err := reader.NewParquetReaderWithContext(context.Background(), fr, nil, reader.WithNP(int64(runtime.NumCPU())))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = pr.PFile.Close() })
 	return pr
@@ -27,10 +27,10 @@ func newTestWriter(t *testing.T, path, schema string) *writer.ParquetWriter {
 	t.Helper()
 	fw, err := local.NewLocalFileWriter(path)
 	require.NoError(t, err)
-	pw, err := writer.NewParquetWriter(fw, schema, writer.WithNP(int64(runtime.NumCPU())))
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, schema, writer.WithNP(int64(runtime.NumCPU())))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = pw.WriteStop()
+		_ = pw.WriteStopWithContext(context.Background())
 		_ = pw.PFile.Close()
 	})
 	return pw
@@ -69,7 +69,7 @@ func TestPipelineWriter(t *testing.T) {
 		pw := newTestWriter(t, filepath.Join(tempDir, "out.parquet"), schema)
 
 		// Stop the writer first so writes will fail
-		_ = pw.WriteStop()
+		_ = pw.WriteStopWithContext(context.Background())
 
 		writerChan := make(chan any, 1)
 		type row struct {
@@ -159,7 +159,7 @@ func TestRunPipeline(t *testing.T) {
 		tempDir := t.TempDir()
 		pw := newTestWriter(t, filepath.Join(tempDir, "out.parquet"), schema)
 		// Stop the writer so writes fail immediately.
-		_ = pw.WriteStop()
+		_ = pw.WriteStopWithContext(context.Background())
 
 		err := RunPipeline(pr, pw, "good.parquet", "test-target", 1, nil)
 		require.Error(t, err)

--- a/io/reader.go
+++ b/io/reader.go
@@ -109,20 +109,20 @@ func applyKeyFile(kf keyFileSchema, opt *ReadOption) {
 	}
 }
 
-func newLocalReader(u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
+func newLocalReader(_ context.Context, u *url.URL, _ ReadOption) (source.ParquetFileReader, error) {
 	return local.NewLocalFileReader(u.Path)
 }
 
-func newAWSS3Reader(u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
+func newAWSS3Reader(ctx context.Context, u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
 	s3Client, err := getS3Client(u.Host, option.Anonymous, option.HTTPIgnoreTLSError)
 	if err != nil {
 		return nil, err
 	}
 
-	return s3v2.NewS3FileReaderWithClient(context.Background(), s3Client, u.Host, strings.TrimLeft(u.Path, "/"), option.ObjectVersion)
+	return s3v2.NewS3FileReaderWithClient(ctx, s3Client, u.Host, strings.TrimLeft(u.Path, "/"), option.ObjectVersion)
 }
 
-func newAzureStorageBlobReader(u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
+func newAzureStorageBlobReader(ctx context.Context, u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
 	objectVersion := ""
 	if option.ObjectVersion != nil {
 		objectVersion = *option.ObjectVersion
@@ -132,10 +132,10 @@ func newAzureStorageBlobReader(u *url.URL, option ReadOption) (source.ParquetFil
 		return nil, err
 	}
 
-	return pqazblob.NewAzBlobFileReader(context.Background(), azURL, cred, blockblob.ClientOptions{})
+	return pqazblob.NewAzBlobFileReader(ctx, azURL, cred, blockblob.ClientOptions{})
 }
 
-func newGoogleCloudStorageReader(u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
+func newGoogleCloudStorageReader(ctx context.Context, u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
 	generation := int64(-1)
 	if option.ObjectVersion != nil {
 		var err error
@@ -144,7 +144,6 @@ func newGoogleCloudStorageReader(u *url.URL, option ReadOption) (source.ParquetF
 			return nil, fmt.Errorf("invalid GCS generation [%s]: %w", *option.ObjectVersion, err)
 		}
 	}
-	ctx := context.Background()
 
 	var options []googleoption.ClientOption
 	if option.Anonymous {
@@ -158,11 +157,11 @@ func newGoogleCloudStorageReader(u *url.URL, option ReadOption) (source.ParquetF
 	return gcs.NewGcsFileReaderWithClient(ctx, client, "", u.Host, strings.TrimLeft(u.Path, "/"), generation)
 }
 
-func newHTTPReader(u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
-	return pqhttp.NewHttpReaderWithContext(context.Background(), u.String(), option.HTTPMultipleConnection, option.HTTPIgnoreTLSError, option.HTTPExtraHeaders)
+func newHTTPReader(ctx context.Context, u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
+	return pqhttp.NewHttpReaderWithContext(ctx, u.String(), option.HTTPMultipleConnection, option.HTTPIgnoreTLSError, option.HTTPExtraHeaders)
 }
 
-func newHDFSReader(u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
+func newHDFSReader(_ context.Context, u *url.URL, _ ReadOption) (source.ParquetFileReader, error) {
 	userName := u.User.Username()
 	if userName == "" {
 		osUser, err := user.Current()
@@ -174,8 +173,8 @@ func newHDFSReader(u *url.URL, option ReadOption) (source.ParquetFileReader, err
 	return hdfs.NewHdfsFileReader([]string{u.Host}, userName, u.Path)
 }
 
-func newSourceReader(URI string, option ReadOption) (source.ParquetFileReader, error) {
-	readerFuncTable := map[string]func(*url.URL, ReadOption) (source.ParquetFileReader, error){
+func newSourceReader(ctx context.Context, URI string, option ReadOption) (source.ParquetFileReader, error) {
+	readerFuncTable := map[string]func(context.Context, *url.URL, ReadOption) (source.ParquetFileReader, error){
 		schemeLocal:              newLocalReader,
 		schemeAWSS3:              newAWSS3Reader,
 		schemeGoogleCloudStorage: newGoogleCloudStorageReader,
@@ -193,14 +192,14 @@ func newSourceReader(URI string, option ReadOption) (source.ParquetFileReader, e
 	if !found {
 		return nil, fmt.Errorf("unknown location scheme [%s]", u.Scheme)
 	}
-	src, err := readerFunc(u, option)
+	src, err := readerFunc(ctx, u, option)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open file [%s]: %w", u.String(), err)
 	}
 	return src, nil
 }
 
-func NewParquetFileReader(URI string, option ReadOption) (*reader.ParquetReader, error) {
+func NewParquetFileReader(ctx context.Context, URI string, option ReadOption) (*reader.ParquetReader, error) {
 	if option.KeyFile != nil {
 		kf, err := parseKeyFile(*option.KeyFile)
 		if err != nil {
@@ -209,7 +208,7 @@ func NewParquetFileReader(URI string, option ReadOption) (*reader.ParquetReader,
 		applyKeyFile(kf, &option)
 	}
 
-	fileReader, err := newSourceReader(URI, option)
+	fileReader, err := newSourceReader(ctx, URI, option)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +220,7 @@ func NewParquetFileReader(URI string, option ReadOption) (*reader.ParquetReader,
 	}
 
 	readerOpts := append(encOpts, reader.WithNP(int64(runtime.NumCPU())))
-	pr, err := reader.NewParquetReaderWithContext(context.Background(), fileReader, nil, readerOpts...)
+	pr, err := reader.NewParquetReaderWithContext(ctx, fileReader, nil, readerOpts...)
 	if err != nil {
 		_ = fileReader.Close()
 		return nil, err

--- a/io/reader.go
+++ b/io/reader.go
@@ -159,7 +159,7 @@ func newGoogleCloudStorageReader(u *url.URL, option ReadOption) (source.ParquetF
 }
 
 func newHTTPReader(u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
-	return pqhttp.NewHttpReader(u.String(), option.HTTPMultipleConnection, option.HTTPIgnoreTLSError, option.HTTPExtraHeaders)
+	return pqhttp.NewHttpReaderWithContext(context.Background(), u.String(), option.HTTPMultipleConnection, option.HTTPIgnoreTLSError, option.HTTPExtraHeaders)
 }
 
 func newHDFSReader(u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
@@ -221,7 +221,7 @@ func NewParquetFileReader(URI string, option ReadOption) (*reader.ParquetReader,
 	}
 
 	readerOpts := append(encOpts, reader.WithNP(int64(runtime.NumCPU())))
-	pr, err := reader.NewParquetReader(fileReader, nil, readerOpts...)
+	pr, err := reader.NewParquetReaderWithContext(context.Background(), fileReader, nil, readerOpts...)
 	if err != nil {
 		_ = fileReader.Close()
 		return nil, err

--- a/io/reader_test.go
+++ b/io/reader_test.go
@@ -1,6 +1,7 @@
 package io
 
 import (
+	"context"
 	"encoding/base64"
 	"os"
 	"path/filepath"
@@ -393,12 +394,12 @@ func TestNewParquetFileReaderEncryption(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			defer func() { _ = pr.ReadStop() }()
+			defer func() { _ = pr.ReadStopWithContext(context.Background()) }()
 
 			if !tc.readRows {
 				return
 			}
-			rows, err := pr.ReadByNumber(10)
+			rows, err := pr.ReadByNumberWithContext(context.Background(), 10)
 			if tc.readErr != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.readErr)

--- a/io/reader_test.go
+++ b/io/reader_test.go
@@ -242,7 +242,7 @@ func TestNewParquetFileReader(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			_, err := NewParquetFileReader(tc.uri, tc.option)
+			_, err := NewParquetFileReader(context.Background(), tc.uri, tc.option)
 			if tc.errMsg == "" {
 				require.NoError(t, err)
 				return
@@ -387,7 +387,7 @@ func TestNewParquetFileReaderEncryption(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			pr, err := NewParquetFileReader(tc.uri, tc.option)
+			pr, err := NewParquetFileReader(context.Background(), tc.uri, tc.option)
 			if tc.errMsg != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
@@ -538,7 +538,7 @@ func FuzzNewParquetFileReader(f *testing.F) {
 		if err := os.WriteFile(path, data, 0o600); err != nil {
 			t.Skip()
 		}
-		pr, err := NewParquetFileReader(path, ReadOption{})
+		pr, err := NewParquetFileReader(context.Background(), path, ReadOption{})
 		if err != nil {
 			return
 		}

--- a/io/writer.go
+++ b/io/writer.go
@@ -50,7 +50,7 @@ type WriteOption struct {
 	WriterKeyFile       *string  `name:"writer-key-file" group:"Encryption" help:"path to a JSON file containing encryption keys ({footer_key, column_keys}); CLI flags override file values; --writer-column-key flags merge with file column_keys, CLI wins per path. Recommend chmod 600 on the file."`
 }
 
-func newLocalWriter(u *url.URL) (source.ParquetFileWriter, error) {
+func newLocalWriter(_ context.Context, u *url.URL) (source.ParquetFileWriter, error) {
 	fileWriter, err := local.NewLocalFileWriter(u.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open local file [%s]: %w", u.Path, err)
@@ -58,46 +58,46 @@ func newLocalWriter(u *url.URL) (source.ParquetFileWriter, error) {
 	return fileWriter, nil
 }
 
-func newAWSS3Writer(u *url.URL) (source.ParquetFileWriter, error) {
+func newAWSS3Writer(ctx context.Context, u *url.URL) (source.ParquetFileWriter, error) {
 	s3Client, err := getS3Client(u.Host, false, false)
 	if err != nil {
 		return nil, err
 	}
 
-	fileWriter, err := s3v2.NewS3FileWriterWithClient(context.Background(), s3Client, u.Host, strings.TrimLeft(u.Path, "/"), nil)
+	fileWriter, err := s3v2.NewS3FileWriterWithClient(ctx, s3Client, u.Host, strings.TrimLeft(u.Path, "/"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open S3 object [%s]: %w", u.String(), err)
 	}
 	return fileWriter, nil
 }
 
-func newGoogleCloudStorageWriter(u *url.URL) (source.ParquetFileWriter, error) {
-	fileWriter, err := gcs.NewGcsFileWriter(context.Background(), "", u.Host, strings.TrimLeft(u.Path, "/"))
+func newGoogleCloudStorageWriter(ctx context.Context, u *url.URL) (source.ParquetFileWriter, error) {
+	fileWriter, err := gcs.NewGcsFileWriter(ctx, "", u.Host, strings.TrimLeft(u.Path, "/"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open GCS object [%s]: %w", u.String(), err)
 	}
 	return fileWriter, nil
 }
 
-func newAzureStorageBlobWriter(u *url.URL) (source.ParquetFileWriter, error) {
+func newAzureStorageBlobWriter(ctx context.Context, u *url.URL) (source.ParquetFileWriter, error) {
 	// write operation cannot be with anonymous access
 	azURL, cred, err := azureAccessDetail(*u, false, "")
 	if err != nil {
 		return nil, err
 	}
 
-	fileWriter, err := azblob.NewAzBlobFileWriter(context.Background(), azURL, cred, blockblob.ClientOptions{})
+	fileWriter, err := azblob.NewAzBlobFileWriter(ctx, azURL, cred, blockblob.ClientOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to open Azure blob object [%s]: %w", u.String(), err)
 	}
 	return fileWriter, nil
 }
 
-func newHTTPWriter(u *url.URL) (source.ParquetFileWriter, error) {
+func newHTTPWriter(_ context.Context, u *url.URL) (source.ParquetFileWriter, error) {
 	return nil, fmt.Errorf("writing to [%s] endpoint is not currently supported", u.Scheme)
 }
 
-func newHDFSWriter(u *url.URL) (source.ParquetFileWriter, error) {
+func newHDFSWriter(_ context.Context, u *url.URL) (source.ParquetFileWriter, error) {
 	userName := u.User.Username()
 	if userName == "" {
 		osUser, err := user.Current()
@@ -112,8 +112,8 @@ func newHDFSWriter(u *url.URL) (source.ParquetFileWriter, error) {
 	return fileWriter, nil
 }
 
-func NewParquetFileWriter(uri string) (source.ParquetFileWriter, error) {
-	writerFuncTable := map[string]func(*url.URL) (source.ParquetFileWriter, error){
+func NewParquetFileWriter(ctx context.Context, uri string) (source.ParquetFileWriter, error) {
+	writerFuncTable := map[string]func(context.Context, *url.URL) (source.ParquetFileWriter, error){
 		schemeLocal:              newLocalWriter,
 		schemeAWSS3:              newAWSS3Writer,
 		schemeGoogleCloudStorage: newGoogleCloudStorageWriter,
@@ -128,7 +128,7 @@ func NewParquetFileWriter(uri string) (source.ParquetFileWriter, error) {
 		return nil, err
 	}
 	if writerFunc, found := writerFuncTable[u.Scheme]; found {
-		return writerFunc(u)
+		return writerFunc(ctx, u)
 	}
 	return nil, fmt.Errorf("unknown location scheme [%s]", u.Scheme)
 }
@@ -167,13 +167,13 @@ func writerOpts(option WriteOption, columnKeys []writerColumnKey) ([]writer.Writ
 	return opts, nil
 }
 
-func NewCSVWriter(uri string, opt WriteOption, schema []string) (*writer.CSVWriter, error) {
+func NewCSVWriter(ctx context.Context, uri string, opt WriteOption, schema []string) (*writer.CSVWriter, error) {
 	opt, err := applyWriterKeyFileOption(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	fileWriter, err := NewParquetFileWriter(uri)
+	fileWriter, err := NewParquetFileWriter(ctx, uri)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func NewCSVWriter(uri string, opt WriteOption, schema []string) (*writer.CSVWrit
 		return nil, err
 	}
 	opts = append(opts, encOpts...)
-	pw, err := writer.NewCSVWriterWithContext(context.Background(), schema, fileWriter, opts...)
+	pw, err := writer.NewCSVWriterWithContext(ctx, schema, fileWriter, opts...)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err
@@ -204,13 +204,13 @@ func NewCSVWriter(uri string, opt WriteOption, schema []string) (*writer.CSVWrit
 	return pw, nil
 }
 
-func NewJSONWriter(uri string, opt WriteOption, schema string) (*writer.JSONWriter, error) {
+func NewJSONWriter(ctx context.Context, uri string, opt WriteOption, schema string) (*writer.JSONWriter, error) {
 	opt, err := applyWriterKeyFileOption(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	fileWriter, err := NewParquetFileWriter(uri)
+	fileWriter, err := NewParquetFileWriter(ctx, uri)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func NewJSONWriter(uri string, opt WriteOption, schema string) (*writer.JSONWrit
 		return nil, err
 	}
 	opts = append(opts, encOpts...)
-	pw, err := writer.NewJSONWriterWithContext(context.Background(), schema, fileWriter, opts...)
+	pw, err := writer.NewJSONWriterWithContext(ctx, schema, fileWriter, opts...)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err
@@ -241,13 +241,13 @@ func NewJSONWriter(uri string, opt WriteOption, schema string) (*writer.JSONWrit
 	return pw, nil
 }
 
-func NewGenericWriter(uri string, opt WriteOption, schema string) (*writer.ParquetWriter, error) {
+func NewGenericWriter(ctx context.Context, uri string, opt WriteOption, schema string) (*writer.ParquetWriter, error) {
 	opt, err := applyWriterKeyFileOption(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	fileWriter, err := NewParquetFileWriter(uri)
+	fileWriter, err := NewParquetFileWriter(ctx, uri)
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +270,7 @@ func NewGenericWriter(uri string, opt WriteOption, schema string) (*writer.Parqu
 		return nil, err
 	}
 	opts = append(opts, encOpts...)
-	pw, err := writer.NewParquetWriterWithContext(context.Background(), fileWriter, schema, opts...)
+	pw, err := writer.NewParquetWriterWithContext(ctx, fileWriter, schema, opts...)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err

--- a/io/writer.go
+++ b/io/writer.go
@@ -196,7 +196,7 @@ func NewCSVWriter(uri string, opt WriteOption, schema []string) (*writer.CSVWrit
 		return nil, err
 	}
 	opts = append(opts, encOpts...)
-	pw, err := writer.NewCSVWriter(schema, fileWriter, opts...)
+	pw, err := writer.NewCSVWriterWithContext(context.Background(), schema, fileWriter, opts...)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err
@@ -233,7 +233,7 @@ func NewJSONWriter(uri string, opt WriteOption, schema string) (*writer.JSONWrit
 		return nil, err
 	}
 	opts = append(opts, encOpts...)
-	pw, err := writer.NewJSONWriter(schema, fileWriter, opts...)
+	pw, err := writer.NewJSONWriterWithContext(context.Background(), schema, fileWriter, opts...)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err
@@ -270,7 +270,7 @@ func NewGenericWriter(uri string, opt WriteOption, schema string) (*writer.Parqu
 		return nil, err
 	}
 	opts = append(opts, encOpts...)
-	pw, err := writer.NewParquetWriter(fileWriter, schema, opts...)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fileWriter, schema, opts...)
 	if err != nil {
 		_ = fileWriter.Close()
 		return nil, err

--- a/io/writer_test.go
+++ b/io/writer_test.go
@@ -1,6 +1,7 @@
 package io
 
 import (
+	"context"
 	"encoding/base64"
 	"os"
 	"path/filepath"
@@ -126,7 +127,7 @@ func TestNewParquetFileWriter(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			pw, err := NewParquetFileWriter(tc.uri)
+			pw, err := NewParquetFileWriter(context.Background(), tc.uri)
 			defer func() {
 				if pw != nil {
 					_ = pw.Close()
@@ -304,7 +305,7 @@ func TestNewCSVWriter(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			pw, err := NewCSVWriter(tc.uri, tc.option, tc.schema)
+			pw, err := NewCSVWriter(context.Background(), tc.uri, tc.option, tc.schema)
 			defer func() {
 				if pw != nil {
 					_ = pw.PFile.Close()
@@ -430,7 +431,7 @@ func TestNewJSONWriter(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			pw, err := NewJSONWriter(tc.uri, tc.option, tc.schema)
+			pw, err := NewJSONWriter(context.Background(), tc.uri, tc.option, tc.schema)
 			defer func() {
 				if pw != nil {
 					_ = pw.PFile.Close()
@@ -634,7 +635,7 @@ func TestNewGenericWriter(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			pw, err := NewGenericWriter(tc.uri, tc.option, tc.schema)
+			pw, err := NewGenericWriter(context.Background(), tc.uri, tc.option, tc.schema)
 			defer func() {
 				if pw != nil {
 					_ = pw.PFile.Close()
@@ -655,21 +656,21 @@ func TestWriterKeyFileReadBeforeOpeningDestination(t *testing.T) {
 	validJSONSchema := `{"Tag":"name=root","Fields":[{"Tag":"name=id, type=INT64"}]}`
 	constructors := map[string]func(string, WriteOption) error{
 		"csv": func(uri string, option WriteOption) error {
-			pw, err := NewCSVWriter(uri, option, []string{"name=Id, type=INT64"})
+			pw, err := NewCSVWriter(context.Background(), uri, option, []string{"name=Id, type=INT64"})
 			if pw != nil {
 				_ = pw.PFile.Close()
 			}
 			return err
 		},
 		"json": func(uri string, option WriteOption) error {
-			pw, err := NewJSONWriter(uri, option, validJSONSchema)
+			pw, err := NewJSONWriter(context.Background(), uri, option, validJSONSchema)
 			if pw != nil {
 				_ = pw.PFile.Close()
 			}
 			return err
 		},
 		"generic": func(uri string, option WriteOption) error {
-			pw, err := NewGenericWriter(uri, option, validJSONSchema)
+			pw, err := NewGenericWriter(context.Background(), uri, option, validJSONSchema)
 			if pw != nil {
 				_ = pw.PFile.Close()
 			}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/alecthomas/kong"
 	"github.com/posener/complete"
@@ -23,7 +26,7 @@ import (
 	pio "github.com/hangxie/parquet-tools/io"
 )
 
-var cli struct {
+type cli struct {
 	Cat              cat.Cmd                      `cmd:"" help:"Prints the content of a Parquet file, data only."`
 	Import           importcmd.Cmd                `cmd:"" help:"Create Parquet file from other source data."`
 	Inspect          inspect.Cmd                  `cmd:"" help:"Inspect Parquet file structure in detail."`
@@ -39,17 +42,29 @@ var cli struct {
 	Version          version.Cmd                  `cmd:"" help:"Show build version."`
 }
 
-func main() {
+func newParser(cli *cli) *kong.Kong {
 	parser := kong.Must(
-		&cli,
+		cli,
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{Compact: true}),
 		kong.Description("A utility to inspect Parquet files, for full usage see https://github.com/hangxie/parquet-tools/blob/main/README.md"),
 		kong.Vars{"writer_encryption_algorithms": strings.Join(pio.WriterEncryptionAlgorithms, ",")},
 	)
 	kongplete.Complete(parser, kongplete.WithPredictor("file", complete.PredictFiles("*")))
+	return parser
+}
 
-	ctx, err := parser.Parse(os.Args[1:])
+func run(kongCtx *kong.Context, ctx context.Context) error {
+	kongCtx.BindTo(ctx, (*context.Context)(nil))
+	return kongCtx.Run()
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	parser := newParser(new(cli))
+	kongCtx, err := parser.Parse(os.Args[1:])
 	parser.FatalIfErrorf(err)
-	ctx.FatalIfErrorf(ctx.Run())
+	kongCtx.FatalIfErrorf(run(kongCtx, ctx))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParserInjectsCanceledContext(t *testing.T) {
+	parser := newParser(new(cli))
+	kongCtx, err := parser.Parse([]string{"row-count", "testdata/good.parquet"})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorIs(t, run(kongCtx, ctx), context.Canceled)
+}
+
+func TestWriterFinalizationPreservesCancellation(t *testing.T) {
+	err := fs.WalkDir(os.DirFS("cmd"), ".", func(path string, entry fs.DirEntry, err error) error {
+		require.NoError(t, err)
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		source, err := fs.ReadFile(os.DirFS("cmd"), path)
+		require.NoError(t, err)
+		if strings.Contains(string(source), "WriteStopWithContext(context.WithoutCancel(") {
+			t.Errorf("%s detaches writer finalization from cancellation", path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/schema/gostruct_test.go
+++ b/schema/gostruct_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"go/format"
 	"os"
@@ -16,13 +17,13 @@ func TestGoStructNode(t *testing.T) {
 	t.Run("good", func(t *testing.T) {
 		option := pio.ReadOption{}
 		uri := "../testdata/all-types.parquet"
-		pr, err := pio.NewParquetFileReader(uri, option)
+		pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
 		}()
 
-		schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+		schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 		require.NoError(t, err)
 		require.NotNil(t, schemaRoot)
 
@@ -41,13 +42,13 @@ func TestGoStructNode(t *testing.T) {
 	t.Run("composite-map-key", func(t *testing.T) {
 		option := pio.ReadOption{}
 		uri := "../testdata/map-value-map.parquet"
-		pr, err := pio.NewParquetFileReader(uri, option)
+		pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
 		}()
 
-		schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+		schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 		require.NoError(t, err)
 		require.NotNil(t, schemaRoot)
 
@@ -62,13 +63,13 @@ func TestGoStructNode(t *testing.T) {
 	t.Run("composite-map-value", func(t *testing.T) {
 		option := pio.ReadOption{}
 		uri := "../testdata/map-composite-value.parquet"
-		pr, err := pio.NewParquetFileReader(uri, option)
+		pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
 		}()
 
-		schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+		schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 		require.NoError(t, err)
 		require.NotNil(t, schemaRoot)
 
@@ -80,13 +81,13 @@ func TestGoStructNode(t *testing.T) {
 	t.Run("invalid-scalar", func(t *testing.T) {
 		option := pio.ReadOption{}
 		uri := "../testdata/good.parquet"
-		pr, err := pio.NewParquetFileReader(uri, option)
+		pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
 		}()
 
-		schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+		schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 		require.NoError(t, err)
 		require.NotNil(t, schemaRoot)
 
@@ -100,13 +101,13 @@ func TestGoStructNode(t *testing.T) {
 	t.Run("invalid-list", func(t *testing.T) {
 		option := pio.ReadOption{}
 		uri := "../testdata/all-types.parquet"
-		pr, err := pio.NewParquetFileReader(uri, option)
+		pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
 		}()
 
-		schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+		schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 		require.NoError(t, err)
 		require.NotNil(t, schemaRoot)
 
@@ -121,13 +122,13 @@ func TestGoStructNode(t *testing.T) {
 	t.Run("invalid-map-key", func(t *testing.T) {
 		option := pio.ReadOption{}
 		uri := "../testdata/all-types.parquet"
-		pr, err := pio.NewParquetFileReader(uri, option)
+		pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
 		}()
 
-		schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+		schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 		require.NoError(t, err)
 		require.NotNil(t, schemaRoot)
 
@@ -142,13 +143,13 @@ func TestGoStructNode(t *testing.T) {
 	t.Run("invalid-map-value", func(t *testing.T) {
 		option := pio.ReadOption{}
 		uri := "../testdata/all-types.parquet"
-		pr, err := pio.NewParquetFileReader(uri, option)
+		pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
 		}()
 
-		schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+		schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 		require.NoError(t, err)
 		require.NotNil(t, schemaRoot)
 
@@ -163,13 +164,13 @@ func TestGoStructNode(t *testing.T) {
 	t.Run("invalid-list-element", func(t *testing.T) {
 		option := pio.ReadOption{}
 		uri := "../testdata/list-of-list.parquet"
-		pr, err := pio.NewParquetFileReader(uri, option)
+		pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
 		}()
 
-		schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+		schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 		require.NoError(t, err)
 		require.NotNil(t, schemaRoot)
 
@@ -181,13 +182,13 @@ func TestGoStructNode(t *testing.T) {
 	t.Run("as-list", func(t *testing.T) {
 		option := pio.ReadOption{}
 		uri := "../testdata/gostruct-list.parquet"
-		pr, err := pio.NewParquetFileReader(uri, option)
+		pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
 		}()
 
-		root, err := NewSchemaTree(pr, SchemaOption{})
+		root, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 		require.NoError(t, err)
 		require.NotNil(t, root)
 

--- a/schema/jsonschema_test.go
+++ b/schema/jsonschema_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -13,13 +14,13 @@ import (
 func TestJSONSchemaNode(t *testing.T) {
 	option := pio.ReadOption{}
 	uri := "../testdata/all-types.parquet"
-	pr, err := pio.NewParquetFileReader(uri, option)
+	pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 	require.NoError(t, err)
 	defer func() {
 		_ = pr.PFile.Close()
 	}()
 
-	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 	require.NoError(t, err)
 	require.NotNil(t, schemaRoot)
 

--- a/schema/schemanode_test.go
+++ b/schema/schemanode_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"go/format"
@@ -78,13 +79,13 @@ func TestNewSchemaTree(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			option := pio.ReadOption{}
-			pr, err := pio.NewParquetFileReader(tc.uri, option)
+			pr, err := pio.NewParquetFileReader(context.Background(), tc.uri, option)
 			require.NoError(t, err)
 			defer func() {
 				_ = pr.PFile.Close()
 			}()
 
-			schemaRoot, err := NewSchemaTree(pr, tc.option)
+			schemaRoot, err := NewSchemaTree(context.Background(), pr, tc.option)
 			if tc.errMsg != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errMsg)
@@ -115,7 +116,7 @@ func TestNewSchemaTree(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(tmpFile, data, 0o644))
 
-		pr, err := pio.NewParquetFileReader(tmpFile, pio.ReadOption{})
+		pr, err := pio.NewParquetFileReader(context.Background(), tmpFile, pio.ReadOption{})
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
@@ -123,7 +124,7 @@ func TestNewSchemaTree(t *testing.T) {
 
 		require.NoError(t, os.Remove(tmpFile))
 
-		_, err = NewSchemaTree(pr, SchemaOption{})
+		_, err = NewSchemaTree(context.Background(), pr, SchemaOption{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to build encoding map")
 	})
@@ -162,13 +163,13 @@ func TestBuildEncodingMap(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			option := pio.ReadOption{}
-			pr, err := pio.NewParquetFileReader(tc.uri, option)
+			pr, err := pio.NewParquetFileReader(context.Background(), tc.uri, option)
 			require.NoError(t, err)
 			defer func() {
 				_ = pr.PFile.Close()
 			}()
 
-			result, err := buildEncodingMap(pr)
+			result, err := buildEncodingMap(context.Background(), pr)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 
@@ -195,7 +196,7 @@ func TestBuildEncodingMap(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(tmpFile, data, 0o644))
 
-		pr, err := pio.NewParquetFileReader(tmpFile, pio.ReadOption{})
+		pr, err := pio.NewParquetFileReader(context.Background(), tmpFile, pio.ReadOption{})
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
@@ -204,7 +205,7 @@ func TestBuildEncodingMap(t *testing.T) {
 		// Delete the file so Clone() cannot re-open it
 		require.NoError(t, os.Remove(tmpFile))
 
-		_, err = buildEncodingMap(pr)
+		_, err = buildEncodingMap(context.Background(), pr)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to clone file")
 	})
@@ -217,7 +218,7 @@ func TestBuildEncodingMap(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(tmpFile, data, 0o644))
 
-		pr, err := pio.NewParquetFileReader(tmpFile, pio.ReadOption{})
+		pr, err := pio.NewParquetFileReader(context.Background(), tmpFile, pio.ReadOption{})
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
@@ -226,7 +227,7 @@ func TestBuildEncodingMap(t *testing.T) {
 		// Truncate the file to corrupt data pages while keeping it openable
 		require.NoError(t, os.Truncate(tmpFile, 4))
 
-		_, err = buildEncodingMap(pr)
+		_, err = buildEncodingMap(context.Background(), pr)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to read encoding")
 	})
@@ -235,13 +236,13 @@ func TestBuildEncodingMap(t *testing.T) {
 func TestSchemaNodeGetPathMap(t *testing.T) {
 	option := pio.ReadOption{}
 	uri := "../testdata/all-types.parquet"
-	pr, err := pio.NewParquetFileReader(uri, option)
+	pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 	require.NoError(t, err)
 	defer func() {
 		_ = pr.PFile.Close()
 	}()
 
-	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 	require.NoError(t, err)
 	require.NotNil(t, schemaRoot)
 
@@ -321,13 +322,13 @@ func TestSchemaNodeGetPathMap(t *testing.T) {
 func TestSchemaNodeGetInExNameMap(t *testing.T) {
 	option := pio.ReadOption{}
 	uri := "../testdata/all-types.parquet"
-	pr, err := pio.NewParquetFileReader(uri, option)
+	pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 	require.NoError(t, err)
 	defer func() {
 		_ = pr.PFile.Close()
 	}()
 
-	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 	require.NoError(t, err)
 	require.NotNil(t, schemaRoot)
 
@@ -488,13 +489,13 @@ func TestUpdateTagFromConvertedType(t *testing.T) {
 	// Test with nan.parquet which has no converted type annotation
 	option := pio.ReadOption{}
 	uri := "../testdata/nan.parquet"
-	pr, err := pio.NewParquetFileReader(uri, option)
+	pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 	require.NoError(t, err)
 	defer func() {
 		_ = pr.PFile.Close()
 	}()
 
-	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 	require.NoError(t, err)
 	require.NotNil(t, schemaRoot)
 
@@ -523,13 +524,13 @@ func TestUpdateTagFromLogicalType(t *testing.T) {
 	// Test with nan.parquet which has no logical type annotation
 	option := pio.ReadOption{}
 	uri := "../testdata/nan.parquet"
-	pr, err := pio.NewParquetFileReader(uri, option)
+	pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
 	require.NoError(t, err)
 	defer func() {
 		_ = pr.PFile.Close()
 	}()
 
-	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 	require.NoError(t, err)
 	require.NotNil(t, schemaRoot)
 
@@ -568,13 +569,13 @@ func TestUpdateTagFromLogicalType(t *testing.T) {
 
 	// Test with geospatial.parquet which has GEOMETRY and GEOGRAPHY logical types
 	uri = "../testdata/geospatial.parquet"
-	pr, err = pio.NewParquetFileReader(uri, option)
+	pr, err = pio.NewParquetFileReader(context.Background(), uri, option)
 	require.NoError(t, err)
 	defer func() {
 		_ = pr.PFile.Close()
 	}()
 
-	schemaRoot, err = NewSchemaTree(pr, SchemaOption{})
+	schemaRoot, err = NewSchemaTree(context.Background(), pr, SchemaOption{})
 	require.NoError(t, err)
 	require.NotNil(t, schemaRoot)
 
@@ -660,13 +661,13 @@ func TestGoStruct(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			option := pio.ReadOption{}
-			pr, err := pio.NewParquetFileReader(tc.uri, option)
+			pr, err := pio.NewParquetFileReader(context.Background(), tc.uri, option)
 			require.NoError(t, err)
 			defer func() {
 				_ = pr.PFile.Close()
 			}()
 
-			schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+			schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 			require.NoError(t, err)
 			require.NotNil(t, schemaRoot)
 
@@ -696,18 +697,18 @@ func TestGoStructAfterJSONSchema(t *testing.T) {
 		// JSONSchema is called first or not.
 		uri := "../testdata/all-types.parquet"
 
-		pr1, err := pio.NewParquetFileReader(uri, pio.ReadOption{})
+		pr1, err := pio.NewParquetFileReader(context.Background(), uri, pio.ReadOption{})
 		require.NoError(t, err)
 		defer func() { _ = pr1.PFile.Close() }()
-		root1, err := NewSchemaTree(pr1, SchemaOption{})
+		root1, err := NewSchemaTree(context.Background(), pr1, SchemaOption{})
 		require.NoError(t, err)
 		expected, err := root1.GoStruct(false)
 		require.NoError(t, err)
 
-		pr2, err := pio.NewParquetFileReader(uri, pio.ReadOption{})
+		pr2, err := pio.NewParquetFileReader(context.Background(), uri, pio.ReadOption{})
 		require.NoError(t, err)
 		defer func() { _ = pr2.PFile.Close() }()
-		root2, err := NewSchemaTree(pr2, SchemaOption{})
+		root2, err := NewSchemaTree(context.Background(), pr2, SchemaOption{})
 		require.NoError(t, err)
 		root2.JSONSchema()
 		actual, err := root2.GoStruct(false)
@@ -720,10 +721,10 @@ func TestGoStructAfterJSONSchema(t *testing.T) {
 		// Children through a shared pointer. GoStruct must return an error
 		// (unsupported type) rather than panic when it processes the now-flattened
 		// inner MAP structure via the else branch in asMap.
-		pr, err := pio.NewParquetFileReader("../testdata/map-value-map.parquet", pio.ReadOption{})
+		pr, err := pio.NewParquetFileReader(context.Background(), "../testdata/map-value-map.parquet", pio.ReadOption{})
 		require.NoError(t, err)
 		defer func() { _ = pr.PFile.Close() }()
-		root, err := NewSchemaTree(pr, SchemaOption{})
+		root, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 		require.NoError(t, err)
 		root.JSONSchema()
 		_, err = root.GoStruct(false)
@@ -752,13 +753,13 @@ func TestJSONSchema(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			option := pio.ReadOption{}
-			pr, err := pio.NewParquetFileReader(tc.uri, option)
+			pr, err := pio.NewParquetFileReader(context.Background(), tc.uri, option)
 			require.NoError(t, err)
 			defer func() {
 				_ = pr.PFile.Close()
 			}()
 
-			schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+			schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 			require.NoError(t, err)
 			require.NotNil(t, schemaRoot)
 
@@ -805,13 +806,13 @@ func TestCSVSchema(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			option := pio.ReadOption{}
-			pr, err := pio.NewParquetFileReader(tc.uri, option)
+			pr, err := pio.NewParquetFileReader(context.Background(), tc.uri, option)
 			require.NoError(t, err)
 			defer func() {
 				_ = pr.PFile.Close()
 			}()
 
-			schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+			schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 			require.NoError(t, err)
 			require.NotNil(t, schemaRoot)
 
@@ -857,7 +858,7 @@ func TestBuildCompressionCodecMap(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			option := pio.ReadOption{}
-			pr, err := pio.NewParquetFileReader(tc.uri, option)
+			pr, err := pio.NewParquetFileReader(context.Background(), tc.uri, option)
 			require.NoError(t, err)
 			defer func() {
 				_ = pr.PFile.Close()
@@ -908,7 +909,7 @@ func TestBuildBloomFilterMap(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pr, err := pio.NewParquetFileReader(tc.uri, pio.ReadOption{})
+			pr, err := pio.NewParquetFileReader(context.Background(), tc.uri, pio.ReadOption{})
 			require.NoError(t, err)
 			defer func() {
 				_ = pr.PFile.Close()
@@ -954,7 +955,7 @@ func TestBloomFilterSizeMap(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pr, err := pio.NewParquetFileReader(tc.uri, pio.ReadOption{})
+			pr, err := pio.NewParquetFileReader(context.Background(), tc.uri, pio.ReadOption{})
 			require.NoError(t, err)
 			defer func() {
 				_ = pr.PFile.Close()
@@ -975,7 +976,7 @@ func TestBloomFilterSizeMap(t *testing.T) {
 	}
 
 	t.Run("consistent with buildBloomFilterMap", func(t *testing.T) {
-		pr, err := pio.NewParquetFileReader("../testdata/bloom-filter.parquet", pio.ReadOption{})
+		pr, err := pio.NewParquetFileReader(context.Background(), "../testdata/bloom-filter.parquet", pio.ReadOption{})
 		require.NoError(t, err)
 		defer func() {
 			_ = pr.PFile.Close()
@@ -1397,17 +1398,17 @@ func TestIsCompatible(t *testing.T) {
 	}
 	for _, tc := range integrationTests {
 		t.Run(tc.name, func(t *testing.T) {
-			pr1, err := pio.NewParquetFileReader(tc.file1, pio.ReadOption{})
+			pr1, err := pio.NewParquetFileReader(context.Background(), tc.file1, pio.ReadOption{})
 			require.NoError(t, err)
 			defer func() { _ = pr1.PFile.Close() }()
 
-			pr2, err := pio.NewParquetFileReader(tc.file2, pio.ReadOption{})
+			pr2, err := pio.NewParquetFileReader(context.Background(), tc.file2, pio.ReadOption{})
 			require.NoError(t, err)
 			defer func() { _ = pr2.PFile.Close() }()
 
-			tree1, err := NewSchemaTree(pr1, SchemaOption{})
+			tree1, err := NewSchemaTree(context.Background(), pr1, SchemaOption{})
 			require.NoError(t, err)
-			tree2, err := NewSchemaTree(pr2, SchemaOption{})
+			tree2, err := NewSchemaTree(context.Background(), pr2, SchemaOption{})
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expect, tree1.IsCompatible(tree2, tc.option))
@@ -1417,13 +1418,13 @@ func TestIsCompatible(t *testing.T) {
 
 func TestGetTagMapWithCompression(t *testing.T) {
 	option := pio.ReadOption{}
-	pr, err := pio.NewParquetFileReader("../testdata/good.parquet", option)
+	pr, err := pio.NewParquetFileReader(context.Background(), "../testdata/good.parquet", option)
 	require.NoError(t, err)
 	defer func() {
 		_ = pr.PFile.Close()
 	}()
 
-	schemaRoot, err := NewSchemaTree(pr, SchemaOption{})
+	schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 	require.NoError(t, err)
 	require.NotNil(t, schemaRoot)
 
@@ -2316,13 +2317,13 @@ func FuzzNewSchemaTree(f *testing.F) {
 		if err := os.WriteFile(path, data, 0o600); err != nil {
 			t.Skip()
 		}
-		pr, err := pio.NewParquetFileReader(path, pio.ReadOption{})
+		pr, err := pio.NewParquetFileReader(context.Background(), path, pio.ReadOption{})
 		if err != nil {
 			return
 		}
 		defer func() { _ = pr.PFile.Close() }()
 
-		root, err := NewSchemaTree(pr, SchemaOption{})
+		root, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
 		if err != nil {
 			return
 		}

--- a/schema/schematree.go
+++ b/schema/schematree.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"strings"
@@ -20,7 +21,7 @@ func readFirstDataPageEncoding(pr *reader.ParquetReader, rowGroupIndex, columnIn
 	// - Dictionary pages at DataPageOffset
 	// - Proper offset calculation including header sizes
 	// - CRC and other page header variations
-	headerInfo, err := pr.GetFirstDataPageHeader(rowGroupIndex, columnIndex)
+	headerInfo, err := pr.GetFirstDataPageHeaderWithContext(context.Background(), rowGroupIndex, columnIndex)
 	if err != nil {
 		return 0, fmt.Errorf("read first data page header: %w", err)
 	}

--- a/schema/schematree.go
+++ b/schema/schematree.go
@@ -16,12 +16,8 @@ import (
 // readFirstDataPageEncoding reads the first data page header to get its encoding.
 // Uses the parquet-go library's GetFirstDataPageHeader which efficiently reads only
 // the first data page, skipping any dictionary pages.
-func readFirstDataPageEncoding(pr *reader.ParquetReader, rowGroupIndex, columnIndex int) (parquet.Encoding, error) {
-	// Use parquet-go's GetFirstDataPageHeader which correctly handles:
-	// - Dictionary pages at DataPageOffset
-	// - Proper offset calculation including header sizes
-	// - CRC and other page header variations
-	headerInfo, err := pr.GetFirstDataPageHeaderWithContext(context.Background(), rowGroupIndex, columnIndex)
+func readFirstDataPageEncoding(ctx context.Context, pr *reader.ParquetReader, rowGroupIndex, columnIndex int) (parquet.Encoding, error) {
+	headerInfo, err := pr.GetFirstDataPageHeaderWithContext(ctx, rowGroupIndex, columnIndex)
 	if err != nil {
 		return 0, fmt.Errorf("read first data page header: %w", err)
 	}
@@ -33,7 +29,7 @@ func readFirstDataPageEncoding(pr *reader.ParquetReader, rowGroupIndex, columnIn
 // For each column, it reads the page header at DataPageOffset to get the actual data page encoding.
 // Note: Parquet files should use consistent encodings across row groups for the same column.
 // This function reads columns in parallel to speed up remote file access.
-func buildEncodingMap(pr *reader.ParquetReader) (map[string]string, error) {
+func buildEncodingMap(ctx context.Context, pr *reader.ParquetReader) (map[string]string, error) {
 	result := make(map[string]string)
 
 	// Use the first row group to extract encodings
@@ -47,7 +43,7 @@ func buildEncodingMap(pr *reader.ParquetReader) (map[string]string, error) {
 	var mu sync.Mutex
 
 	// Process columns in parallel, use runtime.NumCPU() to match available cores
-	g := new(errgroup.Group)
+	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(runtime.NumCPU())
 
 	for colIndex, col := range columns {
@@ -75,7 +71,7 @@ func buildEncodingMap(pr *reader.ParquetReader) (map[string]string, error) {
 			}
 
 			// Read just the first data page header to get encoding
-			encoding, err := readFirstDataPageEncoding(clonedReader, 0, colIndex)
+			encoding, err := readFirstDataPageEncoding(gctx, clonedReader, 0, colIndex)
 			if err != nil {
 				return fmt.Errorf("failed to read encoding for column [%s]: %w", pathKey, err)
 			}
@@ -172,12 +168,12 @@ func BloomFilterSizeMap(pr *reader.ParquetReader) map[string]int32 {
 	return result
 }
 
-func NewSchemaTree(reader *reader.ParquetReader, option SchemaOption) (*SchemaNode, error) {
+func NewSchemaTree(ctx context.Context, reader *reader.ParquetReader, option SchemaOption) (*SchemaNode, error) {
 	// Extract encoding information from the parquet file unless SkipPageEncoding is set
 	var encodingMap map[string]string
 	if !option.SkipPageEncoding {
 		var err error
-		encodingMap, err = buildEncodingMap(reader)
+		encodingMap, err = buildEncodingMap(ctx, reader)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build encoding map: %w", err)
 		}

--- a/testdata/gen/all-types/main.go
+++ b/testdata/gen/all-types/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -88,15 +89,16 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(AllTypes), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(AllTypes),
+		writer.WithNP(4),
+		writer.WithRowGroupSize(128*1024*1024),
+		writer.WithPageSize(8*1024),
+		writer.WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
-
-	pw.RowGroupSize = 128 * 1024 * 1024
-	pw.PageSize = 8 * 1024
-	pw.CompressionCodec = parquet.CompressionCodec_SNAPPY
 	decimals := []int32{0, 1, 22, 333, 4444, 0, -1, -22, -333, -4444}
 	interval := make([]byte, 4)
 	for i := range 5 {
@@ -183,11 +185,11 @@ func main() {
 			value.NestedList = append(value.NestedList, nested)
 		}
 
-		if err = pw.Write(value); err != nil {
+		if err = pw.WriteWithContext(context.Background(), value); err != nil {
 			fmt.Println("Write error", err)
 		}
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/bloom-filter/main.go
+++ b/testdata/gen/bloom-filter/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -23,13 +24,14 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(BloomFilterData), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(BloomFilterData),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
-
-	pw.CompressionCodec = parquet.CompressionCodec_SNAPPY
 	for i := range 10 {
 		value := BloomFilterData{
 			ID:       int64(i),
@@ -38,12 +40,12 @@ func main() {
 			Score:    float64(i) * 1.5,
 			Category: fmt.Sprintf("cat-%d", i%3),
 		}
-		if err = pw.Write(value); err != nil {
+		if err = pw.WriteWithContext(context.Background(), value); err != nil {
 			fmt.Println("Write error", err)
 			return
 		}
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/crc32/main.go
+++ b/testdata/gen/crc32/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -20,19 +21,21 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Shoe), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Shoe),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_GZIP),
+		writer.WithDataPageVersion(2),
+		writer.WithWriteCRC(true),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
 
-	pw.CompressionCodec = parquet.CompressionCodec_GZIP
-	pw.DataPageVersion = 2 // Use DATA_PAGE_V2 format
-	pw.WriteCRC = true
-	_ = pw.Write(Shoe{"nike", "air_griffey"})
-	_ = pw.Write(Shoe{"fila", "grant_hill_2"})
-	_ = pw.Write(Shoe{"steph_curry", "curry7"})
-	if err = pw.WriteStop(); err != nil {
+	_ = pw.WriteWithContext(context.Background(), Shoe{"nike", "air_griffey"})
+	_ = pw.WriteWithContext(context.Background(), Shoe{"fila", "grant_hill_2"})
+	_ = pw.WriteWithContext(context.Background(), Shoe{"steph_curry", "curry7"})
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/csv/main.go
+++ b/testdata/gen/csv/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -30,16 +31,18 @@ func good() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Student), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Student),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_GZIP),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
 
-	pw.CompressionCodec = parquet.CompressionCodec_GZIP
-	_ = pw.Write(Student{123, "John Doe", 30, 98.2, false})
-	_ = pw.Write(Student{123, "Jane Doe", 25, 98.7, true})
-	if err = pw.WriteStop(); err != nil {
+	_ = pw.WriteWithContext(context.Background(), Student{123, "John Doe", 30, 98.2, false})
+	_ = pw.WriteWithContext(context.Background(), Student{123, "Jane Doe", 25, 98.7, true})
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}
@@ -61,16 +64,18 @@ func optional() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Student), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Student),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_GZIP),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
 
-	pw.CompressionCodec = parquet.CompressionCodec_GZIP
-	_ = pw.Write(Student{123, "John Doe", 30, nil, false})
-	_ = pw.Write(Student{123, "Jane Doe", 25, nil, true})
-	if err = pw.WriteStop(); err != nil {
+	_ = pw.WriteWithContext(context.Background(), Student{123, "John Doe", 30, nil, false})
+	_ = pw.WriteWithContext(context.Background(), Student{123, "Jane Doe", 25, nil, true})
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}
@@ -92,16 +97,18 @@ func repeated() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Student), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Student),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_GZIP),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
 
-	pw.CompressionCodec = parquet.CompressionCodec_GZIP
-	_ = pw.Write(Student{123, "John Doe", 30, []float32{}, false})
-	_ = pw.Write(Student{123, "Jane Doe", 25, []float32{98.1, 99.2}, true})
-	if err = pw.WriteStop(); err != nil {
+	_ = pw.WriteWithContext(context.Background(), Student{123, "John Doe", 30, []float32{}, false})
+	_ = pw.WriteWithContext(context.Background(), Student{123, "Jane Doe", 25, []float32{98.1, 99.2}, true})
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}
@@ -123,16 +130,18 @@ func nested() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Student), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Student),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_GZIP),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
 
-	pw.CompressionCodec = parquet.CompressionCodec_GZIP
-	_ = pw.Write(Student{123, "John Doe", 30, []float32{}, false})
-	_ = pw.Write(Student{123, "Jane Doe", 25, []float32{98.4, 99.3}, true})
-	if err = pw.WriteStop(); err != nil {
+	_ = pw.WriteWithContext(context.Background(), Student{123, "John Doe", 30, []float32{}, false})
+	_ = pw.WriteWithContext(context.Background(), Student{123, "Jane Doe", 25, []float32{98.4, 99.3}, true})
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/data-page-v2/main.go
+++ b/testdata/gen/data-page-v2/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -20,18 +21,20 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Shoe), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Shoe),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_GZIP),
+		writer.WithDataPageVersion(2),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
 
-	pw.CompressionCodec = parquet.CompressionCodec_GZIP
-	pw.DataPageVersion = 2 // Use DATA_PAGE_V2 format
-	_ = pw.Write(Shoe{"nike", "air_griffey"})
-	_ = pw.Write(Shoe{"fila", "grant_hill_2"})
-	_ = pw.Write(Shoe{"steph_curry", "curry7"})
-	if err = pw.WriteStop(); err != nil {
+	_ = pw.WriteWithContext(context.Background(), Shoe{"nike", "air_griffey"})
+	_ = pw.WriteWithContext(context.Background(), Shoe{"fila", "grant_hill_2"})
+	_ = pw.WriteWithContext(context.Background(), Shoe{"steph_curry", "curry7"})
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/dict-page/main.go
+++ b/testdata/gen/dict-page/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -20,13 +21,14 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Shoe), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Shoe),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_GZIP),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
-
-	pw.CompressionCodec = parquet.CompressionCodec_GZIP
 
 	// Create records with repeating brand values to benefit from dictionary encoding
 	brands := []string{"nike", "adidas", "reebok"}
@@ -36,13 +38,13 @@ func main() {
 			ShoeBrand: brands[i%len(brands)],
 			ShoeName:  shoe,
 		}
-		if err = pw.Write(shoe); err != nil {
+		if err = pw.WriteWithContext(context.Background(), shoe); err != nil {
 			fmt.Println("Write error", err)
 			return
 		}
 	}
 
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/empty/main.go
+++ b/testdata/gen/empty/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -18,13 +19,15 @@ func main() {
 		log.Println("Can't create file", err)
 		return
 	}
-	pw, err := writer.NewParquetWriter(fw, new(Dummy), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Dummy),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_UNCOMPRESSED),
+	)
 	if err != nil {
 		log.Println("Can't create parquet writer", err)
 		return
 	}
-	pw.CompressionCodec = parquet.CompressionCodec_UNCOMPRESSED
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		log.Println("WriteStop error", err)
 	}
 	_ = fw.Close()

--- a/testdata/gen/geospatial/main.go
+++ b/testdata/gen/geospatial/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -23,15 +24,16 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Geospatial), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Geospatial),
+		writer.WithNP(4),
+		writer.WithRowGroupSize(128*1024*1024),
+		writer.WithPageSize(8*1024),
+		writer.WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
-
-	pw.RowGroupSize = 128 * 1024 * 1024
-	pw.PageSize = 8 * 1024
-	pw.CompressionCodec = parquet.CompressionCodec_SNAPPY
 	for i := range 10 {
 		var geom, geog []byte
 		switch i % 7 {
@@ -79,11 +81,11 @@ func main() {
 			Geography: string(geog),
 		}
 
-		if err = pw.Write(value); err != nil {
+		if err = pw.WriteWithContext(context.Background(), value); err != nil {
 			fmt.Println("Write error", err)
 		}
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/good/main.go
+++ b/testdata/gen/good/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -25,17 +26,22 @@ func writeFile(filename string, codec parquet.CompressionCodec) error {
 		return fmt.Errorf("can't create local file %s: %w", filename, err)
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Shoe), 4)
+	pw, err := writer.NewParquetWriterWithContext(
+		context.Background(),
+		fw,
+		new(Shoe),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(codec),
+	)
 	if err != nil {
 		_ = fw.Close()
 		return fmt.Errorf("can't create parquet writer for %s: %w", filename, err)
 	}
 
-	pw.CompressionCodec = codec
 	for _, s := range shoes {
-		_ = pw.Write(s)
+		_ = pw.WriteWithContext(context.Background(), s)
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		return fmt.Errorf("WriteStop error for %s: %w", filename, err)
 	}
 	_ = fw.Close()

--- a/testdata/gen/gostruct-list/main.go
+++ b/testdata/gen/gostruct-list/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strconv"
@@ -27,15 +28,16 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(ListTypes), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(ListTypes),
+		writer.WithNP(4),
+		writer.WithRowGroupSize(128*1024*1024),
+		writer.WithPageSize(8*1024),
+		writer.WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
-
-	pw.RowGroupSize = 128 * 1024 * 1024
-	pw.PageSize = 8 * 1024
-	pw.CompressionCodec = parquet.CompressionCodec_SNAPPY
 	for i := range 3 {
 		value := ListTypes{
 			ListOfStruct: slices.Repeat([]NestedStruct{{
@@ -45,11 +47,11 @@ func main() {
 			ListOfString: slices.Repeat([]string{strconv.FormatInt(int64(i), 10)}, i),
 		}
 
-		if err = pw.Write(value); err != nil {
+		if err = pw.WriteWithContext(context.Background(), value); err != nil {
 			fmt.Println("Write error", err)
 		}
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/high-compression/main.go
+++ b/testdata/gen/high-compression/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -23,25 +24,27 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Record), 1)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Record),
+		writer.WithNP(1),
+		writer.WithCompressionCodec(parquet.CompressionCodec_ZSTD),
+		writer.WithRowGroupSize(512*1024*1024), // 512MB row groups
+		writer.WithPageSize(512*1024*1024),     // 512MB pages to maximize compression ratio
+	)
 	if err != nil {
 		fmt.Printf("Can't create writer: %v", err)
 		return
 	}
-	pw.CompressionCodec = parquet.CompressionCodec_ZSTD
-	pw.RowGroupSize = 512 * 1024 * 1024 // 512MB row groups
-	pw.PageSize = 512 * 1024 * 1024     // 512MB pages to maximize compression ratio
 
 	// Write 2M identical records — compresses extremely well with PLAIN encoding
 	const numRecords = 2_000_000
 	repeatedValue := "this is a repeated value that appears in every single row of the parquet file"
 	for range numRecords {
-		if err = pw.Write(Record{Value: repeatedValue}); err != nil {
+		if err = pw.WriteWithContext(context.Background(), Record{Value: repeatedValue}); err != nil {
 			fmt.Printf("Write error: %v", err)
 			return
 		}
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Printf("WriteStop error: %v", err)
 		return
 	}

--- a/testdata/gen/int96-nil-min-max/main.go
+++ b/testdata/gen/int96-nil-min-max/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -20,23 +21,25 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(AllTypes), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(AllTypes),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_ZSTD),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
 
-	pw.CompressionCodec = parquet.CompressionCodec_ZSTD
 	for i := range 10 {
 		value := AllTypes{
 			Int96: nil,
 			Utf8:  fmt.Sprintf("UTF8-%d", i),
 		}
-		if err = pw.Write(value); err != nil {
+		if err = pw.WriteWithContext(context.Background(), value); err != nil {
 			fmt.Println("Write error", err)
 		}
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/list-of-list/main.go
+++ b/testdata/gen/list-of-list/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -43,14 +44,16 @@ func main() {
 	}
 
 	// write
-	pw, err := writer.NewParquetWriter(fw, jsonSchema, 1)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, jsonSchema,
+		writer.WithNP(1),
+		writer.WithRowGroupSize(128*1024*1024),
+		writer.WithCompressionCodec(parquet.CompressionCodec_LZ4),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		os.Exit(1)
 	}
 
-	pw.RowGroupSize = 128 * 1024 * 1024 // 128M
-	pw.CompressionCodec = parquet.CompressionCodec_LZ4
 	for i := range 5 {
 		rec := RecordType{
 			Lol: make([][]string, i),
@@ -61,11 +64,11 @@ func main() {
 				rec.Lol[j][k] = fmt.Sprintf("%d-%d-%d", i+1, j+1, k+1)
 			}
 		}
-		if err = pw.Write(rec); err != nil {
+		if err = pw.WriteWithContext(context.Background(), rec); err != nil {
 			fmt.Println("Write error", err)
 		}
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		os.Exit(1)
 	}

--- a/testdata/gen/map-value-map/main.go
+++ b/testdata/gen/map-value-map/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -54,14 +55,16 @@ func main() {
 	}
 
 	// write
-	pw, err := writer.NewParquetWriter(fw, jsonSchema, 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, jsonSchema,
+		writer.WithNP(4),
+		writer.WithRowGroupSize(128*1024*1024),
+		writer.WithCompressionCodec(parquet.CompressionCodec_LZ4_RAW),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		os.Exit(1)
 	}
 
-	pw.RowGroupSize = 128 * 1024 * 1024 // 128M
-	pw.CompressionCodec = parquet.CompressionCodec_LZ4_RAW
 	for i := range 10 {
 		stu := Student{
 			Name: "StudentName" + strconv.Itoa(i+1),
@@ -76,11 +79,11 @@ func main() {
 				},
 			},
 		}
-		if err = pw.Write(stu); err != nil {
+		if err = pw.WriteWithContext(context.Background(), stu); err != nil {
 			fmt.Println("Write error", err)
 		}
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		os.Exit(1)
 	}

--- a/testdata/gen/nan/main.go
+++ b/testdata/gen/nan/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"math"
 
@@ -18,7 +19,7 @@ func main() {
 		log.Fatalf("Failed to create file: %v", err)
 	}
 
-	pw, err := writer.NewParquetWriter(file, new(Data), 1)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), file, new(Data), writer.WithNP(1))
 	if err != nil {
 		log.Fatalf("Failed to create parquet writer: %v", err)
 	}
@@ -27,11 +28,11 @@ func main() {
 		Value: math.NaN(),
 	}
 
-	if err := pw.Write(data); err != nil {
+	if err := pw.WriteWithContext(context.Background(), data); err != nil {
 		log.Fatalf("Failed to write data: %v", err)
 	}
 
-	if err := pw.WriteStop(); err != nil {
+	if err := pw.WriteStopWithContext(context.Background()); err != nil {
 		log.Fatalf("Failed to close parquet writer: %v", err)
 	}
 

--- a/testdata/gen/optional-fields/main.go
+++ b/testdata/gen/optional-fields/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -27,21 +28,23 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Row), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Row),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_GZIP),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
 
-	pw.CompressionCodec = parquet.CompressionCodec_GZIP
-	_ = pw.Write(Row{nil, nil, nil, nil})
-	_ = pw.Write(Row{
+	_ = pw.WriteWithContext(context.Background(), Row{nil, nil, nil, nil})
+	_ = pw.WriteWithContext(context.Background(), Row{
 		Field1: toPtr([]string{"val1", "val2"}),
 		Field2: toPtr(map[string]string{"val1": "val2"}),
 		Field3: toPtr(SubStruct{Foo: "bar"}),
 		Field4: toPtr(types.StrIntToBinary("123", "BigEndian", 12, true)),
 	})
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/pargo-prefix/main.go
+++ b/testdata/gen/pargo-prefix/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -35,15 +36,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(PargoPrefix), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(PargoPrefix),
+		writer.WithNP(4),
+		writer.WithRowGroupSize(128*1024*1024),
+		writer.WithPageSize(8*1024),
+		writer.WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		os.Exit(1)
 	}
 
-	pw.RowGroupSize = 128 * 1024 * 1024
-	pw.PageSize = 8 * 1024
-	pw.CompressionCodec = parquet.CompressionCodec_SNAPPY
 	decimals := []int32{0, 1, 22, 333, 4444, 0, -1, -22, -333, -4444}
 	for i := range 10 {
 		value := PargoPrefix{
@@ -65,11 +68,11 @@ func main() {
 			value.NestedList = append(value.NestedList, nested)
 		}
 
-		if err = pw.Write(value); err != nil {
+		if err = pw.WriteWithContext(context.Background(), value); err != nil {
 			fmt.Println("Write error", err)
 		}
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		os.Exit(1)
 	}
@@ -82,17 +85,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	pw, err = writer.NewParquetWriter(fw, new(Shoe), 4)
+	pw, err = writer.NewParquetWriterWithContext(context.Background(), fw, new(Shoe),
+		writer.WithNP(4),
+		writer.WithCompressionCodec(parquet.CompressionCodec_GZIP),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		os.Exit(1)
 	}
 
-	pw.CompressionCodec = parquet.CompressionCodec_GZIP
-	_ = pw.Write(Shoe{"nike", "air_griffey"})
-	_ = pw.Write(Shoe{"fila", "grant_hill_2"})
-	_ = pw.Write(Shoe{"steph_curry", "curry7"})
-	if err = pw.WriteStop(); err != nil {
+	_ = pw.WriteWithContext(context.Background(), Shoe{"nike", "air_griffey"})
+	_ = pw.WriteWithContext(context.Background(), Shoe{"fila", "grant_hill_2"})
+	_ = pw.WriteWithContext(context.Background(), Shoe{"steph_curry", "curry7"})
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		os.Exit(1)
 	}

--- a/testdata/gen/retype/main.go
+++ b/testdata/gen/retype/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -91,8 +92,8 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(
-		fw, new(RetypeTest),
+	pw, err := writer.NewParquetWriterWithContext(
+		context.Background(), fw, new(RetypeTest),
 		writer.WithNP(4),
 		writer.WithRowGroupSize(128*1024*1024),
 		writer.WithPageSize(8*1024),
@@ -231,12 +232,12 @@ func main() {
 		_ = listElemBsonStr
 		_ = mapValueBsonStr
 
-		if err = pw.Write(value); err != nil {
+		if err = pw.WriteWithContext(context.Background(), value); err != nil {
 			fmt.Println("Write error", err)
 		}
 	}
 
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/row-group/main.go
+++ b/testdata/gen/row-group/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -21,19 +22,21 @@ func main() {
 		return
 	}
 
-	pw, err := writer.NewParquetWriter(fw, new(Something), 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(Something),
+		writer.WithNP(4),
+		writer.WithRowGroupSize(256),
+		writer.WithPageSize(32),
+		writer.WithCompressionCodec(parquet.CompressionCodec_GZIP),
+	)
 	if err != nil {
 		fmt.Println("Can't create parquet writer", err)
 		return
 	}
-	pw.RowGroupSize = 256
-	pw.PageSize = 32
-	pw.CompressionCodec = parquet.CompressionCodec_GZIP
 
 	for i := range 20 {
-		_ = pw.Write(Something{"the brand is: " + strconv.Itoa(i), "the name is: " + strconv.Itoa(i)})
+		_ = pw.WriteWithContext(context.Background(), Something{"the brand is: " + strconv.Itoa(i), "the name is: " + strconv.Itoa(i)})
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		fmt.Println("WriteStop error", err)
 		return
 	}

--- a/testdata/gen/top-level-tag/main.go
+++ b/testdata/gen/top-level-tag/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -62,24 +63,26 @@ func genParquet(name, jsonSchema string) error {
 	}
 
 	// write
-	pw, err := writer.NewParquetWriter(fw, jsonSchema, 4)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, jsonSchema,
+		writer.WithNP(4),
+		writer.WithRowGroupSize(128*1024*1024),
+		writer.WithCompressionCodec(parquet.CompressionCodec_LZ4_RAW),
+	)
 	if err != nil {
 		return fmt.Errorf("cannot create parquet writer: %w", err)
 	}
 
-	pw.RowGroupSize = 128 * 1024 * 1024 // 128M
-	pw.CompressionCodec = parquet.CompressionCodec_LZ4_RAW
 	for i := range 3 {
 		stu := Student{
 			Name: "StudentName" + strconv.Itoa(i),
 			Id:   int64(i * i),
 		}
 
-		if err = pw.Write(stu); err != nil {
+		if err = pw.WriteWithContext(context.Background(), stu); err != nil {
 			return fmt.Errorf("error from Write(): %w", err)
 		}
 	}
-	if err = pw.WriteStop(); err != nil {
+	if err = pw.WriteStopWithContext(context.Background()); err != nil {
 		return fmt.Errorf("error from WriteStop(): %w", err)
 	}
 	_ = fw.Close()

--- a/testdata/gen/unknown-type/main.go
+++ b/testdata/gen/unknown-type/main.go
@@ -40,7 +40,8 @@ func writeBase(path string) error {
 	if err != nil {
 		return err
 	}
-	pw, err := writer.NewParquetWriter(
+	pw, err := writer.NewParquetWriterWithContext(
+		context.Background(),
 		fw, new(plainRow),
 		writer.WithRowGroupSize(128*1024*1024),
 		writer.WithPageSize(8*1024),
@@ -55,11 +56,11 @@ func writeBase(path string) error {
 		{ID: new(int32(2)), UnknownCol: nil, Name: new("bob")},
 		{ID: new(int32(3)), UnknownCol: new(int32(30)), Name: new("charlie")},
 	} {
-		if err := pw.Write(row); err != nil {
+		if err := pw.WriteWithContext(context.Background(), row); err != nil {
 			return err
 		}
 	}
-	if err := pw.WriteStop(); err != nil {
+	if err := pw.WriteStopWithContext(context.Background()); err != nil {
 		return err
 	}
 	return fw.Close()


### PR DESCRIPTION
## Changes

- Upgrade `parquet-go` to v3.5.0 and migrate deprecated calls to context-aware APIs.
- Add `context.Context` parameters to Parquet reader, writer, pipeline, encryption, and schema operations.
- Propagate the context through every CLI command and inspection helper.
- Create a signal-aware root context using `signal.NotifyContext`.
- Cancel active operations on Ctrl+C or `SIGTERM`.
- Preserve cancellation during writer finalization and reader cleanup.
- Update tests and test-data generators for the context-aware APIs.
- Document command cancellation behavior.

## Validation

- `make all`