### PR TITLE
test(ci): refresh S3-compatible endpoint images and cover Garage

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,8 +342,9 @@ $ parquet-tools row-count --anonymous s3://daylight-openstreetmap/parquet/osm_fe
 2405462
 ```
 
-S3-compatible object stores such as MinIO, Ceph, Cloudflare R2, and LocalStack
-can be configured with the standard AWS SDK endpoint environment variables.
+S3-compatible object stores such as MinIO, Ceph, Garage, SeaweedFS, Cloudflare
+R2, and LocalStack can be configured with the standard AWS SDK endpoint
+environment variables.
 `AWS_ENDPOINT_URL_S3` affects only S3 and takes precedence over the global
 `AWS_ENDPOINT_URL`. When either setting selects a custom endpoint,
 `parquet-tools` uses path-style bucket addressing and does not query Amazon S3

--- a/scripts/test-s3-compatibility.sh
+++ b/scripts/test-s3-compatibility.sh
@@ -9,6 +9,7 @@ readonly bucket="compatibility"
 readonly minio_image="docker.io/alpine/minio:RELEASE.2025-10-15T17-29-55Z"
 readonly minio_client_image="quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
 readonly ceph_image="quay.io/benjamin_holmes/ceph-aio:v20"
+readonly garage_image="dxflrs/garage:v2.3.0"
 readonly seaweedfs_image="chrislusf/seaweedfs:4.40"
 
 # S3-compatible endpoints must work without access to Amazon S3. Route any
@@ -18,11 +19,13 @@ export HTTPS_PROXY="http://127.0.0.1:1"
 export NO_PROXY="127.0.0.1,localhost"
 
 containers=()
+work_dir=$(mktemp -d)
 
 cleanup() {
 	for container in "${containers[@]}"; do
 		docker rm -f -v "$container" >/dev/null 2>&1 || true
 	done
+	rm -rf "$work_dir"
 }
 trap cleanup EXIT
 
@@ -143,6 +146,46 @@ test_ceph() {
 	verify_parquet_io "http://127.0.0.1:$port" "us-east-1" "cephdemo" "cephdemosecret"
 }
 
+test_garage() {
+	local container="parquet-tools-garage-${RANDOM}"
+	local config="$work_dir/garage.toml"
+	local access_key="garageaccesskey"
+	# Garage rejects secrets shorter than 16 characters.
+	local secret_key="garagesecretkey0"
+
+	# Garage refuses to start without a config file. Single-node mode builds the
+	# cluster layout on its own, and --default-bucket provisions the access key
+	# and the bucket, so no post-start CLI setup is needed.
+	cat >"$config" <<-EOF
+		metadata_dir = "/tmp/meta"
+		data_dir = "/tmp/data"
+		db_engine = "sqlite"
+		replication_factor = 1
+
+		rpc_bind_addr = "[::]:3901"
+		rpc_public_addr = "127.0.0.1:3901"
+		rpc_secret = "$(od -An -tx1 -N32 /dev/urandom | tr -d ' \n')"
+
+		[s3_api]
+		s3_region = "garage"
+		api_bind_addr = "[::]:3900"
+	EOF
+
+	pull_image "$garage_image"
+	docker run -d --name "$container" -p 127.0.0.1::3900 \
+		-v "$config:/etc/garage.toml:ro" \
+		-e GARAGE_DEFAULT_ACCESS_KEY="$access_key" \
+		-e GARAGE_DEFAULT_SECRET_KEY="$secret_key" \
+		-e GARAGE_DEFAULT_BUCKET="$bucket" \
+		"$garage_image" /garage server --single-node --default-bucket >/dev/null
+	containers+=("$container")
+
+	local port
+	port=$(container_port "$container" 3900)
+	wait_for_http "$container" "http://127.0.0.1:$port/"
+	verify_parquet_io "http://127.0.0.1:$port" "garage" "$access_key" "$secret_key"
+}
+
 test_seaweedfs() {
 	local container="parquet-tools-seaweedfs-${RANDOM}"
 	pull_image "$seaweedfs_image"
@@ -163,6 +206,8 @@ echo "==> MinIO endpoint ..."
 test_minio
 echo "==> Ceph RGW endpoint ..."
 test_ceph
+echo "==> Garage endpoint ..."
+test_garage
 echo "==> SeaweedFS endpoint ..."
 test_seaweedfs
 echo "All S3-compatible endpoint tests passed"

--- a/scripts/test-s3-compatibility.sh
+++ b/scripts/test-s3-compatibility.sh
@@ -8,7 +8,7 @@ readonly bucket="compatibility"
 # server release; alpine-docker/minio builds it from the release tag.
 readonly minio_image="docker.io/alpine/minio:RELEASE.2025-10-15T17-29-55Z"
 readonly minio_client_image="quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
-readonly ceph_image="quay.io/ceph/demo:main-30dc8b9a-squid-centos-stream9"
+readonly ceph_image="quay.io/benjamin_holmes/ceph-aio:v20"
 readonly seaweedfs_image="chrislusf/seaweedfs:4.40"
 
 # S3-compatible endpoints must work without access to Amazon S3. Route any
@@ -105,39 +105,42 @@ test_minio() {
 
 test_ceph() {
 	local container="parquet-tools-ceph-${RANDOM}"
-	# The demo image defaults to BlueStore, which needs a block device and native
-	# AIO. MemStore keeps this endpoint compatibility test self-contained.
-	pull_image --platform linux/amd64 "$ceph_image"
-	docker run -d --platform linux/amd64 --name "$container" -p 127.0.0.1::8080 \
-		-e MON_IP=127.0.0.1 \
-		-e CEPH_PUBLIC_NETWORK=0.0.0.0/0 \
-		-e DEMO_DAEMONS=osd,rgw \
-		-e CEPH_DEMO_UID=demo \
-		-e CEPH_DEMO_ACCESS_KEY=demo \
-		-e CEPH_DEMO_SECRET_KEY=demo \
-		--entrypoint /bin/bash "$ceph_image" -lc \
-		"sed -i 's/osd objectstore = bluestore/osd objectstore = memstore/g' /opt/ceph-container/bin/demo && exec /opt/ceph-container/bin/demo" >/dev/null
+	# Only the RADOS gateway matters here, so the dashboard, CephFS, and RBD
+	# subsystems stay off to keep startup fast and the container lean.
+	pull_image "$ceph_image"
+	docker run -d --name "$container" -p 127.0.0.1::8000 \
+		-e ENABLE_DASHBOARD=false \
+		-e ENABLE_CEPHFS=false \
+		-e ENABLE_RBD=false \
+		-e DISABLE_MON_DISK_WARNINGS=true \
+		"$ceph_image" >/dev/null
 	containers+=("$container")
 
-	for attempt in $(seq 1 100); do
-		if docker exec "$container" s3cmd ls >/dev/null 2>&1; then
+	local port
+	port=$(container_port "$container" 8000)
+	wait_for_http "$container" "http://127.0.0.1:$port/"
+
+	# The image ships no S3 user, and the gateway answers before the cluster can
+	# serve writes, so retry until user creation goes through.
+	for attempt in $(seq 1 60); do
+		if docker exec "$container" radosgw-admin user create \
+			--uid=demo --display-name=demo \
+			--access-key=cephdemo --secret-key=cephdemosecret >/dev/null 2>&1; then
 			break
 		fi
 		if ! docker inspect -f '{{.State.Running}}' "$container" | grep -q true; then
 			docker logs "$container"
 			return 1
 		fi
-		if [[ $attempt -eq 100 ]]; then
+		if [[ $attempt -eq 60 ]]; then
 			docker logs "$container"
 			return 1
 		fi
-		sleep 6
+		sleep 5
 	done
 
-	docker exec "$container" s3cmd mb "s3://$bucket" >/dev/null
-	local port
-	port=$(container_port "$container" 8080)
-	verify_parquet_io "http://127.0.0.1:$port" "us-east-1" "demo" "demo"
+	make_bucket "$container" "http://cephdemo:cephdemosecret@127.0.0.1:8000"
+	verify_parquet_io "http://127.0.0.1:$port" "us-east-1" "cephdemo" "cephdemosecret"
 }
 
 test_seaweedfs() {

--- a/scripts/test-s3-compatibility.sh
+++ b/scripts/test-s3-compatibility.sh
@@ -10,7 +10,7 @@ readonly minio_image="docker.io/alpine/minio:RELEASE.2025-10-15T17-29-55Z"
 readonly minio_client_image="quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
 readonly ceph_image="quay.io/benjamin_holmes/ceph-aio:v20"
 readonly garage_image="dxflrs/garage:v2.3.0"
-readonly seaweedfs_image="chrislusf/seaweedfs:4.40"
+readonly seaweedfs_image="chrislusf/seaweedfs:4.41"
 
 # S3-compatible endpoints must work without access to Amazon S3. Route any
 # unexpected HTTPS request through a closed local port while allowing the test

--- a/scripts/test-s3-compatibility.sh
+++ b/scripts/test-s3-compatibility.sh
@@ -3,7 +3,10 @@
 set -euo pipefail
 
 readonly bucket="compatibility"
-readonly minio_image="quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z"
+# The MinIO server and client repositories are archived, so these are the final
+# community releases. MinIO's own registry never published an image for the last
+# server release; alpine-docker/minio builds it from the release tag.
+readonly minio_image="docker.io/alpine/minio:RELEASE.2025-10-15T17-29-55Z"
 readonly minio_client_image="quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
 readonly ceph_image="quay.io/ceph/demo:main-30dc8b9a-squid-centos-stream9"
 readonly seaweedfs_image="chrislusf/seaweedfs:4.40"
@@ -18,7 +21,7 @@ containers=()
 
 cleanup() {
 	for container in "${containers[@]}"; do
-		docker rm -f "$container" >/dev/null 2>&1 || true
+		docker rm -f -v "$container" >/dev/null 2>&1 || true
 	done
 }
 trap cleanup EXIT
@@ -52,6 +55,18 @@ wait_for_http() {
 	done
 }
 
+make_bucket() {
+	local container=$1
+	local mc_host=$2
+
+	# MC_HOST_* names the target endpoint, which keeps this to a single mc
+	# invocation instead of a shell wrapping `mc alias set`.
+	pull_image "$minio_client_image"
+	docker run --rm --network "container:$container" \
+		-e "MC_HOST_target=$mc_host" \
+		"$minio_client_image" mb "target/$bucket" >/dev/null
+}
+
 verify_parquet_io() {
 	local endpoint=$1
 	local region=$2
@@ -71,20 +86,20 @@ verify_parquet_io() {
 
 test_minio() {
 	local container="parquet-tools-minio-${RANDOM}"
+	# The image declares /data as a volume but runs as a non-root user, and
+	# Docker creates that anonymous volume owned by root, so MinIO cannot format
+	# its backend there. Keep the data outside the volume.
 	pull_image "$minio_image"
 	docker run -d --name "$container" -p 127.0.0.1::9000 \
 		-e MINIO_ROOT_USER=minioadmin \
 		-e MINIO_ROOT_PASSWORD=minioadmin \
-		"$minio_image" server /data >/dev/null
+		"$minio_image" server /tmp/data >/dev/null
 	containers+=("$container")
 
 	local port
 	port=$(container_port "$container" 9000)
 	wait_for_http "$container" "http://127.0.0.1:$port/minio/health/live"
-	pull_image "$minio_client_image"
-	docker run --rm --network "container:$container" --entrypoint /bin/sh \
-		"$minio_client_image" -c \
-		"mc alias set local http://127.0.0.1:9000 minioadmin minioadmin && mc mb local/$bucket" >/dev/null
+	make_bucket "$container" "http://minioadmin:minioadmin@127.0.0.1:9000"
 	verify_parquet_io "http://127.0.0.1:$port" "us-east-1" "minioadmin" "minioadmin"
 }
 


### PR DESCRIPTION
Refreshes the container images behind `scripts/test-s3-compatibility.sh` and adds a fourth endpoint.

## Ceph

`quay.io/ceph/demo` has had no tag pushed since December 2024 and is amd64 only, so the job ran under emulation and needed a `sed` patch to swap BlueStore for MemStore. Replaced with `quay.io/benjamin_holmes/ceph-aio:v20`, which is built weekly for amd64 and arm64 and runs BlueStore on a file-backed OSD. The dashboard, CephFS, and RBD subsystems are disabled since only the RADOS gateway is exercised. The image ships no S3 user, so one is created via `radosgw-admin` in a retry loop.

## MinIO

`minio/minio` and `minio/mc` are both archived upstream, so `RELEASE.2025-10-15T17-29-55Z` and `RELEASE.2025-08-13T08-35-41Z` are the final community releases. MinIO's own registry never published an image for that last server release, so the server now comes from `alpine-docker/minio`, which builds it from the release tag. Bucket creation moved to `MC_HOST_*` in a shared `make_bucket` helper used by both the MinIO and Ceph endpoints.

## Garage

New endpoint on `dxflrs/garage:v2.3.0`. Single-node mode builds the cluster layout on its own and `--default-bucket` provisions the access key and bucket, so no post-start CLI setup is needed. Garage requires a config file to start, which the script generates into a temporary directory with a per-run RPC secret.

## SeaweedFS

Bumped to 4.41.

## Validation

`scripts/test-s3-compatibility.sh` passes against all four endpoints in about 55 seconds locally, and `make all` passes.
