### PR TITLE
fix(import): handle long JSONL lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,7 @@ $ parquet-tools row-count /tmp/json.parquet
 #### Import from JSONL
 
 JSONL is [line-delimited JSON streaming format](https://en.wikipedia.org/wiki/JSON_streaming#Line-delimited_JSON), use JSONL if you want to load multiple JSON objects into parquet.
+JSONL records may be up to 16 MiB by default, excluding the line delimiter. Use `--jsonl-max-line-size` to set a different limit in bytes; import fails with an error if a record exceeds the limit.
 
 ```bash
 $ parquet-tools import -f jsonl -s testdata/jsonl.source -m testdata/jsonl.schema /tmp/jsonl.parquet

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strings"
 	"time"
@@ -17,14 +18,20 @@ import (
 	pio "github.com/hangxie/parquet-tools/io"
 )
 
+const (
+	defaultJSONLMaxLineSize = 16 * 1024 * 1024
+	maxJSONLDelimiterSize   = 2
+)
+
 // Cmd is a kong command for import
 type Cmd struct {
-	FieldDelimiter string `name:"field-delimiter" help:"Delimiter separating nested field path components in field and column parameters" default:"."`
-	Format         string `help:"Source file formats (csv/json/jsonl)." short:"f" enum:"csv,json,jsonl" default:"csv"`
-	Schema         string `required:"" short:"m" predictor:"file" help:"Schema file name."`
-	SkipHeader     bool   `help:"Skip first line of CSV files" default:"false"`
-	Source         string `required:"" short:"s" predictor:"file" help:"Source file name."`
-	URI            string `arg:"" predictor:"file" help:"URI of Parquet file."`
+	FieldDelimiter   string `name:"field-delimiter" help:"Delimiter separating nested field path components in field and column parameters" default:"."`
+	Format           string `help:"Source file formats (csv/json/jsonl)." short:"f" enum:"csv,json,jsonl" default:"csv"`
+	JSONLMaxLineSize int    `name:"jsonl-max-line-size" help:"Maximum JSONL record size in bytes, excluding the line delimiter." default:"16777216"`
+	Schema           string `required:"" short:"m" predictor:"file" help:"Schema file name."`
+	SkipHeader       bool   `help:"Skip first line of CSV files" default:"false"`
+	Source           string `required:"" short:"s" predictor:"file" help:"Source file name."`
+	URI              string `arg:"" predictor:"file" help:"URI of Parquet file."`
 	pio.WriteOption
 }
 
@@ -161,6 +168,17 @@ func (c Cmd) importJSON(ctx context.Context) error {
 }
 
 func (c Cmd) importJSONL(ctx context.Context) error {
+	maxLineSize := c.JSONLMaxLineSize
+	if maxLineSize == 0 {
+		maxLineSize = defaultJSONLMaxLineSize
+	}
+	if maxLineSize < 0 {
+		return errors.New("JSONL maximum line size must be greater than zero")
+	}
+	if maxLineSize > math.MaxInt-maxJSONLDelimiterSize {
+		return errors.New("JSONL maximum line size is too large")
+	}
+
 	schemaData, err := os.ReadFile(c.Schema)
 	if err != nil {
 		return fmt.Errorf("failed to load schema from [%s]: %w", c.Schema, err)
@@ -179,6 +197,11 @@ func (c Cmd) importJSONL(ctx context.Context) error {
 		_ = jsonlFile.Close()
 	}()
 	scanner := bufio.NewScanner(jsonlFile)
+	scannerBufferSize := maxLineSize + maxJSONLDelimiterSize
+	scanner.Buffer(
+		make([]byte, 0, min(bufio.MaxScanTokenSize, scannerBufferSize)),
+		scannerBufferSize,
+	)
 	scanner.Split(bufio.ScanLines)
 
 	parquetWriter, err := pio.NewJSONWriter(ctx, c.URI, c.WriteOption, string(schemaData))
@@ -188,6 +211,13 @@ func (c Cmd) importJSONL(ctx context.Context) error {
 
 	for scanner.Scan() {
 		jsonData := scanner.Bytes()
+		if len(jsonData) > maxLineSize {
+			return fmt.Errorf(
+				"JSONL line exceeds maximum line size of %d bytes in [%s]",
+				maxLineSize,
+				c.Source,
+			)
+		}
 		if err := json.Unmarshal(jsonData, &dummy); err != nil {
 			return fmt.Errorf("invalid JSON string: %s", string(jsonData))
 		}
@@ -195,6 +225,14 @@ func (c Cmd) importJSONL(ctx context.Context) error {
 		if err := parquetWriter.WriteWithContext(ctx, string(jsonData)); err != nil {
 			return fmt.Errorf("failed to write to parquet file: %w", err)
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf(
+			"failed to read JSONL source file [%s] with maximum line size %d bytes: %w",
+			c.Source,
+			maxLineSize,
+			err,
+		)
 	}
 	if err := parquetWriter.WriteStopWithContext(ctx); err != nil {
 		return fmt.Errorf("failed to close Parquet writer [%s]: %w", c.URI, err)

--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,6 +23,13 @@ var (
 	importEncryptionFooterKey = new("MDEyMzQ1Njc4OTAxMjM0NQ==")
 	importEncryptionColumnKey = "MTIzNDU2Nzg5MDEyMzQ1MA=="
 )
+
+const jsonlLineSizeTestSchema = `{
+	"Tag": "name=parquet_go_root, inname=Parquet_go_root",
+	"Fields": [
+		{"Tag": "name=Value, inname=Value, type=BYTE_ARRAY, convertedtype=UTF8"}
+	]
+}`
 
 type mockParquetFileWriter struct {
 	closeFunc func() error
@@ -234,6 +242,151 @@ func TestCmd(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestCmdJSONLLineSize(t *testing.T) {
+	testCases := []struct {
+		name             string
+		values           []string
+		jsonlMaxLineSize int
+		wantRows         int64
+		wantErr          string
+	}{
+		{
+			name:     "line-over-64-kib",
+			values:   []string{"before", strings.Repeat("x", 70*1024), "after"},
+			wantRows: 3,
+		},
+		{
+			name:             "configured-limit-exceeded",
+			values:           []string{"before", strings.Repeat("x", 2*1024), "after"},
+			jsonlMaxLineSize: 1024,
+			wantErr:          "failed to read JSONL source file",
+		},
+		{
+			name:             "invalid-configured-limit",
+			values:           []string{"value"},
+			jsonlMaxLineSize: -1,
+			wantErr:          "JSONL maximum line size must be greater than zero",
+		},
+		{
+			name:             "configured-limit-too-large",
+			values:           []string{"value"},
+			jsonlMaxLineSize: math.MaxInt,
+			wantErr:          "JSONL maximum line size is too large",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			sourcePath := filepath.Join(tempDir, "source.jsonl")
+			schemaPath := filepath.Join(tempDir, "schema.json")
+			parquetPath := filepath.Join(tempDir, "output.parquet")
+
+			var source strings.Builder
+			encoder := json.NewEncoder(&source)
+			for _, value := range tc.values {
+				require.NoError(t, encoder.Encode(map[string]string{"Value": value}))
+			}
+			require.NoError(t, os.WriteFile(sourcePath, []byte(source.String()), 0o600))
+			require.NoError(t, os.WriteFile(schemaPath, []byte(jsonlLineSizeTestSchema), 0o600))
+
+			err := (Cmd{
+				Source:           sourcePath,
+				Format:           "jsonl",
+				Schema:           schemaPath,
+				JSONLMaxLineSize: tc.jsonlMaxLineSize,
+				URI:              parquetPath,
+			}).Run(context.Background())
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			reader, err := pio.NewParquetFileReader(context.Background(), parquetPath, pio.ReadOption{})
+			require.NoError(t, err)
+			require.Equal(t, tc.wantRows, reader.GetNumRows())
+		})
+	}
+}
+
+func TestCmdJSONLMaxLineSizeBoundary(t *testing.T) {
+	const maxLineSize = 1024
+
+	testCases := []struct {
+		name      string
+		lineSize  int
+		delimiter string
+		wantErr   string
+	}{
+		{
+			name:      "LF-at-limit",
+			lineSize:  maxLineSize,
+			delimiter: "\n",
+		},
+		{
+			name:      "CRLF-at-limit",
+			lineSize:  maxLineSize,
+			delimiter: "\r\n",
+		},
+		{
+			name:     "unterminated-at-limit",
+			lineSize: maxLineSize,
+		},
+		{
+			name:      "LF-over-limit",
+			lineSize:  maxLineSize + 1,
+			delimiter: "\n",
+			wantErr:   "exceeds maximum line size",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			sourcePath := filepath.Join(tempDir, "source.jsonl")
+			schemaPath := filepath.Join(tempDir, "schema.json")
+			parquetPath := filepath.Join(tempDir, "output.parquet")
+
+			emptyRecord, err := json.Marshal(map[string]string{"Value": ""})
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, tc.lineSize, len(emptyRecord))
+			record, err := json.Marshal(map[string]string{
+				"Value": strings.Repeat("x", tc.lineSize-len(emptyRecord)),
+			})
+			require.NoError(t, err)
+			require.Len(t, record, tc.lineSize)
+			require.NoError(t, os.WriteFile(
+				sourcePath,
+				append(record, tc.delimiter...),
+				0o600,
+			))
+			require.NoError(t, os.WriteFile(
+				schemaPath,
+				[]byte(jsonlLineSizeTestSchema),
+				0o600,
+			))
+
+			err = (Cmd{
+				Source:           sourcePath,
+				Format:           "jsonl",
+				Schema:           schemaPath,
+				JSONLMaxLineSize: maxLineSize,
+				URI:              parquetPath,
+			}).Run(context.Background())
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			reader, err := pio.NewParquetFileReader(context.Background(), parquetPath, pio.ReadOption{})
+			require.NoError(t, err)
+			require.Equal(t, int64(1), reader.GetNumRows())
+		})
+	}
 }
 
 func TestCmdDefaultDataPageVersionWithDictionaryEncoding(t *testing.T) {


### PR DESCRIPTION
## Summary

- raise the default JSONL scanner limit from 64 KiB to 16 MiB
- add `--jsonl-max-line-size` for configurable limits
- return scanner failures instead of silently finalizing a truncated Parquet file
- document and test long-line behavior

## Testing

- `make all`

Closes #1028
