### PR TITLE
docs(compatibility): non-finite floats across tools, plus two fuzz targets

### DIFF
--- a/cmd/import/import_test.go
+++ b/cmd/import/import_test.go
@@ -916,3 +916,43 @@ func TestCloseWriter(t *testing.T) {
 		require.Equal(t, 2, callCount)
 	})
 }
+
+// FuzzImportJSONL walks the JSONL source path with arbitrary content: the line
+// scanner, the per-line JSON check, and the value conversions the writer does,
+// including the "NaN"/"Infinity" spellings cat emits.
+func FuzzImportJSONL(f *testing.F) {
+	f.Add("{\"dbl\":1.5,\"str\":\"a\",\"num\":3}\n")
+	f.Add("{\"dbl\":\"NaN\",\"str\":\"a\",\"num\":3}\n{\"dbl\":\"-Infinity\",\"str\":\"b\",\"num\":4}\n")
+	f.Add("{\"dbl\":NaN}\n")
+	f.Add("[]\n\n{}\n")
+
+	schema := `{"Tag":"name=root","Fields":[` +
+		`{"Tag":"name=dbl, type=DOUBLE"},` +
+		`{"Tag":"name=str, type=BYTE_ARRAY, convertedtype=UTF8"},` +
+		`{"Tag":"name=num, type=INT64"}]}`
+
+	f.Fuzz(func(t *testing.T, source string) {
+		dir := t.TempDir()
+		schemaFile := filepath.Join(dir, "schema.json")
+		sourceFile := filepath.Join(dir, "source.jsonl")
+		if os.WriteFile(schemaFile, []byte(schema), 0o600) != nil ||
+			os.WriteFile(sourceFile, []byte(source), 0o600) != nil {
+			t.Skip()
+		}
+
+		cmd := Cmd{
+			FieldDelimiter: ".",
+			Format:         "jsonl",
+			Schema:         schemaFile,
+			Source:         sourceFile,
+			URI:            filepath.Join(dir, "output.parquet"),
+			WriteOption: pio.WriteOption{
+				CompressionCodec: "SNAPPY",
+				DataPageVersion:  2,
+				PageSize:         1024,
+				RowGroupSize:     1 << 20,
+			},
+		}
+		_ = cmd.Run(context.Background())
+	})
+}

--- a/compatibility.md
+++ b/compatibility.md
@@ -100,6 +100,28 @@ Unsupported converted type (20)
 
 **Workaround:** Use `parquet-tools retype --bson-to-string` to convert BSON columns to string representation before reading with DuckDB.
 
