### PR TITLE
test: restore and improve coverage

### DIFF
--- a/cmd/cat/cat_test.go
+++ b/cmd/cat/cat_test.go
@@ -3,6 +3,7 @@ package cat
 import (
 	"context"
 	"encoding/binary"
+	"encoding/csv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -464,6 +465,36 @@ func TestCmdEncoder(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNullifyUnknownColumnsIgnoresNonMapRow(t *testing.T) {
+	nullifyUnknownCols("row", map[string]struct{}{"unknown": {}})
+}
+
+func TestCmdEncoderRejectsUnsupportedFormat(t *testing.T) {
+	fileReader, err := pio.NewParquetFileReader(context.Background(), "file://../../testdata/good.parquet", pio.ReadOption{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, fileReader.PFile.Close()) }()
+
+	rows, err := fileReader.ReadByNumberWithContext(context.Background(), 1)
+	require.NoError(t, err)
+	rowChan := make(chan any, 1)
+	rowChan <- rows[0]
+
+	err = (Cmd{Format: "unsupported"}).encoder(
+		context.Background(), rowChan, make(chan string, 1), fileReader.SchemaHandler, nil, nil,
+	)
+	require.ErrorContains(t, err, "unsupported format: [unsupported]")
+}
+
+func TestValuesToCSVReturnsWriterError(t *testing.T) {
+	builder := new(strings.Builder)
+	writer := csv.NewWriter(builder)
+	writer.Comma = '\n'
+
+	line, err := (&Cmd{}).valuesToCSV([]string{"value"}, builder, writer)
+	require.Empty(t, line)
+	require.ErrorContains(t, err, "invalid field or comment delimiter")
 }
 
 func BenchmarkCatCmd(b *testing.B) {

--- a/cmd/inspect/indexes_test.go
+++ b/cmd/inspect/indexes_test.go
@@ -68,13 +68,33 @@ func TestColumnIndexMetadataDoesNotDecodeNullPageBounds(t *testing.T) {
 		SchemaElement: parquet.SchemaElement{Type: parquet.TypePtr(parquet.Type_INT32)},
 	}
 	index := &parquet.ColumnIndex{
-		NullPages:     []bool{true, false},
-		MinValues:     [][]byte{{0, 0, 0, 0}, {1, 0, 0, 0}},
-		MaxValues:     [][]byte{{0, 0, 0, 0}, {2, 0, 0, 0}},
-		BoundaryOrder: parquet.BoundaryOrder_ASCENDING,
+		NullPages:                 []bool{true, false},
+		MinValues:                 [][]byte{{0, 0, 0, 0}, {1, 0, 0, 0}},
+		MaxValues:                 [][]byte{{0, 0, 0, 0}, {2, 0, 0, 0}},
+		BoundaryOrder:             parquet.BoundaryOrder_ASCENDING,
+		NullCounts:                []int64{1, 0},
+		RepetitionLevelHistograms: []int64{2, 3},
+		DefinitionLevelHistograms: []int64{4, 5},
 	}
 
 	metadata := cmd.columnIndexMetadata(index, schemaNode)
 	require.Equal(t, []any{nil, int32(1)}, metadata["minValues"])
 	require.Equal(t, []any{nil, int32(2)}, metadata["maxValues"])
+	require.Equal(t, []int64{1, 0}, metadata["nullCounts"])
+	require.Equal(t, []int64{2, 3}, metadata["repetitionLevelHistograms"])
+	require.Equal(t, []int64{4, 5}, metadata["definitionLevelHistograms"])
+}
+
+func TestDecodeIndexBoundsWithoutSchema(t *testing.T) {
+	require.Equal(t, []any{nil}, (Cmd{}).decodeIndexBounds([][]byte{{1}}, nil, true, nil))
+}
+
+func TestOffsetIndexMetadataIncludesUnencodedByteCount(t *testing.T) {
+	metadata := offsetIndexMetadata(&parquet.OffsetIndex{
+		PageLocations:               []*parquet.PageLocation{nil},
+		UnencodedByteArrayDataBytes: []int64{10, 20},
+	})
+
+	require.Empty(t, metadata["pageLocations"])
+	require.Equal(t, []int64{10, 20}, metadata["unencodedByteArrayDataBytes"])
 }

