### PR TITLE
ci(release): modernize multi-platform container image build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     schedule:
       interval: weekly
       day: friday
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: friday

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,29 +78,36 @@ jobs:
         run: |
           echo "REL_TAG=$(cat ./build/VERSION)" >> ${GITHUB_ENV}
       - name: Log into Docker Hub
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Log into GitHub Container Registry
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # The release binaries are cross-compiled before this job, so emulation
+      # only has to cover the Debian setup in the Dockerfile.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64,arm
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Build and push to docker hub and ghcr.io
-        env:
-          PLATFORM: linux/amd64,linux/arm64,linux/arm
-        run: |
-            docker context create multi-platform
-            docker run --privileged --rm tonistiigi/binfmt --install all
-            docker buildx create multi-platform --platform ${{ env.PLATFORM }} --use
-            docker buildx build --progress plain \
-                -f package/container/Dockerfile --push \
-                --platform ${{ env.PLATFORM }} \
-                --provenance=false --sbom=false \
-                -t hangxie/parquet-tools:${{ env.REL_TAG }} \
-                -t hangxie/parquet-tools:latest \
-                -t ghcr.io/hangxie/parquet-tools:${{ env.REL_TAG }} \
-                -t ghcr.io/hangxie/parquet-tools:latest \
-                .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: package/container/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          # SBOM stays off to avoid the per-platform scanning overhead.
+          provenance: mode=max
+          sbom: false
+          tags: |
+            hangxie/parquet-tools:${{ env.REL_TAG }}
+            hangxie/parquet-tools:latest
+            ghcr.io/hangxie/parquet-tools:${{ env.REL_TAG }}
+            ghcr.io/hangxie/parquet-tools:latest


### PR DESCRIPTION
Cleans up the `docker-image` job in `release.yml`. No change to what gets published, other than provenance attestations now being attached.

The release binaries for `linux-amd64`, `linux-arm`, and `linux-arm64` are already cross-compiled by `release-build` before this job runs, so the Dockerfile does no Go compilation under emulation — only the Debian setup and picking the right prebuilt binary. That keeps the single-runner Buildx build the right shape here; native ARM runners plus a digest-merge job would add machinery without moving the wall clock.

### Changes

- `docker/login-action` v3.3.0 → `@v4` for both registries.
- Replaced `docker context create` + privileged `tonistiigi/binfmt --install all` + `docker buildx create` with `setup-qemu-action@v4` and `setup-buildx-action@v4`. The separate Docker context was never needed — `buildx create` uses the `docker-container` driver on the default context. QEMU is now scoped to `arm64,arm` instead of installing every emulator.
- Replaced `docker buildx build` with `build-push-action@v7`. This is for workflow cleanliness, not caching: the `COPY ./build/release/*-linux*.gz` invalidates the only meaningful layer on every build, and releases are tag-triggered, so there is no useful cache story for this Dockerfile.
- Enabled `provenance: mode=max`. It had been disabled alongside SBOM. The `unknown/unknown` platform entries that attestation manifests produce are a registry-UI concern, not a malformed image, and both Docker Hub and GHCR render them correctly.
- Left `sbom: false`. BuildKit scans each target filesystem separately, so this is real extra work per platform. Note the scanner itself is pinned to the build platform (`bc.BuildPlatforms[0]` in `frontend/dockerfile/builder/build.go`, passed to `llb.Image(scanner, llb.Platform(scannerPlatform))`), so it runs natively as amd64 on `ubuntu-latest` rather than under emulation.

- Spelled the 32-bit ARM platform `linux/arm/v7`. Buildx already normalizes `linux/arm` to this, so the published manifest is unchanged — it just states the intent.
- Added the `github-actions` ecosystem to `dependabot.yml`. The action pins were only ever bumped by hand, which is how `login-action` fell a major behind.

### Not changed

- **`GOARM=7` in `build-bin.sh`.** Verified unnecessary rather than merely redundant: with no local CPU information to detect, `cmd/dist` returns 7 specifically so cross-compilation defaults are reproducible. `GOOS=linux GOARCH=arm go env GOARM` confirms `7` on the Go 1.26 toolchain, so the armv7 binaries were already correct.
- **`uname -m` dispatch in the Dockerfile.** Correct as long as QEMU is in play. `TARGETARCH`/`TARGETVARIANT` would make that dependency explicit instead of implicit, but that is a separate change.

### Testing

`make all` passes, and CI is green.

The provenance change is **not covered by CI**: no PR-triggered workflow builds the container image, so its first real execution is the next tag push. It could not be verified locally either — this was checked, and the available Docker CLI is a Podman/buildah shim with no BuildKit and therefore no attestation support.

A `workflow_dispatch` run is not a cheap way to de-risk it. This workflow is tag-push only, and adding the trigger would also run the sibling `github-release` job off the same `release-build` artifacts, creating a bogus GitHub release. Exercising it early would mean a scratch branch with a cut-down workflow that runs `release-build` plus `docker-image` against a throwaway GHCR tag. Otherwise the next release is the first run.
