### PR TITLE
fix(pages): carry star history forward to the generation date

### DIFF
--- a/scripts/star-history.py
+++ b/scripts/star-history.py
@@ -134,6 +134,21 @@ def monthly_points(cumulative):
     return [v for _, v in sorted(monthly.items())]
 
 
+def extend_to_today(cumulative):
+    """Carry the running total forward to today.
+
+    Without this the chart stops at the last star event, so a few quiet weeks
+    look identical to the generator having died.
+    """
+    if not cumulative:
+        return cumulative
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    last = max(cumulative)
+    if today <= last:
+        return cumulative
+    return {**cumulative, today: cumulative[last]}
+
+
 def daily_all(cumulative):
     """Return list of (date_str, count) for every day from first star to last, with carry-forward."""
     if not cumulative:
@@ -403,7 +418,7 @@ def main():
     print(f"Fetching stars for {REPO}...", flush=True)
     stars = fetch_stars(token)
     print(f"Total: {len(stars)} stars")
-    cumulative = cumulative_by_date(stars)
+    cumulative = extend_to_today(cumulative_by_date(stars))
     pts = monthly_points(cumulative)
     generate_html(pts, cumulative, out)
     if out.endswith(".html"):


### PR DESCRIPTION
The star history chart stopped at the last star event rather than at generation time. With no new stars between 2026-08-12 and the 2026-08-23 scheduled run, the published page looked frozen on Aug 12 even though the workflow ran and deployed successfully.

`extend_to_today` carries the running total forward to the current UTC date, so the line reaches the right edge of both the HTML and PNG charts and a quiet stretch reads as flat instead of stale. `monthly_points` and `daily_all` pick up the extra point automatically; a same-day star leaves the series unchanged.