--- a/cmd/inspect/metadata_test.go
+++ b/cmd/inspect/metadata_test.go
@@ -7,6 +7,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAddKeyValueMetadata(t *testing.T) {
+	value := "value"
+	testCases := map[string]struct {
+		metadata []*parquet.KeyValue
+		expected any
+	}{
+		"absent": {},
+		"nil-entry": {
+			metadata: []*parquet.KeyValue{nil},
+			expected: []map[string]any{},
+		},
+		"key-only": {
+			metadata: []*parquet.KeyValue{{Key: "key"}},
+			expected: []map[string]any{{"key": "key"}},
+		},
+		"key-and-value": {
+			metadata: []*parquet.KeyValue{{Key: "key", Value: &value}},
+			expected: []map[string]any{{"key": "key", "value": "value"}},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			output := map[string]any{}
+			addKeyValueMetadata(output, tc.metadata)
+			if tc.expected == nil {
+				require.NotContains(t, output, "keyValueMetadata")
+			} else {
+				require.Equal(t, tc.expected, output["keyValueMetadata"])
+			}
+		})
+	}
+}
+
 func TestAddRowGroupMetadata(t *testing.T) {
 	output := map[string]any{}
 	addRowGroupMetadata(output, &parquet.RowGroup{
@@ -20,6 +54,55 @@ func TestAddRowGroupMetadata(t *testing.T) {
 	require.Equal(t, int64(20), output["totalCompressedSize"])
 	require.Equal(t, int16(3), output["ordinal"])
 	require.Equal(t, []map[string]any{{"columnIndex": int32(1), "direction": "DESC", "nullsFirst": true}}, output["sortingColumns"])
+}
+
+func TestAddRowGroupMetadataSkipsNilSortingColumn(t *testing.T) {
+	output := map[string]any{}
+	addRowGroupMetadata(output, &parquet.RowGroup{
+		SortingColumns: []*parquet.SortingColumn{nil, {ColumnIdx: 1}},
+	})
+
+	require.Equal(t, []map[string]any{{
+		"columnIndex": int32(1),
+		"direction":   "ASC",
+		"nullsFirst":  false,
+	}}, output["sortingColumns"])
+}
+
+func TestAddColumnMetadataOptionalStatistics(t *testing.T) {
+	zMin, zMax, mMin, mMax := 1.0, 2.0, 3.0, 4.0
+	output := map[string]any{}
+	addColumnMetadata(output, &parquet.ColumnChunk{MetaData: &parquet.ColumnMetaData{
+		SizeStatistics: &parquet.SizeStatistics{
+			RepetitionLevelHistogram: []int64{1, 2},
+			DefinitionLevelHistogram: []int64{3, 4},
+		},
+		GeospatialStatistics: &parquet.GeospatialStatistics{
+			GeospatialTypes: []int32{1, 2},
+			Bbox: &parquet.BoundingBox{
+				Xmin: 10, Xmax: 20, Ymin: 30, Ymax: 40,
+				Zmin: &zMin, Zmax: &zMax, Mmin: &mMin, Mmax: &mMax,
+			},
+		},
+	}})
+
+	require.Equal(t, map[string]any{
+		"repetitionLevelHistogram": []int64{1, 2},
+		"definitionLevelHistogram": []int64{3, 4},
+	}, output["sizeStatistics"])
+	require.Equal(t, map[string]any{
+		"geospatialTypes": []int32{1, 2},
+		"boundingBox": map[string]any{
+			"xMin": 10.0, "xMax": 20.0, "yMin": 30.0, "yMax": 40.0,
+			"zMin": 1.0, "zMax": 2.0, "mMin": 3.0, "mMax": 4.0,
+		},
+	}, output["geospatialStatistics"])
+}
+
+func TestAddSchemaElementMetadataIgnoresNilElement(t *testing.T) {
+	output := map[string]any{}
+	addSchemaElementMetadata(output, nil)
+	require.Empty(t, output)
 }
 
 func TestAddFileMetadataDoesNotDuplicateTotalRows(t *testing.T) {
@@ -54,6 +137,39 @@ func TestAddFileMetadataColumnOrders(t *testing.T) {
 				require.NotContains(t, output, "columnOrders")
 			} else {
 				require.Equal(t, tc.expected, output["columnOrders"])
+			}
+		})
+	}
+}
+
+func TestAddFileMetadataEncryptionAlgorithm(t *testing.T) {
+	testCases := map[string]struct {
+		algorithm *parquet.EncryptionAlgorithm
+		expected  any
+	}{
+		"absent": {},
+		"gcm": {
+			algorithm: &parquet.EncryptionAlgorithm{AES_GCM_V1: &parquet.AesGcmV1{}},
+			expected:  "AES_GCM_V1",
+		},
+		"gcm-ctr": {
+			algorithm: &parquet.EncryptionAlgorithm{AES_GCM_CTR_V1: &parquet.AesGcmCtrV1{}},
+			expected:  "AES_GCM_CTR_V1",
+		},
+		"unknown": {
+			algorithm: &parquet.EncryptionAlgorithm{},
+			expected:  "UNKNOWN",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			output := map[string]any{}
+			addFileMetadata(output, &parquet.FileMetaData{EncryptionAlgorithm: tc.algorithm})
+			if tc.expected == nil {
+				require.NotContains(t, output, "encryptionAlgorithm")
+			} else {
+				require.Equal(t, tc.expected, output["encryptionAlgorithm"])
 			}
 		})
 	}

