### PR TITLE
feat(io): accept abfss, az, abfs, and wasb Azure URI schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ parquet-tools: error: unable to open file [gs://cloud-samples-data/bigquery/us-s
 #### Azure Storage Container
 
 `parquet-tools` uses the [HDFS URL format](https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-hadoop-use-blob-storage#access-files-from-within-cluster):
-* starts with `wasbs://` (`wasb://` is not supported), followed by
+* starts with `wasbs://`, followed by
 * container as user name, followed by
 * storage account as host, followed by
 * blob name as path
@@ -439,6 +439,28 @@ means the parquet file is at:
 * storage account `azureopendatastorage`
 * container `laborstatisticscontainer`
 * blob `lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet`
+
+The filesystem-style scheme used by ADLS Gen2, Databricks, Synapse, and Fabric is accepted as well, with the DFS endpoint host translated to the blob endpoint host that the Azure SDK talks to:
+
+> abfss://laborstatisticscontainer@azureopendatastorage.dfs.core.windows.net/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet
+
+So is the `az://` scheme used by [adlfs](https://github.com/fsspec/adlfs), which accepts both the account-bearing form and the shorthand:
+
+> az://laborstatisticscontainer@azureopendatastorage.dfs.core.windows.net/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet
+
+The shorthand form does not name a storage account, so it has to come from the `AZURE_STORAGE_ACCOUNT_NAME` environment variable:
+
+```bash
+$ AZURE_STORAGE_ACCOUNT_NAME=azureopendatastorage parquet-tools row-count --anonymous az://laborstatisticscontainer/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet
+6582726
+$ parquet-tools row-count --anonymous az://laborstatisticscontainer/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet
+parquet-tools: error: unable to open file [az://laborstatisticscontainer/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet]: az:// URI without a storage account requires environment variable AZURE_STORAGE_ACCOUNT_NAME to name it
+```
+
+`wasb://` and `abfs://` are accepted as aliases of `wasbs://` and `abfss://`.
+
+> [!NOTE]
+> Although `wasb://` and `abfs://` mean plain HTTP in Hadoop, `parquet-tools` treats them as naming aliases only: all Azure schemes use HTTPS.
 
 `parquet-tools` uses `AZURE_STORAGE_ACCESS_KEY` environment variable to identify access:
 

--- a/io/io.go
+++ b/io/io.go
@@ -26,6 +26,16 @@ const (
 	schemeHTTPS              string = "https"
 	schemeAWSS3              string = "s3"
 	schemeAzureStorageBlob   string = "wasbs"
+	// wasb and abfs nominally mean plain HTTP in Hadoop, but they are accepted here
+	// as naming aliases only: every Azure scheme talks to the Blob endpoint over HTTPS.
+	schemeAzureStorageBlobAlias string = "wasb"
+	schemeAzureDataLake         string = "abfss"
+	schemeAzureDataLakeAlias    string = "abfs"
+	schemeAzureShorthand        string = "az"
+
+	azureBlobHostSuffix string = ".blob.core.windows.net"
+	azureDFSHostSuffix  string = ".dfs.core.windows.net"
+	azureAccountEnvVar  string = "AZURE_STORAGE_ACCOUNT_NAME"
 )
 
 // ValidateFieldDelimiter rejects values that conflict with field assignments.
@@ -93,7 +103,11 @@ func knownLocationScheme(scheme string) bool {
 		schemeHTTP,
 		schemeHTTPS,
 		schemeAWSS3,
-		schemeAzureStorageBlob:
+		schemeAzureStorageBlob,
+		schemeAzureStorageBlobAlias,
+		schemeAzureDataLake,
+		schemeAzureDataLakeAlias,
+		schemeAzureShorthand:
 		return true
 	default:
 		return false
@@ -177,12 +191,51 @@ func getS3Client(ctx context.Context, bucket string, isPublic, ignoreTLS bool) (
 	return s3.NewFromConfig(cfg), nil
 }
 
-func azureAccessDetail(azURL url.URL, anonymous bool, versionId string) (string, *azblob.SharedKeyCredential, error) {
-	container := azURL.User.Username()
-	if azURL.Host == "" || container == "" || strings.HasSuffix(azURL.Path, "/") {
-		return "", nil, fmt.Errorf("azure blob URI format: wasbs://container@storageaccount.blob.core.windows.net/path/to/blob")
+// azureBlobLocation maps any of the accepted Azure URI spellings to the Blob REST
+// endpoint host and container that the azblob SDK talks to.
+func azureBlobLocation(azURL url.URL) (string, string, error) {
+	host, container := azURL.Host, azURL.User.Username()
+	if azURL.Scheme == schemeAzureShorthand && container == "" {
+		// adlfs shorthand az://container/path carries no account, so it has to
+		// come from the environment; the account-bearing spelling falls through.
+		account := os.Getenv(azureAccountEnvVar)
+		if account == "" {
+			return "", "", fmt.Errorf("%s:// URI without a storage account requires environment variable %s to name it", schemeAzureShorthand, azureAccountEnvVar)
+		}
+		host, container = account+azureBlobHostSuffix, azURL.Host
 	}
-	httpURL := fmt.Sprintf("https://%s/%s%s", azURL.Host, container, azURL.Path)
+
+	// ADLS Gen2 serves the same data on both endpoints, so a DFS host only needs
+	// renaming to reach the Blob API.
+	if account, found := strings.CutSuffix(host, azureDFSHostSuffix); found {
+		host = account + azureBlobHostSuffix
+	}
+	return host, container, nil
+}
+
+// azureURIFormat spells out the expected URI layout for the scheme the user typed.
+func azureURIFormat(scheme string) string {
+	switch scheme {
+	case schemeAzureShorthand:
+		return schemeAzureShorthand + "://container/path/to/blob"
+	case schemeAzureDataLake, schemeAzureDataLakeAlias:
+		return scheme + "://container@storageaccount" + azureDFSHostSuffix + "/path/to/blob"
+	case schemeAzureStorageBlobAlias:
+		return scheme + "://container@storageaccount" + azureBlobHostSuffix + "/path/to/blob"
+	default:
+		return schemeAzureStorageBlob + "://container@storageaccount" + azureBlobHostSuffix + "/path/to/blob"
+	}
+}
+
+func azureAccessDetail(azURL url.URL, anonymous bool, versionId string) (string, *azblob.SharedKeyCredential, error) {
+	host, container, err := azureBlobLocation(azURL)
+	if err != nil {
+		return "", nil, err
+	}
+	if host == "" || container == "" || azURL.Path == "" || strings.HasSuffix(azURL.Path, "/") {
+		return "", nil, fmt.Errorf("azure blob URI format: %s", azureURIFormat(azURL.Scheme))
+	}
+	httpURL := fmt.Sprintf("https://%s/%s%s", host, container, azURL.Path)
 	if versionId != "" {
 		httpURL = fmt.Sprintf("%s?versionid=%s", httpURL, versionId)
 	}
@@ -193,7 +246,7 @@ func azureAccessDetail(azURL url.URL, anonymous bool, versionId string) (string,
 		return httpURL, nil, nil
 	}
 
-	credential, err := azblob.NewSharedKeyCredential(strings.Split(azURL.Host, ".")[0], accessKey)
+	credential, err := azblob.NewSharedKeyCredential(strings.Split(host, ".")[0], accessKey)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create Azure credential: %w", err)
 	}

--- a/io/io_test.go
+++ b/io/io_test.go
@@ -130,6 +130,139 @@ func TestAzureAccessDetail(t *testing.T) {
 	})
 }
 
+func TestAzureAccessDetailSchemeVariants(t *testing.T) {
+	testCases := map[string]struct {
+		scheme    string
+		host      string
+		container string
+		path      string
+		account   string
+		expected  string
+		errMsg    string
+	}{
+		"wasbs": {
+			scheme:    schemeAzureStorageBlob,
+			host:      "storageaccount.blob.core.windows.net",
+			container: "container",
+			path:      "/path/to/object",
+			expected:  "https://storageaccount.blob.core.windows.net/container/path/to/object",
+		},
+		"wasb-alias-stays-on-https": {
+			scheme:    schemeAzureStorageBlobAlias,
+			host:      "storageaccount.blob.core.windows.net",
+			container: "container",
+			path:      "/path/to/object",
+			expected:  "https://storageaccount.blob.core.windows.net/container/path/to/object",
+		},
+		"abfss-dfs-host-translated": {
+			scheme:    schemeAzureDataLake,
+			host:      "storageaccount.dfs.core.windows.net",
+			container: "container",
+			path:      "/path/to/object",
+			expected:  "https://storageaccount.blob.core.windows.net/container/path/to/object",
+		},
+		"abfs-alias-stays-on-https": {
+			scheme:    schemeAzureDataLakeAlias,
+			host:      "storageaccount.dfs.core.windows.net",
+			container: "container",
+			path:      "/path/to/object",
+			expected:  "https://storageaccount.blob.core.windows.net/container/path/to/object",
+		},
+		"abfss-blob-host-untouched": {
+			scheme:    schemeAzureDataLake,
+			host:      "storageaccount.blob.core.windows.net",
+			container: "container",
+			path:      "/path/to/object",
+			expected:  "https://storageaccount.blob.core.windows.net/container/path/to/object",
+		},
+		"abfss-non-azure-host-untouched": {
+			scheme:    schemeAzureDataLake,
+			host:      "storageaccount.dfs.example.com",
+			container: "container",
+			path:      "/path/to/object",
+			expected:  "https://storageaccount.dfs.example.com/container/path/to/object",
+		},
+		"abfss-missing-container": {
+			scheme: schemeAzureDataLake,
+			host:   "storageaccount.dfs.core.windows.net",
+			path:   "/path/to/object",
+			errMsg: "azure blob URI format: abfss://container@storageaccount.dfs.core.windows.net/path/to/blob",
+		},
+		"az-account-from-env": {
+			scheme:   schemeAzureShorthand,
+			host:     "container",
+			path:     "/path/to/object",
+			account:  "storageaccount",
+			expected: "https://storageaccount.blob.core.windows.net/container/path/to/object",
+		},
+		"az-without-account": {
+			scheme: schemeAzureShorthand,
+			host:   "container",
+			path:   "/path/to/object",
+			errMsg: "AZURE_STORAGE_ACCOUNT_NAME",
+		},
+		"az-missing-blob": {
+			scheme:  schemeAzureShorthand,
+			host:    "container",
+			account: "storageaccount",
+			errMsg:  "azure blob URI format: az://container/path/to/blob",
+		},
+		"az-trailing-slash": {
+			scheme:  schemeAzureShorthand,
+			host:    "container",
+			path:    "/path/to/",
+			account: "storageaccount",
+			errMsg:  "azure blob URI format: az://container/path/to/blob",
+		},
+		"az-with-blob-host-in-uri": {
+			scheme:    schemeAzureShorthand,
+			host:      "storageaccount.blob.core.windows.net",
+			container: "container",
+			path:      "/path/to/object",
+			expected:  "https://storageaccount.blob.core.windows.net/container/path/to/object",
+		},
+		"az-with-dfs-host-in-uri": {
+			scheme:    schemeAzureShorthand,
+			host:      "storageaccount.dfs.core.windows.net",
+			container: "container",
+			path:      "/path/to/object",
+			expected:  "https://storageaccount.blob.core.windows.net/container/path/to/object",
+		},
+		"az-uri-account-beats-env": {
+			scheme:    schemeAzureShorthand,
+			host:      "uriaccount.blob.core.windows.net",
+			container: "container",
+			path:      "/path/to/object",
+			account:   "envaccount",
+			expected:  "https://uriaccount.blob.core.windows.net/container/path/to/object",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// Cannot use t.Parallel() with t.Setenv()
+			t.Setenv("AZURE_STORAGE_ACCESS_KEY", "")
+			t.Setenv("AZURE_STORAGE_ACCOUNT_NAME", tc.account)
+
+			u := url.URL{Scheme: tc.scheme, Host: tc.host, Path: tc.path}
+			if tc.container != "" {
+				u.User = url.User(tc.container)
+			}
+			uri, cred, err := azureAccessDetail(u, false, "")
+			if tc.errMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errMsg)
+				require.Equal(t, "", uri)
+				require.Nil(t, cred)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, uri)
+			require.Nil(t, cred)
+		})
+	}
+}
+
 func TestNormalizeFieldPath(t *testing.T) {
 	testCases := []struct {
 		name      string

--- a/io/reader.go
+++ b/io/reader.go
@@ -175,13 +175,17 @@ func newHDFSReader(_ context.Context, u *url.URL, _ ReadOption) (source.ParquetF
 
 func newSourceReader(ctx context.Context, URI string, option ReadOption) (source.ParquetFileReader, error) {
 	readerFuncTable := map[string]func(context.Context, *url.URL, ReadOption) (source.ParquetFileReader, error){
-		schemeLocal:              newLocalReader,
-		schemeAWSS3:              newAWSS3Reader,
-		schemeGoogleCloudStorage: newGoogleCloudStorageReader,
-		schemeAzureStorageBlob:   newAzureStorageBlobReader,
-		schemeHTTP:               newHTTPReader,
-		schemeHTTPS:              newHTTPReader,
-		schemeHDFS:               newHDFSReader,
+		schemeLocal:                 newLocalReader,
+		schemeAWSS3:                 newAWSS3Reader,
+		schemeGoogleCloudStorage:    newGoogleCloudStorageReader,
+		schemeAzureStorageBlob:      newAzureStorageBlobReader,
+		schemeAzureStorageBlobAlias: newAzureStorageBlobReader,
+		schemeAzureDataLake:         newAzureStorageBlobReader,
+		schemeAzureDataLakeAlias:    newAzureStorageBlobReader,
+		schemeAzureShorthand:        newAzureStorageBlobReader,
+		schemeHTTP:                  newHTTPReader,
+		schemeHTTPS:                 newHTTPReader,
+		schemeHDFS:                  newHDFSReader,
 	}
 
 	u, err := parseURI(URI)

--- a/io/reader_test.go
+++ b/io/reader_test.go
@@ -117,6 +117,8 @@ func TestNewParquetFileReader(t *testing.T) {
 	s3URL := "s3://daylight-openstreetmap/parquet/osm_features/release=v1.58/type=way/20241112_191814_00139_grr7u_0041fe64-a5ba-4375-88bf-ef790dfedfff"
 	gcsURL := "gs://cloud-samples-data/bigquery/us-states/us-states.parquet"
 	azblobURL := "wasbs://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet"
+	abfssURL := "abfss://laborstatisticscontainer@azureopendatastorage.dfs.core.windows.net/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet"
+	azShorthandURL := "az://laborstatisticscontainer@azureopendatastorage.dfs.core.windows.net/lfs/part-00000-tid-6312913918496818658-3a88e4f5-ebeb-4691-bfb6-e7bd5d4f2dd0-63558-c000.snappy.parquet"
 	httpURL := "https://github.com/hangxie/parquet-tools/raw/refs/heads/main/testdata/good.parquet"
 	testCases := map[string]struct {
 		uri    string
@@ -223,10 +225,30 @@ func TestNewParquetFileReader(t *testing.T) {
 			rOpt,
 			"connection refused",
 		},
+		"azblob-abfss-good": {
+			abfssURL,
+			ReadOption{Anonymous: true},
+			"",
+		},
 		"azblob-invalid-uri1": {
 			"wasbs://bad/url",
 			rOpt,
 			"azure blob URI format:",
+		},
+		"azblob-wasb-invalid-uri": {
+			"wasb://storageaccount.blob.core.windows.net//aa",
+			rOpt,
+			"azure blob URI format: wasb://",
+		},
+		"azblob-az-without-account": {
+			"az://container/path/to/object",
+			rOpt,
+			"requires environment variable AZURE_STORAGE_ACCOUNT_NAME",
+		},
+		"azblob-az-with-account-good": {
+			azShorthandURL,
+			ReadOption{Anonymous: true},
+			"",
 		},
 		"azblob-invalid-uri2": {
 			"wasbs://storageaccount.blob.core.windows.net//aa",
@@ -239,6 +261,7 @@ func TestNewParquetFileReader(t *testing.T) {
 	t.Setenv("AWS_PROFILE", "")
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null")
 	t.Setenv("AZURE_STORAGE_ACCESS_KEY", base64.StdEncoding.EncodeToString(uuid.New().NodeID()))
+	t.Setenv("AZURE_STORAGE_ACCOUNT_NAME", "")
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/io/writer.go
+++ b/io/writer.go
@@ -116,13 +116,17 @@ func newHDFSWriter(_ context.Context, u *url.URL) (source.ParquetFileWriter, err
 
 func NewParquetFileWriter(ctx context.Context, uri string) (source.ParquetFileWriter, error) {
 	writerFuncTable := map[string]func(context.Context, *url.URL) (source.ParquetFileWriter, error){
-		schemeLocal:              newLocalWriter,
-		schemeAWSS3:              newAWSS3Writer,
-		schemeGoogleCloudStorage: newGoogleCloudStorageWriter,
-		schemeAzureStorageBlob:   newAzureStorageBlobWriter,
-		schemeHTTP:               newHTTPWriter,
-		schemeHTTPS:              newHTTPWriter,
-		schemeHDFS:               newHDFSWriter,
+		schemeLocal:                 newLocalWriter,
+		schemeAWSS3:                 newAWSS3Writer,
+		schemeGoogleCloudStorage:    newGoogleCloudStorageWriter,
+		schemeAzureStorageBlob:      newAzureStorageBlobWriter,
+		schemeAzureStorageBlobAlias: newAzureStorageBlobWriter,
+		schemeAzureDataLake:         newAzureStorageBlobWriter,
+		schemeAzureDataLakeAlias:    newAzureStorageBlobWriter,
+		schemeAzureShorthand:        newAzureStorageBlobWriter,
+		schemeHTTP:                  newHTTPWriter,
+		schemeHTTPS:                 newHTTPWriter,
+		schemeHDFS:                  newHDFSWriter,
 	}
 
 	u, err := parseURI(uri)

--- a/io/writer_test.go
+++ b/io/writer_test.go
@@ -108,6 +108,14 @@ func TestNewParquetFileWriter(t *testing.T) {
 			"wasbs://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/will-not-create-till-close",
 			"",
 		},
+		"azblob-abfss-good": {
+			"abfss://laborstatisticscontainer@azureopendatastorage.dfs.core.windows.net/will-not-create-till-close",
+			"",
+		},
+		"azblob-az-without-account": {
+			"az://laborstatisticscontainer/will-not-create-till-close",
+			"requires environment variable AZURE_STORAGE_ACCOUNT_NAME",
+		},
 		"http-not-support": {
 			"https://domain.tld/path/to/file",
 			"writing to [https] endpoint is not currently supported",
@@ -126,6 +134,7 @@ func TestNewParquetFileWriter(t *testing.T) {
 	t.Setenv("AWS_PROFILE", "")
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null")
 	t.Setenv("AZURE_STORAGE_ACCESS_KEY", base64.StdEncoding.EncodeToString(uuid.New().NodeID()))
+	t.Setenv("AZURE_STORAGE_ACCOUNT_NAME", "")
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Closes #1054

Users pasting URIs from Databricks, Synapse, Fabric, or the fsspec/adlfs ecosystem had to rewrite them into `wasbs://` form. This accepts those spellings against the existing `azblob` backend — no new dependency and no new IO path.

## Changes

- `abfss://` / `abfs://`: the ADLS Gen2 DFS host is translated to the blob host the Azure SDK talks to (`account.dfs.core.windows.net` -> `account.blob.core.windows.net`), since Gen2 accounts serve the same data on both endpoints.
- `az://container/path`: the adlfs convention, which does not carry a storage account, so the account comes from `AZURE_STORAGE_ACCOUNT_NAME`; a clear error names the variable when it is unset.
- `wasb://`: alias of `wasbs://`.
- `az://container@account/path` is rejected with an explanatory error rather than silently reading the account as the container. The issue left this open with "leave it out" as the default position; leaving it unhandled would have misinterpreted it instead.
- Reader and writer dispatch both cover the new schemes, so writes work through them too.

`wasb://` and `abfs://` nominally mean plain HTTP in Hadoop, but are treated here as naming aliases only — all Azure schemes stay on HTTPS. Silently downgrading credentials to plaintext in a standalone tool would be surprising, and would fail against accounts with secure transfer required (the Azure default) anyway. An explicit opt-in flag for plain HTTP (Azurite and similar) remains a follow-up, as does dispatching native `https://` Azure URLs.

## Verification

Against the public `azureopendatastorage` dataset, each spelling returns `6582726` rows:

```
$ parquet-tools row-count --anonymous abfss://laborstatisticscontainer@azureopendatastorage.dfs.core.windows.net/lfs/part-00000-...snappy.parquet
$ parquet-tools row-count --anonymous abfs://laborstatisticscontainer@azureopendatastorage.dfs.core.windows.net/lfs/part-00000-...snappy.parquet
$ parquet-tools row-count --anonymous wasb://laborstatisticscontainer@azureopendatastorage.blob.core.windows.net/lfs/part-00000-...snappy.parquet
$ AZURE_STORAGE_ACCOUNT_NAME=azureopendatastorage parquet-tools row-count --anonymous az://laborstatisticscontainer/lfs/part-00000-...snappy.parquet
```

`make all` passes. The new functions are at 100% statement coverage.

## Docs

`README.md` documents the new URI formats, `AZURE_STORAGE_ACCOUNT_NAME`, and the note that `abfs://`/`wasb://` still use HTTPS.