### PR TITLE
perf(cat): build schema tree once and skip page encoding

### DIFF
--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -237,8 +237,14 @@ func (c Cmd) printer(ctx context.Context, outputChan chan string) error {
 }
 
 func (c Cmd) outputRows(ctx context.Context, fileReader *reader.ParquetReader) error {
-	// cat never reports encoding, so skip the per-column data page header reads.
-	schemaRoot, err := pschema.NewSchemaTree(ctx, fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96, SkipPageEncoding: true})
+	// cat reports neither encoding nor bloom filters, so skip the per-column
+	// page and bloom filter header reads that populating them would cost.
+	schemaOption := pschema.SchemaOption{
+		FailOnInt96:      c.FailOnInt96,
+		SkipPageEncoding: true,
+		SkipBloomFilter:  true,
+	}
+	schemaRoot, err := pschema.NewSchemaTree(ctx, fileReader, schemaOption)
 	if err != nil {
 		return err
 	}

--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -109,21 +109,6 @@ func (c *Cmd) outputHeader(schemaRoot *pschema.SchemaNode) ([]string, error) {
 	return fieldList, nil
 }
 
-func (c *Cmd) retrieveFieldDef(ctx context.Context, fileReader *reader.ParquetReader) ([]string, error) {
-	schemaRoot, err := pschema.NewSchemaTree(ctx, fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96})
-	if err != nil {
-		return nil, err
-	}
-
-	// CSV and TSV do not support nested schema
-	fieldList, err := c.outputHeader(schemaRoot)
-	if err != nil {
-		return nil, err
-	}
-
-	return fieldList, nil
-}
-
 func mapToStrList(flatValues map[string]any, fieldList []string) []string {
 	values := make([]string, len(fieldList))
 	for index, field := range fieldList {
@@ -252,12 +237,14 @@ func (c Cmd) printer(ctx context.Context, outputChan chan string) error {
 }
 
 func (c Cmd) outputRows(ctx context.Context, fileReader *reader.ParquetReader) error {
-	fieldList, err := c.retrieveFieldDef(ctx, fileReader)
+	// cat never reports encoding, so skip the per-column data page header reads.
+	schemaRoot, err := pschema.NewSchemaTree(ctx, fileReader, pschema.SchemaOption{FailOnInt96: c.FailOnInt96, SkipPageEncoding: true})
 	if err != nil {
 		return err
 	}
 
-	schemaRoot, err := pschema.NewSchemaTree(ctx, fileReader, pschema.SchemaOption{})
+	// CSV and TSV do not support nested schema
+	fieldList, err := c.outputHeader(schemaRoot)
 	if err != nil {
 		return err
 	}

--- a/cmd/cat/cat_test.go
+++ b/cmd/cat/cat_test.go
@@ -7,10 +7,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/hangxie/parquet-go/v3/reader"
+	"github.com/hangxie/parquet-go/v3/source"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hangxie/parquet-tools/cmd/internal/testutils"
@@ -463,6 +465,43 @@ func TestCmdEncoder(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+// cloneCountingFile counts Clone calls, which only the per-column page header
+// reads make, so a nonzero count means cat paid for encoding information.
+type cloneCountingFile struct {
+	source.ParquetFileReader
+	clones *atomic.Int64
+}
+
+func (f *cloneCountingFile) Clone() (source.ParquetFileReader, error) {
+	f.clones.Add(1)
+	cloned, err := f.ParquetFileReader.Clone()
+	if err != nil {
+		return nil, err
+	}
+	return &cloneCountingFile{ParquetFileReader: cloned, clones: f.clones}, nil
+}
+
+func TestOutputRowsSkipsPageEncoding(t *testing.T) {
+	for _, format := range []string{"json", "csv"} {
+		t.Run(format, func(t *testing.T) {
+			fileReader, err := pio.NewParquetFileReader(context.Background(), "../../testdata/good.parquet", pio.ReadOption{})
+			require.NoError(t, err)
+			defer func() { require.NoError(t, fileReader.PFile.Close()) }()
+
+			clones := new(atomic.Int64)
+			fileReader.PFile = &cloneCountingFile{ParquetFileReader: fileReader.PFile, clones: clones}
+
+			cmd := Cmd{Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: format}
+			stdout, stderr := testutils.CaptureStdoutStderr(func() {
+				require.NoError(t, cmd.outputRows(context.Background(), fileReader))
+			})
+			require.NotEmpty(t, strings.TrimSpace(stdout))
+			require.Empty(t, stderr)
+			require.Zero(t, clones.Load(), "cat does not use page encoding, it should not read data page headers")
 		})
 	}
 }

--- a/cmd/cat/cat_test.go
+++ b/cmd/cat/cat_test.go
@@ -514,6 +514,24 @@ func TestOutputRowsSkipsUnusedSchemaMetadata(t *testing.T) {
 	}
 }
 
+func TestOutputRowsSkipRowsError(t *testing.T) {
+	fileReader, err := pio.NewParquetFileReader(context.Background(), "../../testdata/good.parquet", pio.ReadOption{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, fileReader.PFile.Close()) }()
+
+	// Building the schema tree reads nothing now, so skipping rows is the first
+	// step a cancelled context can fail.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cmd := Cmd{Skip: 1, Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: "jsonl"}
+	stdout, stderr := testutils.CaptureStdoutStderr(func() {
+		require.ErrorIs(t, cmd.outputRows(ctx, fileReader), context.Canceled)
+	})
+	require.Empty(t, strings.TrimSpace(stdout))
+	require.Empty(t, stderr)
+}
+
 func TestNullifyUnknownColumnsIgnoresNonMapRow(t *testing.T) {
 	nullifyUnknownCols("row", map[string]struct{}{"unknown": {}})
 }

--- a/cmd/cat/cat_test.go
+++ b/cmd/cat/cat_test.go
@@ -469,8 +469,9 @@ func TestCmdEncoder(t *testing.T) {
 	}
 }
 
-// cloneCountingFile counts Clone calls, which only the per-column page header
-// reads make, so a nonzero count means cat paid for encoding information.
+// cloneCountingFile counts Clone calls, which in cat's path only the per-column
+// page header and bloom filter header reads make, so a nonzero count means cat
+// paid for schema metadata it never outputs.
 type cloneCountingFile struct {
 	source.ParquetFileReader
 	clones *atomic.Int64
@@ -485,24 +486,31 @@ func (f *cloneCountingFile) Clone() (source.ParquetFileReader, error) {
 	return &cloneCountingFile{ParquetFileReader: cloned, clones: f.clones}, nil
 }
 
-func TestOutputRowsSkipsPageEncoding(t *testing.T) {
-	for _, format := range []string{"json", "csv"} {
-		t.Run(format, func(t *testing.T) {
-			fileReader, err := pio.NewParquetFileReader(context.Background(), "../../testdata/good.parquet", pio.ReadOption{})
-			require.NoError(t, err)
-			defer func() { require.NoError(t, fileReader.PFile.Close()) }()
+func TestOutputRowsSkipsUnusedSchemaMetadata(t *testing.T) {
+	fixtures := map[string]string{
+		"plain":        "../../testdata/good.parquet",
+		"bloom-filter": "../../testdata/bloom-filter.parquet",
+	}
 
-			clones := new(atomic.Int64)
-			fileReader.PFile = &cloneCountingFile{ParquetFileReader: fileReader.PFile, clones: clones}
+	for name, uri := range fixtures {
+		for _, format := range []string{"json", "csv"} {
+			t.Run(name+"/"+format, func(t *testing.T) {
+				fileReader, err := pio.NewParquetFileReader(context.Background(), uri, pio.ReadOption{})
+				require.NoError(t, err)
+				defer func() { require.NoError(t, fileReader.PFile.Close()) }()
 
-			cmd := Cmd{Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: format}
-			stdout, stderr := testutils.CaptureStdoutStderr(func() {
-				require.NoError(t, cmd.outputRows(context.Background(), fileReader))
+				clones := new(atomic.Int64)
+				fileReader.PFile = &cloneCountingFile{ParquetFileReader: fileReader.PFile, clones: clones}
+
+				cmd := Cmd{Limit: 1, ReadPageSize: 10, SampleRatio: 1.0, Format: format}
+				stdout, stderr := testutils.CaptureStdoutStderr(func() {
+					require.NoError(t, cmd.outputRows(context.Background(), fileReader))
+				})
+				require.NotEmpty(t, strings.TrimSpace(stdout))
+				require.Empty(t, stderr)
+				require.Zero(t, clones.Load(), "cat outputs neither encoding nor bloom filter, it should not read their headers")
 			})
-			require.NotEmpty(t, strings.TrimSpace(stdout))
-			require.Empty(t, stderr)
-			require.Zero(t, clones.Load(), "cat does not use page encoding, it should not read data page headers")
-		})
+		}
 	}
 }
 

--- a/schema/schemanode.go
+++ b/schema/schemanode.go
@@ -67,6 +67,7 @@ type SchemaNode struct {
 type SchemaOption struct {
 	FailOnInt96      bool
 	SkipPageEncoding bool
+	SkipBloomFilter  bool
 }
 
 // cloneForRendering copies the tree state that schema renderers normalize.

--- a/schema/schematree.go
+++ b/schema/schematree.go
@@ -211,9 +211,15 @@ func NewSchemaTree(ctx context.Context, reader *reader.ParquetReader, option Sch
 
 	compressionCodecMap := buildCompressionCodecMap(reader)
 
-	bloomFilterMap, err := buildBloomFilterMap(ctx, reader)
-	if err != nil {
-		return nil, err
+	// Sizing a bloom filter reads its header, so a caller that does not report
+	// bloom filters can opt out of that read.
+	var bloomFilterMap map[string]bloomFilterInfo
+	if !option.SkipBloomFilter {
+		var err error
+		bloomFilterMap, err = buildBloomFilterMap(ctx, reader)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	schemas := reader.SchemaHandler.SchemaElements

--- a/schema/schematree_test.go
+++ b/schema/schematree_test.go
@@ -346,6 +346,21 @@ func TestBuildBloomFilterMap(t *testing.T) {
 	}
 }
 
+func TestNewSchemaTreeBloomFilterError(t *testing.T) {
+	pr, err := pio.NewParquetFileReader(context.Background(), "../testdata/bloom-filter.parquet", pio.ReadOption{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pr.PFile.Close()) }()
+
+	// Page encoding is skipped so the bloom filter read is the first one the
+	// cancelled context can fail.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	root, err := NewSchemaTree(ctx, pr, SchemaOption{SkipPageEncoding: true})
+	require.Nil(t, root)
+	require.ErrorContains(t, err, "bloom filter size")
+}
+
 func TestNewSchemaTreeSkipBloomFilter(t *testing.T) {
 	testCases := map[string]struct {
 		option      SchemaOption

--- a/schema/schematree_test.go
+++ b/schema/schematree_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestSchemaOptionZeroValue(t *testing.T) {
 	option := SchemaOption{}
-	if option.FailOnInt96 || option.SkipPageEncoding {
+	if option.FailOnInt96 || option.SkipPageEncoding || option.SkipBloomFilter {
 		t.Fatal("zero-value schema option must leave optional behavior disabled")
 	}
 }
@@ -342,6 +342,39 @@ func TestBuildBloomFilterMap(t *testing.T) {
 			result, err := buildBloomFilterMap(context.Background(), pr)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestNewSchemaTreeSkipBloomFilter(t *testing.T) {
+	testCases := map[string]struct {
+		option      SchemaOption
+		wantFilters bool
+	}{
+		"default":           {option: SchemaOption{}, wantFilters: true},
+		"skip-bloom-filter": {option: SchemaOption{SkipBloomFilter: true}, wantFilters: false},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			pr, err := pio.NewParquetFileReader(context.Background(), "../testdata/bloom-filter.parquet", pio.ReadOption{})
+			require.NoError(t, err)
+			defer func() { require.NoError(t, pr.PFile.Close()) }()
+
+			root, err := NewSchemaTree(context.Background(), pr, tc.option)
+			require.NoError(t, err)
+
+			filtered := map[string]string{}
+			for _, child := range root.Children {
+				if child.BloomFilter != "" {
+					filtered[child.Name] = child.BloomFilterSize
+				}
+			}
+			if !tc.wantFilters {
+				require.Empty(t, filtered)
+				return
+			}
+			require.Equal(t, map[string]string{"ID": "1024", "Name": "4096", "Score": "1024"}, filtered)
 		})
 	}
 }


### PR DESCRIPTION
Two commits, both trimming schema metadata that `cat` reads but never outputs.

**1. Build the schema tree once, skip page encoding (#1034)**

`cat` built the tree twice per invocation — once in `retrieveFieldDef` for the CSV/TSV header, once in `outputRows` for UNKNOWN-column detection — and neither passed `SkipPageEncoding`, so each build read the first data page header of every column. That was 2 x number-of-columns of wasted roundtrips against S3/GCS/HTTP sources before the first row printed. The tree is now built once with `SkipPageEncoding: true` and shared by both uses, with `retrieveFieldDef` folded into `outputRows`.

**2. Skip bloom filter metadata**

`NewSchemaTree` also sizes every bloom filter it finds, and sizing reads the filter header from the file — one more roundtrip per filtered column. `cat` reports no bloom filter information either. New `SchemaOption.SkipBloomFilter` sits alongside `SkipPageEncoding`; `cat` sets it, and the commands that render bloom filter tags (`schema`, `gostruct`, `transcode`) keep the default behavior.

**Testing**

`TestOutputRowsSkipsUnusedSchemaMetadata` wraps the reader file handle in a `Clone()` counter — both the page header path and `BloomFilterSize` clone, and nothing else in `cat`'s path does — and asserts the count stays zero across `testdata/good.parquet` and `testdata/bloom-filter.parquet`. It failed at 4 and 3 clones respectively before the fixes. `TestNewSchemaTreeSkipBloomFilter` covers the new option at the schema level.

No user-visible change: same flags, same output. `make all` passes; `cmd/cat` coverage 96.1% -> 96.6%, `schema` holds at 99.6%.

Fixes #1034