--- a/cmd/meta/meta_test.go
+++ b/cmd/meta/meta_test.go
@@ -158,6 +158,10 @@ func TestCmd(t *testing.T) {
 			cmd:    Cmd{ReadOption: rOpt, URI: "file/does/not/exist"},
 			errMsg: "no such file or directory",
 		},
+		"peek-key-non-existent": {
+			cmd:    Cmd{ReadOption: rOpt, ShowKeyMetadata: true, URI: "file/does/not/exist"},
+			errMsg: "no such file or directory",
+		},
 		"encrypted-no-key": {
 			cmd:    Cmd{ReadOption: rOpt, URI: "../../testdata/encrypted-footer.parquet"},
 			errMsg: "decryption key required for footer",

--- a/cmd/meta/metadata_test.go
+++ b/cmd/meta/metadata_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestSortingColumnsPreserveNullPlacementAndPrecedence(t *testing.T) {
 	columns := sortingColumnMeta([]*parquet.SortingColumn{
+		nil,
 		{ColumnIdx: 2, Descending: true, NullsFirst: false},
 		{ColumnIdx: 0, Descending: false, NullsFirst: true},
 	})
@@ -17,6 +18,45 @@ func TestSortingColumnsPreserveNullPlacementAndPrecedence(t *testing.T) {
 		{ColumnIndex: 2, Direction: "DESC", NullsFirst: false},
 		{ColumnIndex: 0, Direction: "ASC", NullsFirst: true},
 	}, columns)
+}
+
+func TestKeyValueMetadata(t *testing.T) {
+	value := "value"
+	require.Equal(t, []keyValueMeta{
+		{Key: "key"},
+		{Key: "key-with-value", Value: &value},
+	}, keyValueMetadata([]*parquet.KeyValue{
+		nil,
+		{Key: "key"},
+		{Key: "key-with-value", Value: &value},
+	}))
+}
+
+func TestEncryptionAlgorithmName(t *testing.T) {
+	testCases := map[string]struct {
+		algorithm *parquet.EncryptionAlgorithm
+		expected  *string
+	}{
+		"absent": {},
+		"gcm": {
+			algorithm: &parquet.EncryptionAlgorithm{AES_GCM_V1: &parquet.AesGcmV1{}},
+			expected:  new("AES_GCM_V1"),
+		},
+		"gcm-ctr": {
+			algorithm: &parquet.EncryptionAlgorithm{AES_GCM_CTR_V1: &parquet.AesGcmCtrV1{}},
+			expected:  new("AES_GCM_CTR_V1"),
+		},
+		"unknown": {
+			algorithm: &parquet.EncryptionAlgorithm{},
+			expected:  new("UNKNOWN"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, encryptionAlgorithmName(tc.algorithm))
+		})
+	}
 }
 
 func TestColumnOrderNames(t *testing.T) {

--- a/cmd/retype/rules_test.go
+++ b/cmd/retype/rules_test.go
@@ -1,6 +1,10 @@
 package retype
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestGetActiveRulesOrder(t *testing.T) {
 	cmd := Cmd{Int96ToTimestamp: true, GeoToBinary: true}
@@ -10,5 +14,42 @@ func TestGetActiveRulesOrder(t *testing.T) {
 	}
 	if rules[0] != RuleRegistry[RuleInt96ToTimestamp] || rules[1] != RuleRegistry[RuleGeoToBinary] {
 		t.Fatal("getActiveRules() did not preserve registry order")
+	}
+}
+
+func TestRuleConvertersRejectInvalidInput(t *testing.T) {
+	testCases := map[string]struct {
+		rule  RuleID
+		value any
+		err   string
+	}{
+		"float16-type": {
+			rule:  RuleFloat16ToFloat32,
+			value: 1,
+			err:   "expected string for FLOAT16",
+		},
+		"variant-json": {
+			rule:  RuleVariantToString,
+			value: func() {},
+			err:   "failed to marshal VARIANT to JSON",
+		},
+		"uuid-type": {
+			rule:  RuleUuidToString,
+			value: 1,
+			err:   "expected string for UUID",
+		},
+		"repeated-type": {
+			rule:  RuleRepeatedToList,
+			value: 1,
+			err:   "expected slice for repeated field",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			value, err := RuleRegistry[tc.rule].ConvertData(tc.value)
+			require.Nil(t, value)
+			require.ErrorContains(t, err, tc.err)
+		})
 	}
 }

