### PR TITLE
test(import): cover V2 dictionary page encoding

### DIFF
--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hangxie/parquet-tools/cmd/cat"
+	"github.com/hangxie/parquet-tools/cmd/inspect"
 	"github.com/hangxie/parquet-tools/cmd/internal/testutils"
 	pio "github.com/hangxie/parquet-tools/io"
 )
@@ -230,6 +231,33 @@ func TestCmd(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestCmdDefaultDataPageVersionWithDictionaryEncoding(t *testing.T) {
+	tempDir := t.TempDir()
+	testdataDir := filepath.Join("..", "..", "testdata")
+	goldenDir := filepath.Join("..", "..", "testdata", "golden")
+	uri := filepath.Join(tempDir, "dictionary.parquet")
+
+	require.NoError(t, (Cmd{
+		Source: filepath.Join(testdataDir, "jsonl.source"),
+		Format: "jsonl",
+		Schema: filepath.Join(testdataDir, "jsonl.schema"),
+		URI:    uri,
+	}).Run(context.Background()))
+
+	stdout, stderr := testutils.CaptureStdoutStderr(func() {
+		require.NoError(t, (inspect.Cmd{
+			URI:         uri,
+			RowGroup:    new(0),
+			ColumnChunk: new(1),
+		}).Run(context.Background()))
+	})
+	require.Equal(t,
+		testutils.LoadExpected(t, filepath.Join(goldenDir, "import-dict-page-v2-inspect.json")),
+		stdout,
+	)
+	require.Empty(t, stderr)
 }
 
 func TestCmdEncryption(t *testing.T) {

--- a/scripts/update-golden.sh
+++ b/scripts/update-golden.sh
@@ -89,6 +89,23 @@ assert_all_golden_files_covered() {
 echo "Updating golden files..."
 
 # ============================================================================
+# import command golden files
+# ============================================================================
+echo "  import command..."
+
+IMPORT_TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$IMPORT_TEMP_DIR"' EXIT
+
+$PT import --format jsonl --schema "$TESTDATA_DIR/jsonl.schema" --source "$TESTDATA_DIR/jsonl.source" "$IMPORT_TEMP_DIR/dictionary.parquet"
+
+# import-dict-page-v2-inspect.json
+$PT inspect --row-group 0 --column-chunk 1 "$IMPORT_TEMP_DIR/dictionary.parquet" |
+    format_json > "$GOLDEN_DIR/import-dict-page-v2-inspect.json"
+
+rm -rf "$IMPORT_TEMP_DIR"
+trap - EXIT
+
+# ============================================================================
 # cat command golden files
 # ============================================================================
 echo "  cat command..."

--- a/testdata/golden/import-dict-page-v2-inspect.json
+++ b/testdata/golden/import-dict-page-v2-inspect.json
@@ -1,0 +1,132 @@
+{
+  "columnChunk": {
+    "columnChunkIndex": 1,
+    "compressedSize": 367,
+    "compressionCodec": "SNAPPY",
+    "dataPageOffset": 276,
+    "dictionaryPageOffset": 199,
+    "encodings": [
+      "PLAIN",
+      "RLE",
+      "RLE_DICTIONARY"
+    ],
+    "numValues": 10,
+    "pathInSchema": [
+      "ByteArray"
+    ],
+    "rowGroupIndex": 0,
+    "statistics": {
+      "maxValue": "Qnl0ZUFycmF5LTk=",
+      "minValue": "Qnl0ZUFycmF5LTA=",
+      "nullCount": 0
+    },
+    "type": "BYTE_ARRAY",
+    "uncompressedSize": 454
+  },
+  "pages": [
+    {
+      "index": 0,
+      "offset": 199,
+      "type": "DICTIONARY_PAGE",
+      "compressedSize": 63,
+      "uncompressedSize": 150,
+      "numValues": 10,
+      "encoding": "PLAIN"
+    },
+    {
+      "index": 1,
+      "offset": 276,
+      "type": "DATA_PAGE_V2",
+      "compressedSize": 6,
+      "uncompressedSize": 6,
+      "numValues": 2,
+      "encoding": "RLE_DICTIONARY",
+      "numNulls": 0,
+      "numRows": 2,
+      "definitionLevelsByteLength": 0,
+      "repetitionLevelsByteLength": 0,
+      "isCompressed": false,
+      "statistics": {
+        "maxValue": "Qnl0ZUFycmF5LTE=",
+        "minValue": "Qnl0ZUFycmF5LTA=",
+        "nullCount": 0
+      }
+    },
+    {
+      "index": 2,
+      "offset": 334,
+      "type": "DATA_PAGE_V2",
+      "compressedSize": 6,
+      "uncompressedSize": 6,
+      "numValues": 2,
+      "encoding": "RLE_DICTIONARY",
+      "numNulls": 0,
+      "numRows": 2,
+      "definitionLevelsByteLength": 0,
+      "repetitionLevelsByteLength": 0,
+      "isCompressed": false,
+      "statistics": {
+        "maxValue": "Qnl0ZUFycmF5LTM=",
+        "minValue": "Qnl0ZUFycmF5LTI=",
+        "nullCount": 0
+      }
+    },
+    {
+      "index": 3,
+      "offset": 392,
+      "type": "DATA_PAGE_V2",
+      "compressedSize": 6,
+      "uncompressedSize": 6,
+      "numValues": 2,
+      "encoding": "RLE_DICTIONARY",
+      "numNulls": 0,
+      "numRows": 2,
+      "definitionLevelsByteLength": 0,
+      "repetitionLevelsByteLength": 0,
+      "isCompressed": false,
+      "statistics": {
+        "maxValue": "Qnl0ZUFycmF5LTU=",
+        "minValue": "Qnl0ZUFycmF5LTQ=",
+        "nullCount": 0
+      }
+    },
+    {
+      "index": 4,
+      "offset": 450,
+      "type": "DATA_PAGE_V2",
+      "compressedSize": 6,
+      "uncompressedSize": 6,
+      "numValues": 2,
+      "encoding": "RLE_DICTIONARY",
+      "numNulls": 0,
+      "numRows": 2,
+      "definitionLevelsByteLength": 0,
+      "repetitionLevelsByteLength": 0,
+      "isCompressed": false,
+      "statistics": {
+        "maxValue": "Qnl0ZUFycmF5LTc=",
+        "minValue": "Qnl0ZUFycmF5LTY=",
+        "nullCount": 0
+      }
+    },
+    {
+      "index": 5,
+      "offset": 508,
+      "type": "DATA_PAGE_V2",
+      "compressedSize": 6,
+      "uncompressedSize": 6,
+      "numValues": 2,
+      "encoding": "RLE_DICTIONARY",
+      "numNulls": 0,
+      "numRows": 2,
+      "definitionLevelsByteLength": 0,
+      "repetitionLevelsByteLength": 0,
+      "isCompressed": false,
+      "statistics": {
+        "maxValue": "Qnl0ZUFycmF5LTk=",
+        "minValue": "Qnl0ZUFycmF5LTg=",
+        "nullCount": 0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add an end-to-end import regression test for the default data page version with dictionary encoding
- inspect generated page headers and compare normalized page type/encoding pairs with a golden file
- regenerate the inspect golden through `scripts/update-golden.sh`

## Verification

- `make all`
- parquet-go v3.5.0: regression test fails with `DATA_PAGE` instead of `DATA_PAGE_V2`
- parquet-go v3.5.1: regression test passes with `DATA_PAGE_V2` and `RLE_DICTIONARY`