### PR TITLE
fix: close readers/writers on error paths and correct split --file-count

### DIFF
--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -125,7 +125,7 @@ func (c *Cmd) retrieveFieldDef(ctx context.Context, fileReader *reader.ParquetRe
 }
 
 func mapToStrList(flatValues map[string]any, fieldList []string) []string {
-	values := make([]string, len(flatValues))
+	values := make([]string, len(fieldList))
 	for index, field := range fieldList {
 		switch val := flatValues[field].(type) {
 		case nil:

--- a/cmd/cat/cat_test.go
+++ b/cmd/cat/cat_test.go
@@ -543,3 +543,40 @@ func BenchmarkCatCmd(b *testing.B) {
 		}
 	})
 }
+
+func TestMapToStrList(t *testing.T) {
+	testCases := map[string]struct {
+		flatValues map[string]any
+		fieldList  []string
+		expected   []string
+	}{
+		"all-present": {
+			flatValues: map[string]any{"a": "x", "b": int64(2), "c": nil},
+			fieldList:  []string{"a", "b", "c"},
+			expected:   []string{"x", "2", ""},
+		},
+		"reordered": {
+			flatValues: map[string]any{"a": "x", "b": "y"},
+			fieldList:  []string{"b", "a"},
+			expected:   []string{"y", "x"},
+		},
+		// output slice must be sized by the header field list, not the row map;
+		// a row map with fewer keys than fields must not panic.
+		"fewer-map-keys": {
+			flatValues: map[string]any{"a": "x"},
+			fieldList:  []string{"a", "b", "c"},
+			expected:   []string{"x", "", ""},
+		},
+		"empty-field-list": {
+			flatValues: map[string]any{"a": "x"},
+			fieldList:  []string{},
+			expected:   []string{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, mapToStrList(tc.flatValues, tc.fieldList))
+		})
+	}
+}

--- a/cmd/import/import.go
+++ b/cmd/import/import.go
@@ -94,6 +94,14 @@ func (c Cmd) importCSV(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create CSV writer: %w", err)
 	}