--- a/io/compression_level_test.go
+++ b/io/compression_level_test.go
@@ -119,3 +119,7 @@ func TestParseCompressionLevels(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCompressionLevelRejectsUnknownCodec(t *testing.T) {
+	require.ErrorContains(t, validateCompressionLevel("unknown", 1), "unknown codec [UNKNOWN]")
+}

--- a/schema/schematags_test.go
+++ b/schema/schematags_test.go
@@ -4,11 +4,28 @@ import (
 	"testing"
 
 	"github.com/hangxie/parquet-go/v3/parquet"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTypeStrVariant(t *testing.T) {
 	node := parquet.SchemaElement{LogicalType: &parquet.LogicalType{VARIANT: &parquet.VariantType{}}}
 	if got := typeStr(node); got != "VARIANT" {
 		t.Fatalf("typeStr() = %q, want VARIANT", got)
+	}
+}
+
+func TestTagUpdatesIgnoreAbsentMetadata(t *testing.T) {
+	testCases := map[string]func(*SchemaNode, map[string]string){
+		"empty-list":     (*SchemaNode).updateTagForList,
+		"converted-type": (*SchemaNode).updateTagFromConvertedType,
+		"logical-type":   (*SchemaNode).updateTagFromLogicalType,
+	}
+
+	for name, update := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tags := map[string]string{}
+			update(&SchemaNode{}, tags)
+			require.Empty(t, tags)
+		})
 	}
 }

--- a/schema/statistics_test.go
+++ b/schema/statistics_test.go
@@ -1,10 +1,24 @@
 package schema
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hangxie/parquet-go/v3/parquet"
+	"github.com/stretchr/testify/require"
+)
 
 func TestDecodeStatisticsNil(t *testing.T) {
 	minValue, maxValue := (&SchemaNode{}).DecodeStatistics(nil)
 	if minValue != nil || maxValue != nil {
 		t.Fatalf("DecodeStatistics(nil) = (%v, %v), want (nil, nil)", minValue, maxValue)
 	}
+}
+
+func TestDecodeStatisticsInvalidType(t *testing.T) {
+	invalidType := parquet.Type(999)
+	minValue, maxValue := (&SchemaNode{
+		SchemaElement: parquet.SchemaElement{Type: &invalidType},
+	}).DecodeStatistics(&parquet.Statistics{MinValue: []byte{1}, MaxValue: []byte{2}})
+	require.Nil(t, minValue)
+	require.Nil(t, maxValue)
 }


### PR DESCRIPTION
## Summary

- restore coverage for recently added metadata helpers
- cover deterministic page-index, schema, compression, cat, and retype edge cases
- raise total coverage from 95.8% to 97.5%

## Validation

- `make all`