### PR TITLE
fix(schema): preserve schema tree during rendering

### DIFF
--- a/cmd/merge/merge.go
+++ b/cmd/merge/merge.go
@@ -108,12 +108,7 @@ func (c Cmd) openSources(ctx context.Context) ([]*reader.ParquetReader, string, 
 
 		if rootSchema == nil {
 			rootSchema = currSchema
-			// Build a separate tree for JSON since JSONSchema() mutates the tree
-			jsonTree, jsonErr := pschema.NewSchemaTree(ctx, fileReaders[i], pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
-			if jsonErr != nil {
-				return nil, "", jsonErr
-			}
-			schemaJSON = jsonTree.JSONSchema()
+			schemaJSON = rootSchema.JSONSchema()
 			continue
 		}
 

--- a/schema/gostruct.go
+++ b/schema/gostruct.go
@@ -56,20 +56,22 @@ func (n goStructNode) asList() (string, error) {
 	var err error
 	if n.Children[0].LogicalType != nil {
 		// LIST => Element (of scalar type)
-		n.Children[0].Name = "Element"
-		*n.Children[0].RepetitionType = parquet.FieldRepetitionType_REQUIRED
+		element := *n.Children[0]
+		element.Name = "Element"
+		element.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
 		typeStr, err = goStructNode{
-			SchemaNode:     *n.Children[0],
+			SchemaNode:     element,
 			ForceCamelCase: n.ForceCamelCase,
 		}.String()
 	} else if len(n.Children[0].Children) > 1 {
 		// LIST => Element (of STRUCT)
-		n.Children[0].Name = "Element"
-		n.Children[0].Type = nil
-		n.Children[0].ConvertedType = nil
-		*n.Children[0].RepetitionType = parquet.FieldRepetitionType_REQUIRED
+		element := *n.Children[0]
+		element.Name = "Element"
+		element.Type = nil
+		element.ConvertedType = nil
+		element.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
 		typeStr, err = goStructNode{
-			SchemaNode:     *n.Children[0],
+			SchemaNode:     element,
 			ForceCamelCase: n.ForceCamelCase,
 		}.String()
 	} else if len(n.Children[0].Children) == 1 {
@@ -88,24 +90,14 @@ func (n goStructNode) asList() (string, error) {
 }
 
 func (n goStructNode) asMap() (string, error) {
-	// Parquet MAP has two possible structures depending on whether GetTagMap has
-	// already been called on this node (which flattens MAP->MAP_KEY_VALUE->[K,V]
-	// to MAP->[K,V] via updateTagForMap). Handle both forms.
-	var keyChild, valueChild *SchemaNode
-	first := n.Children[0]
-	if first.ConvertedType != nil && *first.ConvertedType == parquet.ConvertedType_MAP_KEY_VALUE {
-		if len(first.Children) < 2 {
-			return "", fmt.Errorf("invalid MAP structure in [%s]", n.Name)
-		}
-		keyChild = first.Children[0]
-		valueChild = first.Children[1]
-	} else {
-		if len(n.Children) < 2 {
-			return "", fmt.Errorf("invalid MAP structure in [%s]", n.Name)
-		}
-		keyChild = n.Children[0]
-		valueChild = n.Children[1]
+	if len(n.Children) == 0 || n.Children[0] == nil ||
+		n.Children[0].ConvertedType == nil ||
+		*n.Children[0].ConvertedType != parquet.ConvertedType_MAP_KEY_VALUE ||
+		len(n.Children[0].Children) < 2 {
+		return "", fmt.Errorf("invalid MAP structure in [%s]", n.Name)
 	}
+	keyChild := n.Children[0].Children[0]
+	valueChild := n.Children[0].Children[1]
 
 	keyStr, err := goStructNode{
 		SchemaNode:     *keyChild,

--- a/schema/jsonschema.go
+++ b/schema/jsonschema.go
@@ -1,6 +1,10 @@
 package schema
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/hangxie/parquet-go/v3/parquet"
+)
 
 type JSONSchema struct {
 	Tag    string
@@ -30,6 +34,7 @@ func (s jsonSchemaNode) schema() JSONSchema {
 		{"convertedtype", "MAP"}:       {},
 	}
 	tagMap := s.getTagMap()
+	s.normalizeForRendering()
 
 	var annotations []string
 	for _, tag := range orderedTags {
@@ -59,4 +64,46 @@ func (s jsonSchemaNode) schema() JSONSchema {
 	}
 
 	return ret
+}
+
+func (s *jsonSchemaNode) normalizeForRendering() {
+	if s.ConvertedType == nil || len(s.Children) == 0 || s.Children[0] == nil {
+		return
+	}
+
+	switch *s.ConvertedType {
+	case parquet.ConvertedType_LIST:
+		s.normalizeListForRendering()
+	case parquet.ConvertedType_MAP:
+		s.normalizeMapForRendering()
+	}
+}
+
+func (s *jsonSchemaNode) normalizeListForRendering() {
+	element := s.Children[0]
+	switch {
+	case element.LogicalType != nil:
+		element.Name = "Element"
+		element.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
+	case len(element.Children) > 1:
+		element.Name = "Element"
+		element.Type = nil
+		element.ConvertedType = nil
+		element.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
+	case len(element.Children) == 1:
+		s.Children = element.Children
+		s.Children[0].Name = "Element"
+	}
+}
+
+func (s *jsonSchemaNode) normalizeMapForRendering() {
+	keyValue := s.Children[0]
+	if len(keyValue.Children) < 2 ||
+		(keyValue.ConvertedType != nil && *keyValue.ConvertedType != parquet.ConvertedType_MAP_KEY_VALUE) {
+		return
+	}
+
+	s.Children = keyValue.Children[:2]
+	s.Children[0].Name = "Key"
+	s.Children[1].Name = "Value"
 }

--- a/schema/jsonschema.go
+++ b/schema/jsonschema.go
@@ -12,6 +12,11 @@ type jsonSchemaNode struct {
 }
 
 func (s jsonSchemaNode) Schema() JSONSchema {
+	clone := s.cloneForRendering()
+	return jsonSchemaNode{*clone}.schema()
+}
+
+func (s jsonSchemaNode) schema() JSONSchema {
 	// these are tag/value pairs to be ignored as they are default values
 	type tagValPair struct {
 		tag string
@@ -24,7 +29,7 @@ func (s jsonSchemaNode) Schema() JSONSchema {
 		{"convertedtype", "LIST"}:      {},
 		{"convertedtype", "MAP"}:       {},
 	}
-	tagMap := s.GetTagMap()
+	tagMap := s.getTagMap()
 
 	var annotations []string
 	for _, tag := range orderedTags {
@@ -50,7 +55,7 @@ func (s jsonSchemaNode) Schema() JSONSchema {
 	}
 
 	for index, child := range s.Children {
-		ret.Fields[index] = jsonSchemaNode{*child}.Schema()
+		ret.Fields[index] = jsonSchemaNode{*child}.schema()
 	}
 
 	return ret

--- a/schema/jsonschema_test.go
+++ b/schema/jsonschema_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hangxie/parquet-go/v3/parquet"
 	"github.com/stretchr/testify/require"
 
 	pio "github.com/hangxie/parquet-tools/io"
@@ -30,4 +31,20 @@ func TestJSONSchemaNode(t *testing.T) {
 	actual, _ := json.MarshalIndent(schema, "", "  ")
 	expected, _ := os.ReadFile("../testdata/golden/schema-all-types-json.json")
 	require.Equal(t, string(expected), string(actual)+"\n")
+}
+
+func TestNormalizeMapForRenderingRejectsInvalidLayer(t *testing.T) {
+	mapType := parquet.ConvertedType_MAP
+	listType := parquet.ConvertedType_LIST
+	node := jsonSchemaNode{SchemaNode{SchemaElement: parquet.SchemaElement{ConvertedType: &mapType}, Children: []*SchemaNode{
+		{
+			SchemaElement: parquet.SchemaElement{ConvertedType: &listType},
+			Children:      []*SchemaNode{{}, {}},
+		},
+	}}}
+	originalChild := node.Children[0]
+
+	node.normalizeMapForRendering()
+
+	require.Same(t, originalChild, node.Children[0])
 }

--- a/schema/schemanode.go
+++ b/schema/schemanode.go
@@ -69,18 +69,28 @@ type SchemaOption struct {
 	SkipPageEncoding bool
 }
 
-// cloneForRendering copies the tree nodes and child slices that schema
-// renderers normalize while leaving read-only Parquet metadata shared.
+// cloneForRendering copies the tree state that schema renderers normalize.
 func (s *SchemaNode) cloneForRendering() *SchemaNode {
 	if s == nil {
 		return nil
 	}
 
 	clone := *s
+	clone.Type = copyPointer(s.Type)
+	clone.RepetitionType = copyPointer(s.RepetitionType)
+	clone.ConvertedType = copyPointer(s.ConvertedType)
 	clone.Children = make([]*SchemaNode, len(s.Children))
 	for i, child := range s.Children {
 		clone.Children[i] = child.cloneForRendering()
 	}
+	return &clone
+}
+
+func copyPointer[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	clone := *value
 	return &clone
 }
 

--- a/schema/schemanode.go
+++ b/schema/schemanode.go
@@ -69,6 +69,21 @@ type SchemaOption struct {
 	SkipPageEncoding bool
 }
 
+// cloneForRendering copies the tree nodes and child slices that schema
+// renderers normalize while leaving read-only Parquet metadata shared.
+func (s *SchemaNode) cloneForRendering() *SchemaNode {
+	if s == nil {
+		return nil
+	}
+
+	clone := *s
+	clone.Children = make([]*SchemaNode, len(s.Children))
+	for i, child := range s.Children {
+		clone.Children[i] = child.cloneForRendering()
+	}
+	return &clone
+}
+
 func (s SchemaNode) GoStruct(forceCamelCase bool) (string, error) {
 	goStruct, err := goStructNode{
 		SchemaNode:     s,

--- a/schema/schemanode_test.go
+++ b/schema/schemanode_test.go
@@ -732,6 +732,44 @@ func TestGoStructAfterJSONSchema(t *testing.T) {
 	})
 }
 
+func TestSchemaRenderersDoNotMutate(t *testing.T) {
+	testCases := map[string]func(*SchemaNode){
+		"get tag map": func(root *SchemaNode) {
+			for _, node := range root.GetPathMap() {
+				node.GetTagMap()
+			}
+		},
+		"JSON schema": func(root *SchemaNode) {
+			root.JSONSchema()
+		},
+		"CSV schema": func(root *SchemaNode) {
+			_, _ = root.CSVSchema()
+		},
+		"Go struct": func(root *SchemaNode) {
+			_, _ = root.GoStruct(false)
+		},
+	}
+
+	for name, render := range testCases {
+		t.Run(name, func(t *testing.T) {
+			pr, err := pio.NewParquetFileReader(context.Background(), "../testdata/all-types.parquet", pio.ReadOption{})
+			require.NoError(t, err)
+			defer func() { _ = pr.PFile.Close() }()
+
+			root, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
+			require.NoError(t, err)
+			before, err := json.Marshal(root)
+			require.NoError(t, err)
+
+			render(root)
+
+			after, err := json.Marshal(root)
+			require.NoError(t, err)
+			require.JSONEq(t, string(before), string(after))
+		})
+	}
+}
+
 func TestJSONSchema(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/schema/schemanode_test.go
+++ b/schema/schemanode_test.go
@@ -689,12 +689,8 @@ func TestGoStruct(t *testing.T) {
 }
 
 func TestGoStructAfterJSONSchema(t *testing.T) {
-	// Regression test: JSONSchema mutates inner MAP node children through shared
-	// pointers (via updateTagForMap), so asMap must handle the flattened
-	// MAP->[Key,Value] form as well as the original MAP->MAP_KEY_VALUE->[Key,Value] form.
 	t.Run("simple map consistent output", func(t *testing.T) {
-		// A file without nested MAPs: GoStruct result must be identical whether
-		// JSONSchema is called first or not.
+		// GoStruct output must be identical whether JSONSchema is called first or not.
 		uri := "../testdata/all-types.parquet"
 
 		pr1, err := pio.NewParquetFileReader(context.Background(), uri, pio.ReadOption{})
@@ -717,10 +713,8 @@ func TestGoStructAfterJSONSchema(t *testing.T) {
 	})
 
 	t.Run("nested map no panic", func(t *testing.T) {
-		// A file with a MAP-of-MAP: JSONSchema mutates the inner MAP node's
-		// Children through a shared pointer. GoStruct must return an error
-		// (unsupported type) rather than panic when it processes the now-flattened
-		// inner MAP structure via the else branch in asMap.
+		// A MAP-of-MAP remains intact after JSONSchema, and GoStruct reports the
+		// unsupported nested type without panicking.
 		pr, err := pio.NewParquetFileReader(context.Background(), "../testdata/map-value-map.parquet", pio.ReadOption{})
 		require.NoError(t, err)
 		defer func() { _ = pr.PFile.Close() }()
@@ -2207,7 +2201,7 @@ func TestAsMapEdgeCases(t *testing.T) {
 		require.ErrorContains(t, err, "invalid MAP structure")
 	})
 
-	t.Run("pre-processed MAP with only one child", func(t *testing.T) {
+	t.Run("MAP without key-value layer", func(t *testing.T) {
 		node := goStructNode{SchemaNode: SchemaNode{
 			SchemaElement: parquet.SchemaElement{
 				Name:          "mymap",
@@ -2219,7 +2213,7 @@ func TestAsMapEdgeCases(t *testing.T) {
 						Name: "key",
 						Type: &int32T,
 					},
-					// nil ConvertedType → else branch; only 1 child → error
+					// Missing the required MAP_KEY_VALUE layer.
 				},
 			},
 		}}

--- a/schema/schemanode_test.go
+++ b/schema/schemanode_test.go
@@ -2308,6 +2308,11 @@ func TestUpdateTagForMapChildAlreadyProcessed(t *testing.T) {
 						ExNamePath:    []string{"key"},
 						InNamePath:    []string{"root", "mymap", "key"},
 					},
+					{
+						SchemaElement: parquet.SchemaElement{Name: "value", Type: &int32Type},
+						ExNamePath:    []string{"value"},
+						InNamePath:    []string{"root", "mymap", "value"},
+					},
 				},
 			},
 		},

--- a/schema/schemanode_test.go
+++ b/schema/schemanode_test.go
@@ -774,6 +774,39 @@ func TestCloneForRenderingPreservesNilChild(t *testing.T) {
 	require.Nil(t, clone.Children[0])
 }
 
+func TestCloneForRenderingCopiesMutablePointers(t *testing.T) {
+	typeValue := parquet.Type_BYTE_ARRAY
+	repetitionType := parquet.FieldRepetitionType_OPTIONAL
+	convertedType := parquet.ConvertedType_UTF8
+	root := &SchemaNode{SchemaElement: parquet.SchemaElement{
+		Type:           &typeValue,
+		RepetitionType: &repetitionType,
+		ConvertedType:  &convertedType,
+	}}
+
+	clone := root.cloneForRendering()
+
+	require.NotSame(t, root.Type, clone.Type)
+	require.NotSame(t, root.RepetitionType, clone.RepetitionType)
+	require.NotSame(t, root.ConvertedType, clone.ConvertedType)
+	require.Equal(t, root.SchemaElement, clone.SchemaElement)
+}
+
+func TestGetTagMapAllocationsDoNotScaleWithChildren(t *testing.T) {
+	root := &SchemaNode{SchemaElement: parquet.SchemaElement{Name: "root"}}
+	for range 128 {
+		root.Children = append(root.Children, &SchemaNode{})
+	}
+
+	var tagMap map[string]string
+	allocations := testing.AllocsPerRun(10, func() {
+		tagMap = root.GetTagMap()
+	})
+
+	require.Equal(t, "root", tagMap["name"])
+	require.LessOrEqual(t, allocations, 5.0)
+}
+
 func TestJSONSchema(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/schema/schemanode_test.go
+++ b/schema/schemanode_test.go
@@ -764,6 +764,16 @@ func TestSchemaRenderersDoNotMutate(t *testing.T) {
 	}
 }
 
+func TestCloneForRenderingPreservesNilChild(t *testing.T) {
+	root := &SchemaNode{Children: []*SchemaNode{nil}}
+
+	clone := root.cloneForRendering()
+
+	require.NotSame(t, root, clone)
+	require.Len(t, clone.Children, 1)
+	require.Nil(t, clone.Children[0])
+}
+
 func TestJSONSchema(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/schema/schematags.go
+++ b/schema/schematags.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *SchemaNode) GetTagMap() map[string]string {
-	return s.cloneForRendering().getTagMap()
+	return s.getTagMap()
 }
 
 func (s *SchemaNode) getTagMap() map[string]string {
@@ -66,7 +66,7 @@ func (s *SchemaNode) getTagMap() map[string]string {
 }
 
 func (s *SchemaNode) getTagMapWithPrefix(prefix string) map[string]string {
-	tagMap := s.GetTagMap()
+	tagMap := s.getTagMap()
 	ret := map[string]string{}
 	for _, tag := range orderedTags {
 		if tag == "name" || strings.HasPrefix(tag, "key") || strings.HasPrefix(tag, "value") {
@@ -88,32 +88,24 @@ func (s *SchemaNode) updateTagForList(tagMap map[string]string) {
 
 	if s.Children[0].LogicalType != nil {
 		// LIST => Element (of scalar type)
-		s.Children[0].Name = "Element"
-		s.Children[0].RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
 		maps.Copy(tagMap, s.Children[0].getTagMapWithPrefix("value"))
 		return
 	}
 
 	if len(s.Children[0].Children) > 1 {
 		// LIST => Element (of STRUCT)
-		s.Children[0].Name = "Element"
-		s.Children[0].Type = nil
-		s.Children[0].ConvertedType = nil
-		s.Children[0].RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
 		return
 	}
 
 	if len(s.Children[0].Children) == 1 {
 		// LIST => List => Element
 		maps.Copy(tagMap, s.Children[0].Children[0].getTagMapWithPrefix("value"))
-		s.Children = s.Children[0].Children
-		s.Children[0].Name = "Element"
 		return
 	}
 }
 
 func (s *SchemaNode) updateTagForMap(tagMap map[string]string) {
-	if len(s.Children) == 0 || s.Children[0] == nil || len(s.Children[0].Children) == 0 {
+	if len(s.Children) == 0 || s.Children[0] == nil || len(s.Children[0].Children) < 2 {
 		// meaningless interim layer
 		return
 	}
@@ -126,9 +118,6 @@ func (s *SchemaNode) updateTagForMap(tagMap map[string]string) {
 	// expected output is MAP->(Key, Value)
 	maps.Copy(tagMap, s.Children[0].Children[0].getTagMapWithPrefix("key"))
 	maps.Copy(tagMap, s.Children[0].Children[1].getTagMapWithPrefix("value"))
-	s.Children = s.Children[0].Children[0:2]
-	s.Children[0].Name = "Key"
-	s.Children[1].Name = "Value"
 }
 
 func (s *SchemaNode) updateTagFromConvertedType(tagMap map[string]string) {

--- a/schema/schematags.go
+++ b/schema/schematags.go
@@ -10,6 +10,10 @@ import (
 )
 
 func (s *SchemaNode) GetTagMap() map[string]string {
+	return s.cloneForRendering().getTagMap()
+}
+
+func (s *SchemaNode) getTagMap() map[string]string {
 	tagMap := map[string]string{
 		"repetitiontype": repetitionTypeStr(s.SchemaElement),
 		"type":           typeStr(s.SchemaElement),
@@ -85,7 +89,7 @@ func (s *SchemaNode) updateTagForList(tagMap map[string]string) {
 	if s.Children[0].LogicalType != nil {
 		// LIST => Element (of scalar type)
 		s.Children[0].Name = "Element"
-		*s.Children[0].RepetitionType = parquet.FieldRepetitionType_REQUIRED
+		s.Children[0].RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
 		maps.Copy(tagMap, s.Children[0].getTagMapWithPrefix("value"))
 		return
 	}
@@ -95,7 +99,7 @@ func (s *SchemaNode) updateTagForList(tagMap map[string]string) {
 		s.Children[0].Name = "Element"
 		s.Children[0].Type = nil
 		s.Children[0].ConvertedType = nil
-		*s.Children[0].RepetitionType = parquet.FieldRepetitionType_REQUIRED
+		s.Children[0].RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- make GetTagMap, JSONSchema, CSVSchema, and GoStruct preserve the caller schema tree
- normalize a single rendering clone while avoiding subtree clones for individual tag lookups
- copy normalization-sensitive schema pointers and remove the merge and MAP mutation workarounds

## Validation

- make all
- overall coverage: 97.6%
- schema coverage: 99.4%

Closes #1038