### PR TITLE
fix(cat): handle skips across uneven row groups

### DIFF
--- a/cmd/cat/cat_test.go
+++ b/cmd/cat/cat_test.go
@@ -194,6 +194,14 @@ func TestCmd(t *testing.T) {
 			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "row-group.parquet"},
 			golden: "cat-row-group.jsonl",
 		},
+		"skip-uneven-row-groups": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 3, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "row-group.parquet"},
+			golden: "cat-row-group-skip-3.jsonl",
+		},
+		"skip-across-uneven-row-groups": {
+			cmd:    Cmd{ReadOption: rOpt, Skip: 18, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "row-group.parquet"},
+			golden: "cat-row-group-skip-18.jsonl",
+		},
 		"dict-page": {
 			cmd:    Cmd{ReadOption: rOpt, Skip: 0, Limit: 0, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl", NoHeader: true, URI: "dict-page.parquet"},
 			golden: "cat-dict-page.jsonl",

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.31
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.0
 	github.com/google/uuid v1.6.0
-	github.com/hangxie/parquet-go/v3 v3.5.0
+	github.com/hangxie/parquet-go/v3 v3.5.1
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.11.1
 	github.com/willabides/kongplete v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyC
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
-github.com/hangxie/parquet-go/v3 v3.5.0 h1:XLvQbURcgn3MhNtJI40YEyNYNjVx9IpfawiZu/wqxQs=
-github.com/hangxie/parquet-go/v3 v3.5.0/go.mod h1:yzDf7xEK3eX1iubBqTadQRbVAzKbq2Cz2xuvFoNaY1c=
+github.com/hangxie/parquet-go/v3 v3.5.1 h1:2QU0Y0gZ809QGHmcHJ6FryKWrOkbBuyzGrCRRIgMHeQ=
+github.com/hangxie/parquet-go/v3 v3.5.1/go.mod h1:yzDf7xEK3eX1iubBqTadQRbVAzKbq2Cz2xuvFoNaY1c=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/scripts/update-golden.sh
+++ b/scripts/update-golden.sh
@@ -135,6 +135,12 @@ $PT cat --format jsonl "$TESTDATA_DIR/old-style-list.parquet" | format_jsonl > "
 # cat-row-group.jsonl
 $PT cat --format jsonl "$TESTDATA_DIR/row-group.parquet" | format_jsonl > "$GOLDEN_DIR/cat-row-group.jsonl"
 
+# cat-row-group-skip-3.jsonl
+$PT cat --format jsonl --skip 3 --limit 1 "$TESTDATA_DIR/row-group.parquet" | format_jsonl > "$GOLDEN_DIR/cat-row-group-skip-3.jsonl"
+
+# cat-row-group-skip-18.jsonl
+$PT cat --format jsonl --skip 18 --limit 1 "$TESTDATA_DIR/row-group.parquet" | format_jsonl > "$GOLDEN_DIR/cat-row-group-skip-18.jsonl"
+
 # cat-dict-page.jsonl
 $PT cat --format jsonl "$TESTDATA_DIR/dict-page.parquet" | format_jsonl > "$GOLDEN_DIR/cat-dict-page.jsonl"
 

--- a/testdata/golden/cat-row-group-skip-18.jsonl
+++ b/testdata/golden/cat-row-group-skip-18.jsonl
@@ -1,0 +1,4 @@
+{
+  "brand": "the brand is: 18",
+  "name": "the name is: 18"
+}

--- a/testdata/golden/cat-row-group-skip-3.jsonl
+++ b/testdata/golden/cat-row-group-skip-3.jsonl
@@ -1,0 +1,4 @@
+{
+  "brand": "the brand is: 3",
+  "name": "the name is: 3"
+}


### PR DESCRIPTION
## Summary

- add a cat regression test for skipping rows across uneven row groups
- add the corresponding golden output and regeneration command
- update github.com/hangxie/parquet-go/v3 from v3.5.0 to v3.5.1

## Regression

With v3.5.0, skipping 3 rows in the 17-row/3-row fixture returned row 17 instead of row 3. The new test passes with v3.5.1.

## Validation

- make all
