### PR TITLE
fix(schema): reject malformed LIST instead of panicking

### DIFF
--- a/schema/gostruct.go
+++ b/schema/gostruct.go
@@ -52,10 +52,16 @@ func (n goStructNode) asStruct() (string, error) {
 }
 
 func (n goStructNode) asList() (string, error) {
+	// a LIST-annotated group holds exactly one repeated field per parquet spec,
+	// in both the standard and the backward compatible encodings
+	if len(n.Children) != 1 || !n.Children[0].isRepeated() {
+		return "", fmt.Errorf("invalid LIST structure in [%s]", n.Name)
+	}
+
 	var typeStr string
 	var err error
 	if n.Children[0].LogicalType != nil {
-		// LIST => Element (of scalar type)
+		// 2-level LIST => Element (of scalar type with logical type)
 		element := *n.Children[0]
 		element.Name = "Element"
 		element.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
@@ -82,6 +88,17 @@ func (n goStructNode) asList() (string, error) {
 			SchemaNode:     *elementNode,
 			ForceCamelCase: n.ForceCamelCase,
 		}.String()
+	} else if n.Children[0].isLegacyListElement() {
+		// 2-level LIST => Element (of repeated scalar type)
+		element := *n.Children[0]
+		element.Name = "Element"
+		element.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
+		typeStr, err = goStructNode{
+			SchemaNode:     element,
+			ForceCamelCase: n.ForceCamelCase,
+		}.String()
+	} else {
+		return "", fmt.Errorf("invalid LIST structure in [%s]", n.Name)
 	}
 	if err != nil {
 		return "", err

--- a/schema/gostruct_test.go
+++ b/schema/gostruct_test.go
@@ -179,6 +179,99 @@ func TestGoStructNode(t *testing.T) {
 		require.Contains(t, err.Error(), "go struct does not support LIST of LIST in [Parquet_go_root.Lol]")
 	})
 
+	t.Run("malformed-list", func(t *testing.T) {
+		testCases := map[string]func(*SchemaNode){
+			"no-child": func(list *SchemaNode) {
+				list.Children = nil
+			},
+			"nil-child": func(list *SchemaNode) {
+				list.Children = []*SchemaNode{nil}
+			},
+			"element-without-type": func(list *SchemaNode) {
+				list.Children[0].Children = nil
+				list.Children[0].LogicalType = nil
+				list.Children[0].Type = nil
+			},
+			"multiple-children": func(list *SchemaNode) {
+				list.Children = append(list.Children, list.Children[0])
+			},
+			"logical-type-element-not-repeated": func(list *SchemaNode) {
+				element := list.Children[0].Children[0].Children[0].Children[0]
+				element.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_OPTIONAL)
+				list.Children[0] = element
+			},
+			"struct-element-not-repeated": func(list *SchemaNode) {
+				element := list.Children[0]
+				element.Children = append(element.Children, element.Children[0])
+				element.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
+			},
+			"interim-layer-not-repeated": func(list *SchemaNode) {
+				list.Children[0].RepetitionType = nil
+			},
+			"scalar-element-not-repeated": func(list *SchemaNode) {
+				list.Children[0].Children = nil
+				list.Children[0].LogicalType = nil
+				list.Children[0].Type = parquet.TypePtr(parquet.Type_INT32)
+				list.Children[0].RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_OPTIONAL)
+			},
+		}
+
+		for name, corrupt := range testCases {
+			t.Run(name, func(t *testing.T) {
+				option := pio.ReadOption{}
+				uri := "../testdata/list-of-list.parquet"
+				pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
+				require.NoError(t, err)
+				defer func() {
+					_ = pr.PFile.Close()
+				}()
+
+				schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
+				require.NoError(t, err)
+				require.NotNil(t, schemaRoot)
+
+				corrupt(schemaRoot.Children[0])
+				_, err = goStructNode{SchemaNode: *schemaRoot}.String()
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "invalid LIST structure in [lol]")
+			})
+		}
+	})
+
+	t.Run("two-level-list", func(t *testing.T) {
+		option := pio.ReadOption{}
+		uri := "../testdata/list-of-list.parquet"
+		pr, err := pio.NewParquetFileReader(context.Background(), uri, option)
+		require.NoError(t, err)
+		defer func() {
+			_ = pr.PFile.Close()
+		}()
+
+		schemaRoot, err := NewSchemaTree(context.Background(), pr, SchemaOption{})
+		require.NoError(t, err)
+		require.NotNil(t, schemaRoot)
+
+		// legacy 2-level LIST: the LIST group holds a repeated scalar element
+		// without any logical type, ie "lol -> element" instead of
+		// "lol -> list -> element"
+		element := schemaRoot.Children[0].Children[0].Children[0]
+		element.Type = parquet.TypePtr(parquet.Type_INT32)
+		element.ConvertedType = nil
+		element.LogicalType = nil
+		element.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REPEATED)
+		element.Children = nil
+		schemaRoot.Children[0].Children[0] = element
+
+		fieldStr, err := goStructNode{SchemaNode: *schemaRoot.Children[0]}.stringWithName()
+		require.NoError(t, err)
+		require.Equal(t, "Lol []int32 `parquet:\"name=lol, type=LIST, valuetype=INT32, convertedtype=LIST\"`", fieldStr)
+
+		element.Type = parquet.TypePtr(parquet.Type(999))
+		_, err = goStructNode{SchemaNode: *schemaRoot}.String()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown type: 999")
+	})
+
 	t.Run("as-list", func(t *testing.T) {
 		option := pio.ReadOption{}
 		uri := "../testdata/gostruct-list.parquet"
@@ -192,10 +285,14 @@ func TestGoStructNode(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, root)
 
-		// remove interim layer from schema tree, ie
-		// from "ListName -> list -> element" to "ListName -> element"
-		root.Children[0].Children[0] = root.Children[0].Children[0].Children[0]
-		root.Children[1].Children[0] = root.Children[1].Children[0].Children[0]
+		// remove interim layer from schema tree, ie from
+		// "ListName -> list -> element" to the 2-level "ListName -> element",
+		// whose element is repeated
+		for _, list := range root.Children {
+			element := list.Children[0].Children[0]
+			element.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REPEATED)
+			list.Children[0] = element
+		}
 		typeStr, err := goStructNode{SchemaNode: *root}.String()
 		require.NoError(t, err)
 		formatted, err := format.Source([]byte(typeStr))

--- a/schema/schemanode.go
+++ b/schema/schemanode.go
@@ -87,6 +87,18 @@ func (s *SchemaNode) cloneForRendering() *SchemaNode {
 	return &clone
 }
 
+// isRepeated reports whether the node is a REPEATED field.
+func (s *SchemaNode) isRepeated() bool {
+	return s != nil && s.RepetitionType != nil && *s.RepetitionType == parquet.FieldRepetitionType_REPEATED
+}
+
+// isLegacyListElement reports whether the node is the element of a 2-level LIST,
+// ie a repeated scalar sitting directly under the LIST group instead of the
+// 3-level LIST => List => Element layers.
+func (s *SchemaNode) isLegacyListElement() bool {
+	return s != nil && s.Type != nil && s.LogicalType == nil && len(s.Children) == 0 && s.isRepeated()
+}
+
 func copyPointer[T any](value *T) *T {
 	if value == nil {
 		return nil

--- a/schema/schematags.go
+++ b/schema/schematags.go
@@ -82,12 +82,13 @@ func (s *SchemaNode) getTagMapWithPrefix(prefix string) map[string]string {
 }
 
 func (s *SchemaNode) updateTagForList(tagMap map[string]string) {
-	if len(s.Children) == 0 {
+	// a LIST-annotated group holds exactly one repeated field per parquet spec
+	if len(s.Children) != 1 || !s.Children[0].isRepeated() {
 		return
 	}
 
 	if s.Children[0].LogicalType != nil {
-		// LIST => Element (of scalar type)
+		// 2-level LIST => Element (of scalar type with logical type)
 		maps.Copy(tagMap, s.Children[0].getTagMapWithPrefix("value"))
 		return
 	}
@@ -101,6 +102,14 @@ func (s *SchemaNode) updateTagForList(tagMap map[string]string) {
 		// LIST => List => Element
 		maps.Copy(tagMap, s.Children[0].Children[0].getTagMapWithPrefix("value"))
 		return
+	}
+
+	if s.Children[0].isLegacyListElement() {
+		// 2-level LIST => Element (of repeated scalar type), the element is
+		// rendered as the slice itself so its value type is not repeated
+		element := *s.Children[0]
+		element.RepetitionType = parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REQUIRED)
+		maps.Copy(tagMap, element.getTagMapWithPrefix("value"))
 	}
 }
 

--- a/schema/schematags_test.go
+++ b/schema/schematags_test.go
@@ -29,3 +29,80 @@ func TestTagUpdatesIgnoreAbsentMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestTagUpdatesOnMalformedStructures(t *testing.T) {
+	mapKeyValue := parquet.ConvertedTypePtr(parquet.ConvertedType_MAP_KEY_VALUE)
+
+	testCases := map[string]struct {
+		node     *SchemaNode
+		update   func(*SchemaNode, map[string]string)
+		wantTags map[string]string
+	}{
+		"list-nil-child": {
+			node:     &SchemaNode{Children: []*SchemaNode{nil}},
+			update:   (*SchemaNode).updateTagForList,
+			wantTags: map[string]string{},
+		},
+		"list-element-without-repetition-type": {
+			node: &SchemaNode{Children: []*SchemaNode{
+				{Children: []*SchemaNode{{}}},
+			}},
+			update:   (*SchemaNode).updateTagForList,
+			wantTags: map[string]string{},
+		},
+		"list-logical-type-element-not-repeated": {
+			node: &SchemaNode{Children: []*SchemaNode{
+				{SchemaElement: parquet.SchemaElement{
+					Type:           parquet.TypePtr(parquet.Type_BYTE_ARRAY),
+					LogicalType:    &parquet.LogicalType{STRING: &parquet.StringType{}},
+					RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_OPTIONAL),
+				}},
+			}},
+			update:   (*SchemaNode).updateTagForList,
+			wantTags: map[string]string{},
+		},
+		"list-legacy-scalar-element": {
+			node: &SchemaNode{Children: []*SchemaNode{
+				{SchemaElement: parquet.SchemaElement{
+					Type:           parquet.TypePtr(parquet.Type_INT32),
+					RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_REPEATED),
+				}},
+			}},
+			update:   (*SchemaNode).updateTagForList,
+			wantTags: map[string]string{"valuetype": "INT32", "valuerepetitiontype": "REQUIRED"},
+		},
+		"list-scalar-element-not-repeated": {
+			node: &SchemaNode{Children: []*SchemaNode{
+				{SchemaElement: parquet.SchemaElement{
+					Type:           parquet.TypePtr(parquet.Type_INT32),
+					RepetitionType: parquet.FieldRepetitionTypePtr(parquet.FieldRepetitionType_OPTIONAL),
+				}},
+			}},
+			update:   (*SchemaNode).updateTagForList,
+			wantTags: map[string]string{},
+		},
+		"map-nil-child": {
+			node:     &SchemaNode{Children: []*SchemaNode{nil}},
+			update:   (*SchemaNode).updateTagForMap,
+			wantTags: map[string]string{},
+		},
+		"map-key-value-without-value": {
+			node: &SchemaNode{Children: []*SchemaNode{
+				{
+					SchemaElement: parquet.SchemaElement{ConvertedType: mapKeyValue},
+					Children:      []*SchemaNode{{}},
+				},
+			}},
+			update:   (*SchemaNode).updateTagForMap,
+			wantTags: map[string]string{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tags := map[string]string{}
+			require.NotPanics(t, func() { tc.update(tc.node, tags) })
+			require.Equal(t, tc.wantTags, tags)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1032

`asList` indexed `Children[0]` with no length or nil check, so `schema --format go` panicked with `index out of range` on a LIST group with no element, and an element carrying neither children nor a logical type silently rendered as `[]` with no element type (invalid Go).

- return `invalid LIST structure in [...]`, matching what `asMap` already does
- render a legacy 2-level LIST (a LIST group holding a repeated scalar element) as its element type instead of the empty `[]`
- guard `updateTagForList` against a nil child

The other two paths named in the issue no longer panic on current `main`: `updateTagForMap` already checks `len(s.Children[0].Children) < 2`, and the `*s.Children[0].RepetitionType` dereference is gone. Both are now covered by regression tests so they stay that way.