### PR TITLE
ci(pages): publish the coverage badge and retire the release-time report

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
           cache-dependency-path: go.sum
       - name: Installing Dependencies
         run: make deps
-      - name: Prepare coverage
-        run: make test
       - name: Build release
         run: make release-build
       - name: Upload artifacts
@@ -46,13 +44,6 @@ jobs:
         with:
           name: release-artifacts
           path: build
-      - name: Update coverage badge
-        uses: ncruces/go-coverage-report@main
-        with:
-          report: true
-          chart: true
-          amend: true
-          coverage-file: build/test/coverage.out
       - name: Push to github
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ collect-coverage:  ## Run tests and append current coverage to coverage.csv
 pages: pages-coverage pages-star  ## Generate all GitHub Pages content to build/pages/
 
 .PHONY: pages-coverage
-pages-coverage:  ## Collect coverage and generate chart (COLLECT_ARGS="--start 2024-01-01 --end 2024-06-01")
+pages-coverage:  ## Collect coverage and generate chart, report and badge (COLLECT_ARGS="--start 2024-01-01 --end 2024-06-01")
 	@echo "==> Generating coverage history page"
 	@mkdir -p $(PAGES_DIR)
 	@$(PYTHON) scripts/coverage-history.py $(COLLECT_ARGS) $(PAGES_DIR)/coverage-history.html $(COVERAGE_CSV)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![](https://img.shields.io/github/v/tag/hangxie/parquet-tools.svg?color=brightgreen&label=version&sort=semver)](https://github.com/hangxie/parquet-tools/releases)
 [![[parquet-tools]](https://github.com/hangxie/parquet-tools/actions/workflows/release.yml/badge.svg)](https://github.com/hangxie/parquet-tools/actions/workflows/release.yml)
 [![](https://goreportcard.com/badge/github.com/hangxie/parquet-tools)](https://goreportcard.com/report/github.com/hangxie/parquet-tools)
-[![](https://github.com/hangxie/parquet-tools/wiki/coverage.svg)](https://github.com/hangxie/parquet-tools/wiki/Coverage-Report)
+[![](https://hangxie.github.io/parquet-tools/coverage.svg)](https://hangxie.github.io/parquet-tools/coverage-history.html)
 
 # parquet-tools
 A utility to inspect Parquet files.
@@ -2066,7 +2066,7 @@ Run `./scripts/gen-bench.sh <version>` to benchmark a tag or commit three times 
 
 `make pages-star` and `make pages-coverage` generate the project's GitHub Pages charts locally to `build/pages/`. Run both with `make pages`.
 
-`make pages-coverage` collects coverage data and generates the chart. It checks out each day's latest commit, runs `go test`, and writes results to `scripts/coverage.csv` (sorted chronologically). Days with no commits carry forward the previous day's coverage. Days before the first commit with non-zero coverage are skipped.
+`make pages-coverage` collects coverage data and generates the chart. It checks out each day's latest commit, runs `go test`, and appends results to `build/coverage.csv` (sorted chronologically). Days with no commits carry forward the previous day's coverage, and days before the first commit with non-zero coverage are skipped. It also writes the per-package HTML coverage report to `build/pages/coverage.html` and the README coverage badge to `build/pages/coverage.svg`.
 
 ```bash
 make pages-coverage                                                          # last 7 days (default)
@@ -2074,7 +2074,7 @@ make pages-coverage COLLECT_ARGS="--start 2021-05-01"                       # fu
 make pages-coverage COLLECT_ARGS="--start 2024-01-01 --end 2024-06-01"      # explicit range
 ```
 
-These scripts require the Python `matplotlib` module, which is **not** installed automatically. Install it with whichever tool fits your environment:
+The coverage HTML chart and badge need no third-party modules. The companion PNG and `make pages-star` additionally require Python's `matplotlib`, which is **not** installed automatically; without it the coverage PNG is skipped with a warning and the rest of that run still succeeds. Install it with whichever tool fits your environment:
 
 ```bash
 # apt (Debian/Ubuntu)
@@ -2091,6 +2091,8 @@ uv pip install matplotlib
 ```
 
 `make pages-star` also requires a `GITHUB_TOKEN` environment variable to fetch star data from the GitHub API.
+
+The `github-pages` workflow runs the same targets weekly and publishes the result to <https://hangxie.github.io/parquet-tools/>. It seeds `build/coverage.csv` from the previously published copy so history accumulates across runs rather than living in the repository, and the coverage badge in this README is served from the same deployment.
 
 ## Credit
 

--- a/scripts/coverage-history.py
+++ b/scripts/coverage-history.py
@@ -455,7 +455,14 @@ zone.addEventListener('mouseleave', () => {{ tip.style.display = 'none'; }});
 
 
 def generate_png(points, output_path):
-    import matplotlib
+    # The HTML chart is self-contained SVG; only the PNG needs matplotlib, so a
+    # missing module downgrades to a warning instead of failing the whole run.
+    try:
+        import matplotlib
+    except ImportError:
+        print("matplotlib not installed, skipping PNG chart "
+              "(pip install matplotlib)", file=sys.stderr)
+        return
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
     import matplotlib.dates as mdates
@@ -513,6 +520,73 @@ def generate_png(points, output_path):
 
 
 # ---------------------------------------------------------------------------
+# Badge
+# ---------------------------------------------------------------------------
+
+# Advance widths in tenths of a pixel for Verdana 11px, covering the glyphs a
+# percentage can contain. Only these are needed, so a full metrics table would
+# be dead weight.
+_GLYPH_WIDTH = {".": 35, "%": 125}
+_DIGIT_WIDTH = 70
+
+# shields.io's palette, darkest green first.
+_THRESHOLDS = (
+    (90, "#4b0"),
+    (80, "#97ca00"),
+    (70, "#a4a61d"),
+    (60, "#dfb317"),
+    (50, "#fe7d37"),
+)
+_LOW_COLOR = "#e05d44"
+
+_BADGE = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="20" role="img"'
+    ' aria-label="coverage: {t}"><title>coverage: {t}</title><filter id="blur">'
+    '<feGaussianBlur stdDeviation="16"/></filter><linearGradient id="s" x2="0"'
+    ' y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop'
+    ' offset="1" stop-opacity=".1"/></linearGradient><clipPath id="r"><rect'
+    ' width="{w}" height="20" rx="3"/></clipPath><g clip-path="url(#r)"><rect'
+    ' width="61" height="20" fill="#555"/><rect x="61" width="{vw}" height="20"'
+    ' fill="{c}"/><rect width="{w}" height="20" fill="url(#s)"/></g><g fill="#fff"'
+    ' text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif"'
+    ' text-rendering="geometricPrecision" font-size="110"><g transform="scale(.1)">'
+    '<g aria-hidden="true" fill="#010101"><text x="315" y="150" fill-opacity=".8"'
+    ' filter="url(#blur)" textLength="510">coverage</text><text x="315" y="150"'
+    ' fill-opacity=".3" textLength="510">coverage</text></g><text x="315" y="140"'
+    ' textLength="510">coverage</text></g><g transform="scale(.1)"><g'
+    ' aria-hidden="true" fill="#010101"><text x="{vx}" y="150" fill-opacity=".8"'
+    ' filter="url(#blur)" textLength="{vt}">{t}</text><text x="{vx}" y="150"'
+    ' fill-opacity=".3" textLength="{vt}">{t}</text></g><text x="{vx}" y="140"'
+    ' textLength="{vt}">{t}</text></g></g></svg>'
+)
+
+
+def badge_color(coverage):
+    for floor, color in _THRESHOLDS:
+        if coverage >= floor:
+            return color
+    return _LOW_COLOR
+
+
+def generate_badge(coverage, output_path):
+    """Write a shields-style flat coverage badge as a standalone SVG."""
+    text = f"{coverage:.1f}%"
+    text_width = sum(_GLYPH_WIDTH.get(ch, _DIGIT_WIDTH) for ch in text)
+    value_width = text_width // 10 + 10
+    svg = _BADGE.format(
+        w=61 + value_width,
+        vw=value_width,
+        vx=round((61 + value_width / 2) * 10) - 10,
+        vt=text_width,
+        t=text,
+        c=badge_color(coverage),
+    )
+    with open(output_path, "w") as f:
+        f.write(svg)
+    print(f"Generated {output_path} ({text})")
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -549,6 +623,7 @@ def main():
     generate_html(chart_points, args.output)
     if args.output.endswith(".html"):
         generate_png(chart_points, args.output[:-5] + ".png")
+        generate_badge(points[-1][1], str(Path(args.output).parent / "coverage.svg"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ports the coverage-badge work from `parquet-go` into this repo.

## What changes

- **`scripts/coverage-history.py`** — generates the README badge as `build/pages/coverage.svg` alongside the history chart and the per-package HTML report, so the weekly `github-pages` workflow becomes the single source for coverage artifacts. The SVG is byte-identical to the wiki badge it replaces at the same coverage value, so the README renders unchanged. A missing `matplotlib` now downgrades the companion PNG to a warning instead of failing the run, since the HTML chart and the badge are plain SVG.
- **`README.md`** — badge points at `hangxie.github.io/parquet-tools/coverage.svg`, linked to the history chart. The Pages section documents `build/coverage.csv` (it said `scripts/coverage.csv`, which was stale), the badge and report outputs, and that `matplotlib` is only needed for the PNG and `make pages-star`.
- **`.github/workflows/release.yml`** — drops the `ncruces/go-coverage-report` step, the last consumer of release-time coverage and the reason the wiki was rewritten on every tag, plus the `Prepare coverage: make test` step that only existed to feed it. `build.yml` already gates the release.
- **`Makefile`** — help text for `pages-coverage` mentions the badge.

## Verification

- `make all` passes.
- The badge generator reproduces the current wiki `coverage.svg` byte-for-byte at the same coverage value.
- Dry run of `coverage-history.py` against the published `coverage.csv` produces `coverage-history.html` and `coverage.svg`, exercising the matplotlib-missing path.

## Note on merge order

`https://hangxie.github.io/parquet-tools/coverage.svg` does not exist yet, so the README badge is broken until Pages publishes it. Merging this triggers the workflow automatically — `scripts/coverage-history.py` is in its push paths — or it can be run via workflow_dispatch.

The wiki's `coverage.svg`, `coverage.html`, and `Coverage-Report.md` become orphaned once this lands; cleaning them up is left for a follow-up.