+#### 2. Non-finite Floats in JSON Output
+
+DuckDB reads `NaN` and the infinities out of a Parquet file correctly, but its JSON export writes them as the bare literals `NaN`, `Infinity`, and `-Infinity`, which JSON does not allow. `parquet-tools import` rejects such a file.
+
+```
+$ duckdb -c "copy (select dbl from read_parquet('non-finite.parquet')) to 'duck.jsonl' (format json)"
+$ parquet-tools import -f jsonl -m schema.json -s duck.jsonl out.parquet
+parquet-tools: error: invalid JSON string: {"dbl":NaN}
+```
+
+**Workaround:** Cast the column to `VARCHAR` in the DuckDB query (`select dbl::varchar`). That writes `"nan"`, `"inf"`, and `"-inf"`, which `import` accepts case-insensitively.
+
+The other direction needs help too: parquet-tools writes those values as the quoted strings `"NaN"`, `"Infinity"`, and `"-Infinity"`, so `read_json` infers a `JSON` column rather than a `DOUBLE` one. Name the types, and DuckDB parses the strings back into non-finite doubles.
+
+```sql
+select * from read_json('cat.jsonl', columns={dbl: 'DOUBLE'});
+```
+
+#### 3. NaN Drops Column Statistics
+
+DuckDB omits min/max altogether from any float column holding a `NaN`, so `parquet-tools meta` and `inspect` report no bounds for it. Columns holding only infinities keep their bounds. Files written by parquet-tools keep the bounds either way, leaving out only the `NaN` itself, so the same data shows `-Infinity`/`Infinity` there. Both are valid: the Parquet specification forbids writing `NaN` as a min or max but says nothing about the remaining values.
+
 ## hyparquet
 
 [hyparquet](https://github.com/hyparam/hyparquet) is a dependency-free TypeScript Parquet reader for the browser and Node. Verified against version 1.28.1.
@@ -130,6 +152,16 @@ hyparquet cannot read encrypted files at all: an encrypted footer no longer ends
 
 **Workaround:** Use `parquet-tools transcode --key-file` to write a plaintext copy. A footer key alone is not enough when columns carry their own keys.
 
+#### 5. Non-finite Floats Serialize as null
+
+hyparquet decodes `NaN` and the infinities into the right JavaScript numbers, but `JSON.stringify` has no way to spell them and writes `null`, which erases the difference between `NaN`, `±Infinity`, and a genuine null.
+
+**Workaround:** Convert them in a replacer, which yields the same spellings parquet-tools uses:
+
+```js
+JSON.stringify(rows, (k, v) => typeof v === 'number' && !Number.isFinite(v) ? String(v) : v)
+```
+
 ## pandas
 
 [pandas](https://pandas.pydata.org/) uses PyArrow or fastparquet for Parquet support.
@@ -151,6 +183,18 @@ import pandas as pd
 df = pd.read_parquet('file.parquet', dtype_backend='pyarrow')
 ```
 
+#### 2. Non-finite Floats Are Lost in JSON and Confused with NULL
+
+`DataFrame.to_json` writes `NaN` and both infinities as `null`, so a JSON dump cannot be told apart from one of a column full of nulls. The default backend also stores a `NaN` and a NULL as the same value: `isna()` is `True` for both. The Arrow backend keeps them apart (`nan` vs `<NA>`), but its `to_json` still collapses everything to `null`.
+
+```python
+df = pd.read_parquet('non-finite.parquet', columns=['dbl'], dtype_backend='pyarrow')
+df.dbl.isna().tolist()      # [False, ...] - the NaN is a value, not a null
+df.to_json(orient='records')  # [{"dbl":null}, ...]
+```
+
+**Workaround:** Use `parquet-tools cat` when the distinction matters; it spells the values `"NaN"`, `"Infinity"`, and `"-Infinity"` and leaves nulls as `null`.
+
 ## Polars
 
 [Polars](https://pola.rs/) is a fast DataFrame library with native Parquet support.
@@ -162,7 +206,9 @@ df = pd.read_parquet('file.parquet', dtype_backend='pyarrow')
 
 [PyArrow](https://arrow.apache.org/docs/python/) is the Python binding for Apache Arrow, commonly used for Parquet I/O.
 
-**Known Issues:** None. PyArrow reads parquet-tools files without issues.
+**Known Issues:** None. PyArrow reads parquet-tools files without issues, non-finite floats included.
+
+Note that `to_pylist()` hands back plain Python floats, so `json.dumps` writes `NaN`, `Infinity`, and `-Infinity` as bare literals, which is not valid JSON and which `parquet-tools import` rejects. Pass `allow_nan=False` to make `json.dumps` raise instead, or map the values to strings to match the parquet-tools spelling.
 
 ```python
 import pyarrow.parquet as pq

--- a/schema/statistics_test.go
+++ b/schema/statistics_test.go
@@ -22,3 +22,54 @@ func TestDecodeStatisticsInvalidType(t *testing.T) {
 	require.Nil(t, minValue)
 	require.Nil(t, maxValue)
 }
+
+// FuzzDecodeStatistics feeds arbitrary min/max payloads through the decoder that
+// backs meta and inspect output, where a truncated or oversized bound has to
+// come back as nil rather than panic.
+func FuzzDecodeStatistics(f *testing.F) {
+	f.Add(uint8(1), uint8(0), int32(4), int32(0), []byte{0, 0, 0, 0}, []byte{1})
+	f.Add(uint8(4), uint8(1), int32(4), int32(0), []byte{0x7f, 0xc0, 0, 0}, []byte{0xff, 0x80, 0, 0})
+	f.Add(uint8(7), uint8(2), int32(16), int32(38), []byte{1, 2, 3}, []byte{})
+
+	physicalTypes := []parquet.Type{
+		parquet.Type_BOOLEAN,
+		parquet.Type_INT32,
+		parquet.Type_INT64,
+		parquet.Type_INT96,
+		parquet.Type_FLOAT,
+		parquet.Type_DOUBLE,
+		parquet.Type_BYTE_ARRAY,
+		parquet.Type_FIXED_LEN_BYTE_ARRAY,
+	}
+	convertedTypes := []*parquet.ConvertedType{
+		nil,
+		parquet.ConvertedTypePtr(parquet.ConvertedType_UTF8),
+		parquet.ConvertedTypePtr(parquet.ConvertedType_DECIMAL),
+		parquet.ConvertedTypePtr(parquet.ConvertedType_DATE),
+		parquet.ConvertedTypePtr(parquet.ConvertedType_TIMESTAMP_MICROS),
+		parquet.ConvertedTypePtr(parquet.ConvertedType_INTERVAL),
+		parquet.ConvertedTypePtr(parquet.ConvertedType_UINT_64),
+	}
+	logicalTypes := []*parquet.LogicalType{
+		nil,
+		{FLOAT16: parquet.NewFloat16Type()},
+		{UUID: parquet.NewUUIDType()},
+		{DECIMAL: &parquet.DecimalType{Scale: 2, Precision: 9}},
+	}
+
+	f.Fuzz(func(t *testing.T, typeIndex, annotationIndex uint8, typeLength, precision int32, minValue, maxValue []byte) {
+		physicalType := physicalTypes[int(typeIndex)%len(physicalTypes)]
+		node := &SchemaNode{
+			SchemaElement: parquet.SchemaElement{
+				Type:          &physicalType,
+				ConvertedType: convertedTypes[int(annotationIndex)%len(convertedTypes)],
+				LogicalType:   logicalTypes[int(annotationIndex)%len(logicalTypes)],
+				TypeLength:    &typeLength,
+				Precision:     &precision,
+				Scale:         &precision,
+			},
+		}
+		node.DecodeStatistics(&parquet.Statistics{MinValue: minValue, MaxValue: maxValue})
+		node.DecodeStatistics(&parquet.Statistics{Min: minValue, Max: maxValue})
+	})
+}


### PR DESCRIPTION
Follow-up to the non-finite float work: write down how other tools handle these values, and close two fuzz gaps that opened since v1.50.0.

## compatibility.md

Every claim was verified locally against `testdata/non-finite.parquet` (DuckDB 1.4, PyArrow 25.0.1, pandas 3.0.5, hyparquet 1.28.1).

| Tool | JSON rendering of NaN / ±Inf | Valid JSON | Round-trips |
| --- | --- | --- | --- |
| parquet-tools | `"NaN"`, `"Infinity"`, `"-Infinity"` | yes | yes |
| DuckDB (`format json`) | bare `NaN`, `Infinity`, `-Infinity` | no | only via a `VARCHAR` cast |
| PyArrow + `json.dumps` | bare literals | no | no |
| pandas `to_json` | `null` | yes | no, indistinguishable from NULL |
| hyparquet + `JSON.stringify` | `null` | yes | no, indistinguishable from NULL |

Two findings beyond the table:

- DuckDB drops min/max **entirely** from any float column holding a NaN, so `meta` and `inspect` report no bounds for a DuckDB-written file where the parquet-go-written equivalent shows `-Infinity`/`Infinity`. Columns holding only infinities keep their bounds. Both are spec-legal.
- The default pandas backend cannot tell a stored NaN from a NULL at all (`isna()` is true for both). The Arrow backend keeps them apart in the frame, but `to_json` still collapses everything to `null`.

Each section carries a workaround: a `VARCHAR` cast on the way out of DuckDB and `columns={dbl: 'DOUBLE'}` on the way in, `allow_nan=False` for `json.dumps`, and a `JSON.stringify` replacer for hyparquet that reproduces our exact spellings.

## Fuzz targets

`FuzzNewParquetFileReader` stops at reader creation and `FuzzNewSchemaTree` at schema rendering, so two surfaces that grew since v1.50.0 were untested:

- `schema.FuzzDecodeStatistics` — arbitrary min/max payloads across all 8 physical types crossed with converted and logical annotations. This decoder backs `meta` and `inspect` output, which expanded a lot since v1.50.0 (complete metadata, page-index bounds), and is where non-finite float statistics surface. ~10k execs/sec.
- `importcmd.FuzzImportJSONL` — the line scanner, the per-line JSON check, and value conversion, covering both the long-line handling and the `"NaN"`/`"Infinity"` spellings `cat` emits. ~3k execs/sec.

Neither found a crash; they are regression guards. Candidates I measured and dropped: whole-file `cat` and `inspect` runs manage under one execution per second (32 execs in 150s — mutated files send the reader into multi-second allocations), so they cover nothing within the 10s per-target budget of `make fuzz`; `parseURI` and `parseKeyFile` are fast but thin wrappers over `net/url` and `encoding/json`.

`make all` and `make fuzz FUZZTIME=15s` both pass.