+	// Best-effort close (with HDFS retry) on every error path once the writer
+	// exists; disabled once the explicit close below takes over.
+	closed := false
+	defer func() {
+		if !closed {
+			_ = c.closeWriter(parquetWriter.PFile)
+		}
+	}()
 
 	if c.SkipHeader {
 		_, _ = csvReader.Read()
@@ -118,6 +126,7 @@ func (c Cmd) importCSV(ctx context.Context) error {
 		return fmt.Errorf("failed to close Parquet writer [%s]: %w", c.URI, err)
 	}
 
+	closed = true
 	if err := c.closeWriter(parquetWriter.PFile); err != nil {
 		return fmt.Errorf("failed to close Parquet file [%s]: %w", c.URI, err)
 	}
@@ -150,6 +159,14 @@ func (c Cmd) importJSON(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create JSON writer: %w", err)
 	}
+	// Best-effort close (with HDFS retry) on every error path once the writer
+	// exists; disabled once the explicit close below takes over.
+	closed := false
+	defer func() {
+		if !closed {
+			_ = c.closeWriter(parquetWriter.PFile)
+		}
+	}()
 
 	for _, record := range records {
 		if err := parquetWriter.WriteWithContext(ctx, string(record)); err != nil {
@@ -160,6 +177,7 @@ func (c Cmd) importJSON(ctx context.Context) error {
 	if err := parquetWriter.WriteStopWithContext(ctx); err != nil {
 		return fmt.Errorf("failed to close Parquet writer [%s]: %w", c.URI, err)
 	}
+	closed = true
 	if err := c.closeWriter(parquetWriter.PFile); err != nil {
 		return fmt.Errorf("failed to close Parquet file [%s]: %w", c.URI, err)
 	}
@@ -208,6 +226,14 @@ func (c Cmd) importJSONL(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create JSON writer: %w", err)
 	}
+	// Best-effort close (with HDFS retry) on every error path once the writer
+	// exists; disabled once the explicit close below takes over.
+	closed := false
+	defer func() {
+		if !closed {
+			_ = c.closeWriter(parquetWriter.PFile)
+		}
+	}()
 
 	for scanner.Scan() {
 		jsonData := scanner.Bytes()
@@ -237,6 +263,7 @@ func (c Cmd) importJSONL(ctx context.Context) error {
 	if err := parquetWriter.WriteStopWithContext(ctx); err != nil {
 		return fmt.Errorf("failed to close Parquet writer [%s]: %w", c.URI, err)
 	}
+	closed = true
 	if err := c.closeWriter(parquetWriter.PFile); err != nil {
 		return fmt.Errorf("failed to close Parquet file [%s]: %w", c.URI, err)
 	}

--- a/cmd/merge/merge.go
+++ b/cmd/merge/merge.go
@@ -90,18 +90,27 @@ func (c Cmd) Run(ctx context.Context) (retErr error) {
 	return g.Wait()
 }
 
-func (c Cmd) openSources(ctx context.Context) ([]*reader.ParquetReader, string, error) {
+func (c Cmd) openSources(ctx context.Context) (_ []*reader.ParquetReader, _ string, retErr error) {
 	var schemaJSON string
 	var rootSchema *pschema.SchemaNode
-	var err error
-	fileReaders := make([]*reader.ParquetReader, len(c.Source))
-	for i, source := range c.Source {
-		fileReaders[i], err = pio.NewParquetFileReader(ctx, source, c.ReadOption)
+	fileReaders := make([]*reader.ParquetReader, 0, len(c.Source))
+	// Close any already-opened readers if we bail out partway through; the
+	// caller only registers its deferred close once openSources succeeds.
+	defer func() {
+		if retErr != nil {
+			for _, fileReader := range fileReaders {
+				_ = fileReader.PFile.Close()
+			}
+		}
+	}()
+	for _, source := range c.Source {
+		fileReader, err := pio.NewParquetFileReader(ctx, source, c.ReadOption)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to read from [%s]: %w", source, err)
 		}
+		fileReaders = append(fileReaders, fileReader)
 
-		currSchema, err := pschema.NewSchemaTree(ctx, fileReaders[i], pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
+		currSchema, err := pschema.NewSchemaTree(ctx, fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
 		if err != nil {
 			return nil, "", err
 		}

--- a/cmd/meta/meta.go
+++ b/cmd/meta/meta.go
@@ -45,6 +45,9 @@ func (c Cmd) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		_ = reader.PFile.Close()
+	}()
 
 	schemaRoot, err := pschema.NewSchemaTree(ctx, reader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96, SkipPageEncoding: true})
 	if err != nil {

--- a/cmd/split/split.go
+++ b/cmd/split/split.go
@@ -50,12 +50,13 @@ func (c *Cmd) openReader(ctx context.Context) (*reader.ParquetReader, error) {
 	c.current.schemaJSON = schemaRoot.JSONSchema()
 
 	if c.FileCount != 0 {
+		// Distribute rows across exactly FileCount files: each file holds
+		// numRows/FileCount records, and the first numRows%FileCount files get
+		// one extra record each (the padding). When numRows < FileCount the base
+		// count is 0, numRows%FileCount == numRows, and the remaining files are
+		// emitted empty.
 		c.RecordCount = parquetReader.GetNumRows() / c.FileCount
-		if c.RecordCount == 0 {
-			c.current.paddingCount = parquetReader.GetNumRows()
-		} else {
-			c.current.paddingCount = parquetReader.GetNumRows() % c.RecordCount
-		}
+		c.current.paddingCount = parquetReader.GetNumRows() % c.FileCount
 	}
 
 	return parquetReader, nil
@@ -113,6 +114,14 @@ func (c Cmd) Run(ctx context.Context) error {
 	defer func() {
 		_ = parquetReader.PFile.Close()
 	}()
+	// Best-effort close of the in-flight target writer on any early return
+	// (read/write/switch error). closeWriter clears current.writer on the
+	// success path so this does not double-close.
+	defer func() {
+		if c.current.writer != nil {
+			_ = c.current.writer.PFile.Close()
+		}
+	}()
 
 	c.current.fileIndex = 0
 	c.current.targetFile = ""
@@ -161,6 +170,7 @@ func (c *Cmd) closeWriter(ctx context.Context) error {
 	if err := c.current.writer.PFile.Close(); err != nil {
 		return fmt.Errorf("failed to close [%s]: %w", c.current.targetFile, err)
 	}
+	c.current.writer = nil
 	return nil
 }
 

--- a/cmd/split/split_test.go
+++ b/cmd/split/split_test.go
@@ -69,6 +69,17 @@ func TestCmd(t *testing.T) {
 			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 2, NameFormat: "ut-%d.parquet", ReadPageSize: 1000, RecordCount: 0, URI: "all-types.parquet", current: trunkWriter{}},
 			result: map[string]int64{"ut-0.parquet": 3, "ut-1.parquet": 2},
 		},
+		// 3 rows / 2 files: base=1, remainder=1 so the padding is against
+		// FileCount, not RecordCount (3%1==0 would wrongly yield 3 files).
+		"file-count-padding": {
+			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 2, NameFormat: "ut-%d.parquet", ReadPageSize: 1000, RecordCount: 0, URI: "good.parquet", current: trunkWriter{}},
+			result: map[string]int64{"ut-0.parquet": 2, "ut-1.parquet": 1},
+		},
+		// 5 rows / 3 files: base=1, remainder=2, i.e. numRows%FileCount >= numRows/FileCount.
+		"file-count-remainder-ge-base": {
+			cmd:    Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 3, NameFormat: "ut-%d.parquet", ReadPageSize: 1000, RecordCount: 0, URI: "all-types.parquet", current: trunkWriter{}},
+			result: map[string]int64{"ut-0.parquet": 2, "ut-1.parquet": 2, "ut-2.parquet": 1},
+		},
 		"file-count-exceeds-rows": {
 			cmd: Cmd{ReadOption: rOpt, FailOnInt96: false, FileCount: 7, NameFormat: "ut-%d.parquet", ReadPageSize: 1000, RecordCount: 0, URI: "all-types.parquet", current: trunkWriter{}},
 			result: map[string]int64{


### PR DESCRIPTION
Fixes four reported bugs.

## Changes

| Issue | Fix |
|-------|-----|
| #1033 | `cat`: `mapToStrList` sized its output slice from the row-map length but indexed it by header field positions, which panics if the row map has fewer keys than the header. Size by the field list instead. |
| #1031 | `meta`: added the missing `defer reader.PFile.Close()` — it was the only read command holding remote (S3/HDFS/HTTP) connections open until process exit. |
| #1027 | `split`: `--file-count N` could emit more than N files because padding was computed modulo `RecordCount` instead of `FileCount` (e.g. 3 rows into 2 files produced 3). Compute padding against `FileCount`. |
| #1037 | `import`/`split`/`merge`: close writers/readers on error paths to avoid dangling remote uploads and leaked connections. |

### Details on #1037
- `import`: a single deferred best-effort close is registered right after each writer is constructed, covering CSV parse errors, mid-stream write errors, `WriteStop` failures, and JSONL scan/validation errors (including schema-mismatch paths). It routes through `closeWriter` so the HDFS replication retry is retained, and is disabled once the explicit close succeeds (no double-close).
- `split`: best-effort close of the in-flight target writer on read/write/switch errors.
- `merge`: `openSources` now closes already-opened readers when a later source fails to open or has an incompatible schema.

## Testing
- Added table-driven `TestMapToStrList` (cat) and split cases (`file-count-padding`, `file-count-remainder-ge-base`) reproducing the exact issue scenarios; confirmed they fail on the pre-fix code.
- `make all` passes; coverage maintained.