### PR TITLE
fix(io): honor AWS-configured S3 endpoints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,9 @@ jobs:
           echo "==> AWS S3 ..."
           test "$(./build/parquet-tools row-count --anonymous s3://daylight-openstreetmap/parquet/osm_features/release=v1.58/type=way/20241112_191814_00139_grr7u_0041fe64-a5ba-4375-88bf-ef790dfedfff)" == '7124019'
 
+          echo "==> S3-compatible endpoints ..."
+          scripts/test-s3-compatibility.sh
+
           echo "==> Azure blob storage ..."
           test "$(./build/parquet-tools row-count --anonymous wasbs://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet)" == '6582726'
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,27 @@ $ parquet-tools row-count --anonymous s3://daylight-openstreetmap/parquet/osm_fe
 2405462
 ```
 
+S3-compatible object stores such as MinIO, Ceph, Cloudflare R2, and LocalStack
+can be configured with the standard AWS SDK endpoint environment variables.
+`AWS_ENDPOINT_URL_S3` affects only S3 and takes precedence over the global
+`AWS_ENDPOINT_URL`. When either setting selects a custom endpoint,
+`parquet-tools` uses path-style bucket addressing and does not query Amazon S3
+for the bucket region.
+
+For example, to access a local MinIO server:
+
+```bash
+$ export AWS_ENDPOINT_URL_S3=http://localhost:9000
+$ export AWS_REGION=us-east-1
+$ export AWS_ACCESS_KEY_ID=minioadmin
+$ export AWS_SECRET_ACCESS_KEY=minioadmin
+$ parquet-tools row-count s3://example-bucket/example.parquet
+```
+
+The endpoint and region can also come from the standard AWS shared config
+file. Use `--anonymous` for an S3-compatible endpoint that does not require
+signed requests.
+
 Optionally, you can specify object version by using `--object-version` when you perform read operation (like cat, row-count, schema, etc.) for S3, `parquet-tools` will access current version if this parameter is omitted.
 
 If version for the S3 object does not exist or bucket does not have version enabled, `parquet-tools` will report error:

--- a/io/io.go
+++ b/io/io.go
@@ -108,7 +108,7 @@ func newTLSInsecureHTTPClient() *http.Client {
 	}
 }
 
-func getS3BucketRegion(bucket string, isPublic, ignoreTLS bool) (string, error) {
+func getS3BucketRegion(ctx context.Context, bucket string, isPublic, ignoreTLS bool) (string, error) {
 	client := http.DefaultClient
 	if strings.Contains(bucket, ".") && ignoreTLS {
 		// AWS' wildcard cert covers *.s3.amazonaws.com, so if the bucket name
@@ -116,7 +116,11 @@ func getS3BucketRegion(bucket string, isPublic, ignoreTLS bool) (string, error) 
 		// TLS verification disabled instead of mutating http.DefaultTransport.
 		client = newTLSInsecureHTTPClient()
 	}
-	resp, err := client.Head(fmt.Sprintf("https://%s.s3.amazonaws.com", bucket))
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, fmt.Sprintf("https://%s.s3.amazonaws.com", bucket), nil)
+	if err != nil {
+		return "", fmt.Errorf("unable to get region for S3 bucket %s: %w", bucket, err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("unable to get region for S3 bucket %s: %w", bucket, err)
 	}
@@ -139,29 +143,35 @@ func getS3BucketRegion(bucket string, isPublic, ignoreTLS bool) (string, error) 
 	}
 }
 
-func getS3Client(bucket string, isPublic, ignoreTLS bool) (*s3.Client, error) {
-	region, err := getS3BucketRegion(bucket, isPublic, ignoreTLS)
-	if err != nil {
-		return nil, fmt.Errorf("unable to access to [%s]: %w", bucket, err)
-	}
-
+func getS3Client(ctx context.Context, bucket string, isPublic, ignoreTLS bool) (*s3.Client, error) {
 	needCustomHTTP := strings.Contains(bucket, ".") && ignoreTLS
-	if isPublic {
-		cfg := aws.Config{Region: region}
-		if needCustomHTTP {
-			cfg.HTTPClient = newTLSInsecureHTTPClient()
-		}
-		return s3.NewFromConfig(cfg), nil
-	}
-
-	ctx := context.Background()
 	opts := []func(*config.LoadOptions) error{config.WithDefaultRegion("us-east-1")}
+	if isPublic {
+		opts = append(opts, config.WithCredentialsProvider(aws.AnonymousCredentials{}))
+	}
 	if needCustomHTTP {
 		opts = append(opts, config.WithHTTPClient(newTLSInsecureHTTPClient()))
 	}
 	cfg, err := config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load config to determine bucket region: %w", err)
+		return nil, fmt.Errorf("failed to load AWS config for S3 bucket %s: %w", bucket, err)
+	}
+
+	// Service-specific endpoints such as AWS_ENDPOINT_URL_S3 are resolved while
+	// constructing an S3 client rather than being exposed on aws.Config.
+	configuredClient := s3.NewFromConfig(cfg)
+	if configuredClient.Options().BaseEndpoint != nil {
+		if ignoreTLS && !needCustomHTTP {
+			cfg.HTTPClient = newTLSInsecureHTTPClient()
+		}
+		return s3.NewFromConfig(cfg, func(options *s3.Options) {
+			options.UsePathStyle = true
+		}), nil
+	}
+
+	region, err := getS3BucketRegion(ctx, bucket, isPublic, ignoreTLS)
+	if err != nil {
+		return nil, fmt.Errorf("unable to access to [%s]: %w", bucket, err)
 	}
 	cfg.Region = region
 	return s3.NewFromConfig(cfg), nil

--- a/io/io_test.go
+++ b/io/io_test.go
@@ -1,17 +1,21 @@
 package io
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/google/uuid"
 	"github.com/hangxie/parquet-go/v3/parquet"
 	"github.com/stretchr/testify/require"
@@ -267,10 +271,12 @@ func TestGetBucketRegion(t *testing.T) {
 	}
 
 	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
+	t.Setenv("AWS_ENDPOINT_URL", "")
+	t.Setenv("AWS_ENDPOINT_URL_S3", "")
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Setenv("AWS_PROFILE", tc.profile)
-			_, err := getS3Client(tc.bucket, tc.public, tc.ignoreTLS)
+			_, err := getS3Client(context.Background(), tc.bucket, tc.public, tc.ignoreTLS)
 			if tc.errMsg == "" {
 				require.NoError(t, err)
 			} else {
@@ -301,10 +307,135 @@ func TestGetS3BucketRegionUsesHead(t *testing.T) {
 		}),
 	}
 
-	region, err := getS3BucketRegion("example-bucket", true, false)
+	region, err := getS3BucketRegion(context.Background(), "example-bucket", true, false)
 	require.NoError(t, err)
 	require.Equal(t, "us-west-2", region)
 	require.Equal(t, http.MethodHead, method)
+}
+
+func TestGetS3ClientUsesConfiguredEndpoint(t *testing.T) {
+	originalClient := http.DefaultClient
+	t.Cleanup(func() {
+		http.DefaultClient = originalClient
+	})
+	http.DefaultClient = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("unexpected Amazon S3 region probe")
+		}),
+	}
+
+	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	t.Setenv("AWS_REGION", "us-west-2")
+	t.Setenv("AWS_IGNORE_CONFIGURED_ENDPOINT_URLS", "false")
+
+	testCases := []struct {
+		name        string
+		environment string
+		anonymous   bool
+		ignoreTLS   bool
+	}{
+		{name: "global-endpoint", environment: "AWS_ENDPOINT_URL"},
+		{name: "s3-endpoint", environment: "AWS_ENDPOINT_URL_S3"},
+		{name: "anonymous", environment: "AWS_ENDPOINT_URL_S3", anonymous: true},
+		{name: "insecure-tls", environment: "AWS_ENDPOINT_URL_S3", ignoreTLS: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AWS_ENDPOINT_URL", "")
+			t.Setenv("AWS_ENDPOINT_URL_S3", "")
+			t.Setenv(tc.environment, "http://localhost:9000")
+
+			client, err := getS3Client(context.Background(), "test-bucket", tc.anonymous, tc.ignoreTLS)
+			require.NoError(t, err)
+
+			options := client.Options()
+			require.Equal(t, "us-west-2", options.Region)
+			require.Equal(t, aws.String("http://localhost:9000"), options.BaseEndpoint)
+			require.True(t, options.UsePathStyle)
+
+			if tc.anonymous {
+				require.Nil(t, options.Credentials)
+			}
+			if tc.ignoreTLS {
+				httpClient, ok := options.HTTPClient.(*http.Client)
+				require.True(t, ok)
+				transport, ok := httpClient.Transport.(*http.Transport)
+				require.True(t, ok)
+				require.NotNil(t, transport.TLSClientConfig)
+				require.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+			}
+		})
+	}
+}
+
+func TestGetS3ClientRegionProbeUsesContext(t *testing.T) {
+	type contextKey string
+	const key contextKey = "region-probe"
+
+	originalClient := http.DefaultClient
+	t.Cleanup(func() {
+		http.DefaultClient = originalClient
+	})
+
+	var contextValue any
+	http.DefaultClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			contextValue = req.Context().Value(key)
+			return nil, errors.New("stop region probe")
+		}),
+	}
+
+	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	t.Setenv("AWS_ENDPOINT_URL", "")
+	t.Setenv("AWS_ENDPOINT_URL_S3", "")
+
+	ctx := context.WithValue(context.Background(), key, "caller context")
+	_, err := getS3Client(ctx, "test-bucket", false, false)
+	require.ErrorContains(t, err, "stop region probe")
+	require.Equal(t, "caller context", contextValue)
+}
+
+func TestGetS3ClientUsesSharedConfigEndpoint(t *testing.T) {
+	originalClient := http.DefaultClient
+	t.Cleanup(func() {
+		http.DefaultClient = originalClient
+	})
+	http.DefaultClient = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("unexpected Amazon S3 region probe")
+		}),
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config")
+	configData := `[profile custom-endpoint]
+region = us-east-2
+services = local-s3
+
+[services local-s3]
+s3 =
+  endpoint_url = http://localhost:9001
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configData), 0o600))
+	t.Setenv("AWS_CONFIG_FILE", configPath)
+	t.Setenv("AWS_PROFILE", "custom-endpoint")
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	t.Setenv("AWS_ENDPOINT_URL", "")
+	t.Setenv("AWS_ENDPOINT_URL_S3", "")
+	t.Setenv("AWS_IGNORE_CONFIGURED_ENDPOINT_URLS", "false")
+
+	client, err := getS3Client(context.Background(), "test-bucket", false, false)
+	require.NoError(t, err)
+
+	options := client.Options()
+	require.Equal(t, "us-east-2", options.Region)
+	require.Equal(t, aws.String("http://localhost:9001"), options.BaseEndpoint)
+	require.True(t, options.UsePathStyle)
 }
 
 func TestValidCompressionCodecs(t *testing.T) {

--- a/io/reader.go
+++ b/io/reader.go
@@ -114,7 +114,7 @@ func newLocalReader(_ context.Context, u *url.URL, _ ReadOption) (source.Parquet
 }
 
 func newAWSS3Reader(ctx context.Context, u *url.URL, option ReadOption) (source.ParquetFileReader, error) {
-	s3Client, err := getS3Client(u.Host, option.Anonymous, option.HTTPIgnoreTLSError)
+	s3Client, err := getS3Client(ctx, u.Host, option.Anonymous, option.HTTPIgnoreTLSError)
 	if err != nil {
 		return nil, err
 	}

--- a/io/writer.go
+++ b/io/writer.go
@@ -61,7 +61,7 @@ func newLocalWriter(_ context.Context, u *url.URL) (source.ParquetFileWriter, er
 }
 
 func newAWSS3Writer(ctx context.Context, u *url.URL) (source.ParquetFileWriter, error) {
-	s3Client, err := getS3Client(u.Host, false, false)
+	s3Client, err := getS3Client(ctx, u.Host, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/test-s3-compatibility.sh
+++ b/scripts/test-s3-compatibility.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly bucket="compatibility"
+readonly minio_image="quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z"
+readonly minio_client_image="quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
+readonly ceph_image="quay.io/ceph/demo:main-30dc8b9a-squid-centos-stream9"
+readonly seaweedfs_image="chrislusf/seaweedfs:4.40"
+
+# S3-compatible endpoints must work without access to Amazon S3. Route any
+# unexpected HTTPS request through a closed local port while allowing the test
+# services on the loopback interface to be reached directly.
+export HTTPS_PROXY="http://127.0.0.1:1"
+export NO_PROXY="127.0.0.1,localhost"
+
+containers=()
+
+cleanup() {
+	for container in "${containers[@]}"; do
+		docker rm -f "$container" >/dev/null 2>&1 || true
+	done
+}
+trap cleanup EXIT
+
+container_port() {
+	local container=$1
+	local port=$2
+	docker port "$container" "$port/tcp" | sed 's/.*://'
+}
+
+pull_image() {
+	docker pull --quiet "$@" >/dev/null
+}
+
+wait_for_http() {
+	local container=$1
+	local url=$2
+	for attempt in $(seq 1 60); do
+		if curl -sS "$url" >/dev/null 2>&1; then
+			return
+		fi
+		if ! docker inspect -f '{{.State.Running}}' "$container" | grep -q true; then
+			docker logs "$container"
+			return 1
+		fi
+		if [[ $attempt -eq 60 ]]; then
+			docker logs "$container"
+			return 1
+		fi
+		sleep 1
+	done
+}
+
+verify_parquet_io() {
+	local endpoint=$1
+	local region=$2
+	local access_key=$3
+	local secret_key=$4
+
+	export AWS_ENDPOINT_URL_S3=$endpoint
+	export AWS_REGION=$region
+	export AWS_ACCESS_KEY_ID=$access_key
+	export AWS_SECRET_ACCESS_KEY=$secret_key
+
+	./build/parquet-tools transcode -s testdata/good.parquet "s3://$bucket/good.parquet"
+	test "$(./build/parquet-tools row-count "s3://$bucket/good.parquet")" = "3"
+	./build/parquet-tools import -f jsonl -m testdata/jsonl.schema -s testdata/jsonl.source "s3://$bucket/generated.parquet"
+	test "$(./build/parquet-tools row-count "s3://$bucket/generated.parquet")" = "10"
+}
+
+test_minio() {
+	local container="parquet-tools-minio-${RANDOM}"
+	pull_image "$minio_image"
+	docker run -d --name "$container" -p 127.0.0.1::9000 \
+		-e MINIO_ROOT_USER=minioadmin \
+		-e MINIO_ROOT_PASSWORD=minioadmin \
+		"$minio_image" server /data >/dev/null
+	containers+=("$container")
+
+	local port
+	port=$(container_port "$container" 9000)
+	wait_for_http "$container" "http://127.0.0.1:$port/minio/health/live"
+	pull_image "$minio_client_image"
+	docker run --rm --network "container:$container" --entrypoint /bin/sh \
+		"$minio_client_image" -c \
+		"mc alias set local http://127.0.0.1:9000 minioadmin minioadmin && mc mb local/$bucket" >/dev/null
+	verify_parquet_io "http://127.0.0.1:$port" "us-east-1" "minioadmin" "minioadmin"
+}
+
+test_ceph() {
+	local container="parquet-tools-ceph-${RANDOM}"
+	# The demo image defaults to BlueStore, which needs a block device and native
+	# AIO. MemStore keeps this endpoint compatibility test self-contained.
+	pull_image --platform linux/amd64 "$ceph_image"
+	docker run -d --platform linux/amd64 --name "$container" -p 127.0.0.1::8080 \
+		-e MON_IP=127.0.0.1 \
+		-e CEPH_PUBLIC_NETWORK=0.0.0.0/0 \
+		-e DEMO_DAEMONS=osd,rgw \
+		-e CEPH_DEMO_UID=demo \
+		-e CEPH_DEMO_ACCESS_KEY=demo \
+		-e CEPH_DEMO_SECRET_KEY=demo \
+		--entrypoint /bin/bash "$ceph_image" -lc \
+		"sed -i 's/osd objectstore = bluestore/osd objectstore = memstore/g' /opt/ceph-container/bin/demo && exec /opt/ceph-container/bin/demo" >/dev/null
+	containers+=("$container")
+
+	for attempt in $(seq 1 100); do
+		if docker exec "$container" s3cmd ls >/dev/null 2>&1; then
+			break
+		fi
+		if ! docker inspect -f '{{.State.Running}}' "$container" | grep -q true; then
+			docker logs "$container"
+			return 1
+		fi
+		if [[ $attempt -eq 100 ]]; then
+			docker logs "$container"
+			return 1
+		fi
+		sleep 6
+	done
+
+	docker exec "$container" s3cmd mb "s3://$bucket" >/dev/null
+	local port
+	port=$(container_port "$container" 8080)
+	verify_parquet_io "http://127.0.0.1:$port" "us-east-1" "demo" "demo"
+}
+
+test_seaweedfs() {
+	local container="parquet-tools-seaweedfs-${RANDOM}"
+	pull_image "$seaweedfs_image"
+	docker run -d --name "$container" -p 127.0.0.1::8333 \
+		-e AWS_ACCESS_KEY_ID=admin \
+		-e AWS_SECRET_ACCESS_KEY=secret \
+		-e S3_BUCKET="$bucket" \
+		"$seaweedfs_image" >/dev/null
+	containers+=("$container")
+
+	local port
+	port=$(container_port "$container" 8333)
+	wait_for_http "$container" "http://127.0.0.1:$port/"
+	verify_parquet_io "http://127.0.0.1:$port" "us-east-1" "admin" "secret"
+}
+
+echo "==> MinIO endpoint ..."
+test_minio
+echo "==> Ceph RGW endpoint ..."
+test_ceph
+echo "==> SeaweedFS endpoint ..."
+test_seaweedfs
+echo "All S3-compatible endpoint tests passed"


### PR DESCRIPTION
## Summary

- honor `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_S3`, and shared AWS endpoint configuration
- skip Amazon S3 region discovery for custom endpoints and use path-style addressing
- preserve authenticated, anonymous, read, write, and insecure-TLS behavior
- make the standard S3 region-discovery request cancellable
- document MinIO, Ceph, Cloudflare R2, and LocalStack configuration without adding a new CLI flag
- add containerized read/write smoke tests for MinIO, Ceph RGW, and SeaweedFS
- block external HTTPS in compatibility tests to ensure custom endpoints never depend on Amazon S3 connectivity

## Testing

- `scripts/test-s3-compatibility.sh` (locally verified on all three object stores)
- compatibility script fails at MinIO with the S3 endpoint fix reverted
- `make all`
- race-enabled test suite passes
- 97.6% total statement coverage

Closes #1042